### PR TITLE
Fix unicode Python3 error

### DIFF
--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -61,7 +61,7 @@ def is_iterable(val):
 
 
 def is_string(val):
-    return isinstance(val, str) or isinstance(val, unicode)
+    return isinstance(val, six.string_types)
 
 
 def is_integer_array(val):


### PR DESCRIPTION
One line of code change to make it work with Python3.
Use `six.string_types` instead of unicode to have both Python2 & Python3 compatibility.