### PR TITLE
Augmenter.draw_grid works with a list of grayscale images

### DIFF
--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -611,6 +611,14 @@ class Augmenter(object):
                 images = [images[:, :, np.newaxis]]
             else:
                 raise Exception("Unexpected images shape, expected 2-, 3- or 4-dimensional array, got shape %s." % (images.shape,))
+        elif isinstance(images, list):
+            for i, image in enumerate(images):
+                if len(image.shape) == 3:
+                    continue
+                elif len(image.shape) == 2:
+                    images[i] = image[:, :, np.newaxis]
+                else:
+                    raise Exception("Unexpected image shape at index %d, expected 2- or 3-dimensional array, got shape %s." % (i, image.shape,))
         assert isinstance(images, list)
 
         det = self if self.deterministic else self.to_deterministic()


### PR DESCRIPTION
Fixed case when Augmenters.meta.Augmenter.draw_grid was called with a list of grascale images and didn't add dimension.