### PR TITLE
Fix #61, preserve third dimension for grayscale images after cv2.warpPerspective

### DIFF
--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -991,6 +991,8 @@ class PerspectiveTransform(Augmenter):
             # cv2.warpPerspective only supports <=4 channels
             assert images[i].shape[2] <= 4, "PerspectiveTransform is currently limited to images with 4 or less channels."
             warped = cv2.warpPerspective(images[i], M, (max_width, max_height))
+            if warped.ndim == 2 and images[i].ndim == 3:
+                warped = np.expand_dims(warped, 2)
             #print(np.min(warped), np.max(warped), warped.dtype)
             if self.keep_size:
                 h, w = images[i].shape[0:2]


### PR DESCRIPTION
cv2.warpPerspective apparentely does not preserve third dimension when
the image is grayscale (single channel). This code should fix the
warped image afterwards.