### PR TITLE
Fixed typos

### DIFF
--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1250,7 +1250,7 @@ class ElasticTransformation(Augmenter):
     """
 
     # no transformation of keypoints for this currently,
-    # it seems like this is the more appropiate choice overall for this augmentation
+    # it seems like this is the more appropriate choice overall for this augmentation
     # technique
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         return keypoints_on_images

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -894,7 +894,7 @@ class Augmenter(object):
         Usually there is no need to change global into local random states.
         The only noteworthy exceptions are
             * whenever you want to use determinism (so that the global random
-              state is not accidently reverted)
+              state is not accidentally reverted)
             * whenever you want to copy random states from one augmenter to
               another. (Copying the global random state doesn't help very
               much. If you copy the state from A to B, then execute A and then

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -739,7 +739,7 @@ class HooksImages(object):
         Returns
         -------
         out : bool
-            If True, the augmenter may be propagate to its childen.
+            If True, the augmenter may be propagate to its children.
             If False, it may not.
 
         """

--- a/old_version/ImageAugmenter.py
+++ b/old_version/ImageAugmenter.py
@@ -174,7 +174,7 @@ def create_aug_matrices(nb_matrices, img_width_px, img_height_px,
         # create three affine transformation matrices
         # 1st one moves the image to the top left, 2nd one transforms it, 3rd one
         # moves it back to the center.
-        # The movement is neccessary, because rotation is applied to the top left
+        # The movement is necessary, because rotation is applied to the top left
         # and not to the image's center (same for scaling and shear).
         matrix_to_topleft = tf.SimilarityTransform(translation=[-shift_x, -shift_y])
         matrix_transforms = tf.AffineTransform(scale=(scale_x, scale_y),

--- a/tests/test.py
+++ b/tests/test.py
@@ -1524,7 +1524,7 @@ def test_Affine():
     # this one uses a 4x4 area of all 255, which is zoomed out to a 4x4 area
     # in which the center 2x2 area is 255
     # zoom in should probably be adapted to this style
-    # no seperate tests here for x/y axis, should work fine if zoom in works with that
+    # no separate tests here for x/y axis, should work fine if zoom in works with that
     aug = iaa.Affine(scale=0.49, translate_px=0, rotate=0, shear=0)
     aug_det = aug.to_deterministic()
 


### PR DESCRIPTION
appropiate -> appropriate
accidently -> accidentally
childen -> children
neccessary -> necessary
seperate -> separate