### PR TITLE
Batch Loader Hangs while being Terminated

### DIFF
--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -1803,6 +1803,11 @@ class BatchLoader(object):
         """
         self.join_signal.set()
         if self.threaded:
+            while True:
+                try:
+                    self.queue.get(timeout=1)
+                except QueueEmpty:
+                    break
             for worker in self.workers:
                 worker.join()
         else:


### PR DESCRIPTION
## System:
* Operating System: Ubuntu 16.04 LTS server
* Python 3.5.2
* imgaug 0.2.5
## Code to Reproduce
```python
from imgaug import augmenters as iaa
import imgaug as ia
import numpy as np
from skimage import data
import time

def load_batches():

    batch_size = 8
    nb_batches = 150
    astronaut = data.astronaut()
    astronaut = ia.imresize_single_image(astronaut, (64, 64))

    for i in range(nb_batches):

        batch_images = []
        batch_data = []
        # Add some images to the batch.
        for b in range(batch_size):
            batch_images.append(astronaut)
            batch_data.append((i, b))
        # Create the batch object to send to the background processes.
        batch = ia.Batch(
            images=np.array(batch_images, dtype=np.uint8),
            data=batch_data
        )

        yield batch
        
augseq = iaa.Sequential([
    iaa.Fliplr(0.5),
    iaa.CoarseDropout(p=0.1, size_percent=0.1)
])

epochs=10
batch_size=8
nb_workers=1
flag_threaded=True

for e in range(epochs):
    print("==========")
    print("Epoch",e)
    print("==========")
    print("Getting Batch Loader...")
    batch_loader = ia.BatchLoader(load_batches,
                                  nb_workers=nb_workers,
                                  threaded=flag_threaded)  # Load data into the queue.
    print("Batch Loader returned. Getting Background Augmenter...")
    bg_augmenter = ia.BackgroundAugmenter(batch_loader, augseq) # Perform data augmentation in the background.
    print("Background Augmenter returned.")

    time.sleep(5)
    # If we wait for 5 seconds, The queue that the batch loader puts stuffs in 
    # (size=50 by default) is likely to be full.

    print("Terminating Batch Loader...")
    batch_loader.terminate()
    # According to the source code, a worker of the threaded batch loader will 
    # be blocked until it receives an join signal. However, when the queue is 
    # full, the join signal won't be received unless we start to kick stuffs 
    # out of the queue. As a consequence, the batch loader won't be terminated
    # properly and this program will hang.

    print("Batch Loader terminated.")

    print("Terminating Background Augmenter...")
    bg_augmenter.terminate()
    print("Background Augmenter terminated.")
```
# Expected Result
The threaded batch loader can be terminated properly.

## Actual Result
The threaded batch loader won't be terminated properly and the program will hang.

## Proposed solution
Clean the source queue while terminating the batch loader.