### PR TITLE
Add  PadUptoFixedSize and CropFixedSize

### DIFF
--- a/checks/check_fixed_size.py
+++ b/checks/check_fixed_size.py
@@ -15,22 +15,52 @@ def main():
     print("image shape:", image.shape)
     
     augs_many = [
-        iaa.CropFixedSize(200,200, name="width200-height200"),
-        iaa.CropFixedSize(200,322, name="width200-height322"),
-        iaa.CropFixedSize(480,200, name="width480-height200"),
-        iaa.CropFixedSize(480,322, name="width480-height322"),
+        iaa.PadToFixedSize(200,200, name="pad-width200-height200"),
+        iaa.PadToFixedSize(200,322, name="pad-width200-height322"),
+        iaa.PadToFixedSize(200,400, name="pad-width200-height400"),
+        iaa.PadToFixedSize(480,200, name="pad-width480-height200"),
+        iaa.PadToFixedSize(480,322, name="pad-width480-height322"),  # input size == output size
+        iaa.PadToFixedSize(480,400, name="pad-width480-height400"),
+        iaa.PadToFixedSize(600,200, name="pad-width600-height200"),
+        iaa.PadToFixedSize(600,322, name="pad-width600-height322"),
+        iaa.PadToFixedSize(600,400, name="pad-width600-height400"),
+
+        iaa.CropToFixedSize(200,200, name="crop-width200-height200"),
+        iaa.CropToFixedSize(200,322, name="crop-width200-height322"),
+        iaa.CropToFixedSize(200,400, name="crop-width200-height400"),
+        iaa.CropToFixedSize(480,200, name="crop-width480-height200"),
+        iaa.CropToFixedSize(480,322, name="crop-width480-height322"),  # input size == output size
+        iaa.CropToFixedSize(480,400, name="crop-width480-height400"),
+        iaa.CropToFixedSize(600,200, name="crop-width600-height200"),
+        iaa.CropToFixedSize(600,322, name="crop-width600-height322"),
+        iaa.CropToFixedSize(600,400, name="crop-width600-height400"),
+
         iaa.Sequential([
-            iaa.PadUptoFixedSize(480,400),
-            iaa.CropFixedSize(480,400)
-        ], name="width480-height400"),
+            iaa.PadToFixedSize(200,200),
+            iaa.CropToFixedSize(200,200)
+        ], name="pad-crop-width200-height200"),
         iaa.Sequential([
-            iaa.PadUptoFixedSize(600,322),
-            iaa.CropFixedSize(600,322)
-        ], name="width600-height322"),
+            iaa.PadToFixedSize(400,400),
+            iaa.CropToFixedSize(400,400)
+        ], name="pad-crop-width400-height400"),
         iaa.Sequential([
-            iaa.PadUptoFixedSize(600,400),
-            iaa.CropFixedSize(600,400)
-        ], name="width600-height400"),
+            iaa.PadToFixedSize(600,600),
+            iaa.CropToFixedSize(600,600)
+        ], name="pad-crop-width600-height600"),
+
+        iaa.Sequential([
+            iaa.CropToFixedSize(200,200),
+            iaa.PadToFixedSize(200,200)
+        ], name="crop-pad-width200-height200"),
+        iaa.Sequential([
+            iaa.CropToFixedSize(400,400),
+            iaa.PadToFixedSize(400,400)
+        ], name="crop-pad-width400-height400"),
+        iaa.Sequential([
+            iaa.CropToFixedSize(600,600),
+            iaa.PadToFixedSize(600,600)
+        ], name="crop-pad-width600-height600"),
+
     ]
 
     print("original", image.shape)

--- a/checks/check_fixed_size.py
+++ b/checks/check_fixed_size.py
@@ -15,21 +15,21 @@ def main():
     print("image shape:", image.shape)
     
     augs_many = [
-        iaa.CropFixedSize(200,200, name="width200-height200"),
-        iaa.CropFixedSize(200,322, name="width200-height322"),
-        iaa.CropFixedSize(480,200, name="width480-height200"),
-        iaa.CropFixedSize(480,322, name="width480-height322"),
+        iaa.CropToFixedSize(200,200, name="width200-height200"),
+        iaa.CropToFixedSize(200,322, name="width200-height322"),
+        iaa.CropToFixedSize(480,200, name="width480-height200"),
+        iaa.CropToFixedSize(480,322, name="width480-height322"),
         iaa.Sequential([
-            iaa.PadUptoFixedSize(480,400),
-            iaa.CropFixedSize(480,400)
+            iaa.PadToFixedSize(480,400),
+            iaa.CropToFixedSize(480,400)
         ], name="width480-height400"),
         iaa.Sequential([
-            iaa.PadUptoFixedSize(600,322),
-            iaa.CropFixedSize(600,322)
+            iaa.PadToFixedSize(600,322),
+            iaa.CropToFixedSize(600,322)
         ], name="width600-height322"),
         iaa.Sequential([
-            iaa.PadUptoFixedSize(600,400),
-            iaa.CropFixedSize(600,400)
+            iaa.PadToFixedSize(600,400),
+            iaa.CropToFixedSize(600,400)
         ], name="width600-height400"),
     ]
 

--- a/checks/check_fixed_size.py
+++ b/checks/check_fixed_size.py
@@ -15,21 +15,21 @@ def main():
     print("image shape:", image.shape)
     
     augs_many = [
-        iaa.CropToFixedSize(200,200, name="width200-height200"),
-        iaa.CropToFixedSize(200,322, name="width200-height322"),
-        iaa.CropToFixedSize(480,200, name="width480-height200"),
-        iaa.CropToFixedSize(480,322, name="width480-height322"),
+        iaa.CropFixedSize(200,200, name="width200-height200"),
+        iaa.CropFixedSize(200,322, name="width200-height322"),
+        iaa.CropFixedSize(480,200, name="width480-height200"),
+        iaa.CropFixedSize(480,322, name="width480-height322"),
         iaa.Sequential([
-            iaa.PadToFixedSize(480,400),
-            iaa.CropToFixedSize(480,400)
+            iaa.PadUptoFixedSize(480,400),
+            iaa.CropFixedSize(480,400)
         ], name="width480-height400"),
         iaa.Sequential([
-            iaa.PadToFixedSize(600,322),
-            iaa.CropToFixedSize(600,322)
+            iaa.PadUptoFixedSize(600,322),
+            iaa.CropFixedSize(600,322)
         ], name="width600-height322"),
         iaa.Sequential([
-            iaa.PadToFixedSize(600,400),
-            iaa.CropToFixedSize(600,400)
+            iaa.PadUptoFixedSize(600,400),
+            iaa.CropFixedSize(600,400)
         ], name="width600-height400"),
     ]
 

--- a/checks/check_fixed_size.py
+++ b/checks/check_fixed_size.py
@@ -1,0 +1,56 @@
+from __future__ import print_function, division
+import imgaug as ia
+from imgaug import augmenters as iaa
+import numpy as np
+from skimage import data
+import cv2
+
+def main():
+    image = ia.quokka(size=0.5)
+    kps = [ia.KeypointsOnImage(
+        [ia.Keypoint(x=245, y=203), ia.Keypoint(x=365, y=195), ia.Keypoint(x=313, y=269)],
+        shape=(image.shape[0]*2, image.shape[1]*2)
+    )]
+    kps[0] = kps[0].on(image.shape)
+    print("image shape:", image.shape)
+    
+    augs_many = [
+        iaa.CropFixedSize(200,200, name="width200-height200"),
+        iaa.CropFixedSize(200,322, name="width200-height322"),
+        iaa.CropFixedSize(480,200, name="width480-height200"),
+        iaa.CropFixedSize(480,322, name="width480-height322"),
+        iaa.Sequential([
+            iaa.PadUptoFixedSize(480,400),
+            iaa.CropFixedSize(480,400)
+        ], name="width480-height400"),
+        iaa.Sequential([
+            iaa.PadUptoFixedSize(600,322),
+            iaa.CropFixedSize(600,322)
+        ], name="width600-height322"),
+        iaa.Sequential([
+            iaa.PadUptoFixedSize(600,400),
+            iaa.CropFixedSize(600,400)
+        ], name="width600-height400"),
+    ]
+
+    print("original", image.shape)
+    ia.imshow(kps[0].draw_on_image(image))
+
+    print("-----------------")
+    print("Random aug per image")
+    print("-----------------")
+    for aug in augs_many:
+        images_aug = []
+        for _ in range(36):
+            aug_det = aug.to_deterministic()
+            img_aug = aug_det.augment_image(image)
+            kps_aug = aug_det.augment_keypoints(kps)[0]
+            img_aug_kps = kps_aug.draw_on_image(img_aug)
+            img_aug_kps = np.pad(img_aug_kps, ((1, 1), (1, 1), (0, 0)), mode="constant", constant_values=255)
+            #print(aug.name, img_aug_kps.shape, img_aug_kps.shape[1]/img_aug_kps.shape[0])
+            images_aug.append(img_aug_kps)
+        print(aug.name)
+        ia.imshow(ia.draw_grid(images_aug))
+
+if __name__ == "__main__":
+    main()

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -19,8 +19,8 @@ List of augmenters:
     * CropAndPad
     * Crop
     * Pad
-    * PadUptoFixedSize
-    * CropFixedSize
+    * PadToFixedSize
+    * CropToFixedSize
 
 """
 from __future__ import print_function, division, absolute_import
@@ -1149,10 +1149,10 @@ def Crop(px=None, percent=None, keep_size=True, sample_independently=True, name=
     )
     return aug
 
-class PadUptoFixedSize(Augmenter):
+class PadToFixedSize(Augmenter):
 
     """
-    Augmenter that pads the images upto specified width/height only if specified width/height exceed the width/height of input images.
+    Augmenter that pads the images To specified width/height only if specified width/height exceed the width/height of input images.
     The offset varies randomly within valid region (i.e. each input image is fully included in its output image).
 
     Parameters
@@ -1160,7 +1160,7 @@ class PadUptoFixedSize(Augmenter):
     width : int
         Minimum width of new images.
 
-    height : int 
+    height : int
         Minimum height of new images.
 
     pad_mode : ia.ALL or string or list of strings or StochasticParameter, optional(default="constant")
@@ -1180,14 +1180,14 @@ class PadUptoFixedSize(Augmenter):
 
     Examples
     --------
-    >>> aug = iaa.PadUptoFixedSize(width=100, height=100)
+    >>> aug = iaa.PadToFixedSize(width=100, height=100)
 
     for edges smaller than 100 pixels, pads up to 100 pixels, does nothing for the other edges.
 
     """
 
     def __init__(self, width, height, pad_mode="constant", pad_cval=0, name=None, deterministic=False, random_state=None):
-        super(PadUptoFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
+        super(PadToFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.size = width, height
         self.position = ( iap.Uniform(0.0,1.0), iap.Uniform(0.0,1.0) )
 
@@ -1214,9 +1214,9 @@ class PadUptoFixedSize(Augmenter):
         pad_xs, pad_ys, pad_modes, pad_cvals = self._draw_samples(nb_images, random_state)
         for i in sm.xrange(nb_images):
             image = images[i]
-            ia.do_assert(image.dtype == np.uint8, "PadUptoFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
+            ia.do_assert(image.dtype == np.uint8, "PadToFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
             ih, iw = image.shape[:2]
-            
+
             if iw<w or ih<h:
                 if iw<w:
                     pad_x0 = int(pad_xs[i]*(w-iw+1))
@@ -1224,7 +1224,7 @@ class PadUptoFixedSize(Augmenter):
                 else:
                     pad_x0 = 0
                     pad_x1 = 0
-                
+
                 if ih<h:
                     pad_y0 = int(pad_ys[i]*(h-ih+1)) if ih<h else 0
                     pad_y1 = h-ih-pad_y0
@@ -1253,7 +1253,7 @@ class PadUptoFixedSize(Augmenter):
         result = []
         nb_images = len(keypoints_on_images)
         w, h = self.size
-        pad_xs, pad_ys, pad_modes, pad_cvals = self._draw_samples(nb_images, random_state)
+        pad_xs, pad_ys, _, _ = self._draw_samples(nb_images, random_state)
         for i in sm.xrange(nb_images):
             keypoints_on_image = keypoints_on_images[i]
             ih, iw = keypoints_on_image.shape[:2]
@@ -1262,7 +1262,7 @@ class PadUptoFixedSize(Augmenter):
             pad_y = int(pad_ys[i]*(h-ih+1)) if ih<h else 0
 
             keypoints_padded = keypoints_on_image.shift(x=pad_x, y=pad_y)
-            keypoints_padded.shape = (max(ih,h),max(iw,w))
+            keypoints_padded.shape = (max(ih,h),max(iw,w)) + keypoints_padded.shape[2:]
 
             result.append(keypoints_padded)
 
@@ -1286,7 +1286,7 @@ class PadUptoFixedSize(Augmenter):
     def get_parameters(self):
         return [self.position, self.pad_mode, self.pad_cval]
 
-class CropFixedSize(Augmenter):
+class CropToFixedSize(Augmenter):
 
     """
     Augmenter that crops the images to specified width/height.
@@ -1312,21 +1312,21 @@ class CropFixedSize(Augmenter):
 
     Examples
     --------
-    >>> aug = iaa.CropFixedSize(width=100, height=100)
+    >>> aug = iaa.CropToFixedSize(width=100, height=100)
 
     crops 100x100 image from the input image at random position.
 
     >>> aug = iaa.Sequential([
-            iaa.PadUptoFixedSize(width=100, height=100),
-            iaa.CropFixedSize(width=100, height=100)
+            iaa.PadToFixedSize(width=100, height=100),
+            iaa.CropToFixedSize(width=100, height=100)
         ])
 
-    pads upto 100x100 pixel for treating some smaller images than 100x100 pixels, then crop 100x100 image.
+    pads to 100x100 pixel for treating some smaller images than 100x100 pixels, then crop 100x100 image.
 
     """
 
-    def __init__(self, width, height, pad_mode="constant", pad_cval=0, name=None, deterministic=False, random_state=None):
-        super(CropFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
+    def __init__(self, width, height, name=None, deterministic=False, random_state=None):
+        super(CropToFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.size = width, height
         self.position = ( iap.Uniform(0.0,1.0), iap.Uniform(0.0,1.0) )
 
@@ -1338,8 +1338,8 @@ class CropFixedSize(Augmenter):
         for i in sm.xrange(nb_images):
             image = images[i]
             ih, iw = image.shape[:2]
-            ia.do_assert(image.dtype == np.uint8, "CropFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
-            ia.do_assert(w<=iw and h<=ih, "CropFixedSize() can currently only process images larger than target size (both width and height).")
+            ia.do_assert(image.dtype == np.uint8, "CropToFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
+            ia.do_assert(w<=iw and h<=ih, "CropToFixedSize() can currently only process images larger than target size (both width and height).")
             
             offset_x, offset_y = offset_xs[i]*(iw-w+1), offset_ys[i]*(ih-h+1) # relative position to pixel.
             offset_x, offset_y = int(offset_x), int(offset_y)
@@ -1362,7 +1362,7 @@ class CropFixedSize(Augmenter):
             offset_x, offset_y = offset_xs[i]*(iw-w+1), offset_ys[i]*(ih-h+1) # relative position to pixel.
 
             keypoints_cropped = keypoints_on_image.shift(x=-offset_x, y=-offset_y)
-            keypoints_cropped.shape = (h,w)
+            keypoints_cropped.shape = (h,w) + keypoints_cropped.shape[2:]
 
             result.append(keypoints_cropped)
 

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -19,8 +19,8 @@ List of augmenters:
     * CropAndPad
     * Crop
     * Pad
-    * PadToFixedSize
-    * CropToFixedSize
+    * PadUptoFixedSize
+    * CropFixedSize
 
 """
 from __future__ import print_function, division, absolute_import
@@ -1149,10 +1149,10 @@ def Crop(px=None, percent=None, keep_size=True, sample_independently=True, name=
     )
     return aug
 
-class PadToFixedSize(Augmenter):
+class PadUptoFixedSize(Augmenter):
 
     """
-    Augmenter that pads the images To specified width/height only if specified width/height exceed the width/height of input images.
+    Augmenter that pads the images upto specified width/height only if specified width/height exceed the width/height of input images.
     The offset varies randomly within valid region (i.e. each input image is fully included in its output image).
 
     Parameters
@@ -1160,7 +1160,7 @@ class PadToFixedSize(Augmenter):
     width : int
         Minimum width of new images.
 
-    height : int
+    height : int 
         Minimum height of new images.
 
     pad_mode : ia.ALL or string or list of strings or StochasticParameter, optional(default="constant")
@@ -1180,14 +1180,14 @@ class PadToFixedSize(Augmenter):
 
     Examples
     --------
-    >>> aug = iaa.PadToFixedSize(width=100, height=100)
+    >>> aug = iaa.PadUptoFixedSize(width=100, height=100)
 
     for edges smaller than 100 pixels, pads up to 100 pixels, does nothing for the other edges.
 
     """
 
     def __init__(self, width, height, pad_mode="constant", pad_cval=0, name=None, deterministic=False, random_state=None):
-        super(PadToFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
+        super(PadUptoFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.size = width, height
         self.position = ( iap.Uniform(0.0,1.0), iap.Uniform(0.0,1.0) )
 
@@ -1214,9 +1214,9 @@ class PadToFixedSize(Augmenter):
         pad_xs, pad_ys, pad_modes, pad_cvals = self._draw_samples(nb_images, random_state)
         for i in sm.xrange(nb_images):
             image = images[i]
-            ia.do_assert(image.dtype == np.uint8, "PadToFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
+            ia.do_assert(image.dtype == np.uint8, "PadUptoFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
             ih, iw = image.shape[:2]
-
+            
             if iw<w or ih<h:
                 if iw<w:
                     pad_x0 = int(pad_xs[i]*(w-iw+1))
@@ -1224,7 +1224,7 @@ class PadToFixedSize(Augmenter):
                 else:
                     pad_x0 = 0
                     pad_x1 = 0
-
+                
                 if ih<h:
                     pad_y0 = int(pad_ys[i]*(h-ih+1)) if ih<h else 0
                     pad_y1 = h-ih-pad_y0
@@ -1253,7 +1253,7 @@ class PadToFixedSize(Augmenter):
         result = []
         nb_images = len(keypoints_on_images)
         w, h = self.size
-        pad_xs, pad_ys, _, _ = self._draw_samples(nb_images, random_state)
+        pad_xs, pad_ys, pad_modes, pad_cvals = self._draw_samples(nb_images, random_state)
         for i in sm.xrange(nb_images):
             keypoints_on_image = keypoints_on_images[i]
             ih, iw = keypoints_on_image.shape[:2]
@@ -1262,7 +1262,7 @@ class PadToFixedSize(Augmenter):
             pad_y = int(pad_ys[i]*(h-ih+1)) if ih<h else 0
 
             keypoints_padded = keypoints_on_image.shift(x=pad_x, y=pad_y)
-            keypoints_padded.shape = (max(ih,h),max(iw,w)) + keypoints_padded.shape[2:]
+            keypoints_padded.shape = (max(ih,h),max(iw,w))
 
             result.append(keypoints_padded)
 
@@ -1286,7 +1286,7 @@ class PadToFixedSize(Augmenter):
     def get_parameters(self):
         return [self.position, self.pad_mode, self.pad_cval]
 
-class CropToFixedSize(Augmenter):
+class CropFixedSize(Augmenter):
 
     """
     Augmenter that crops the images to specified width/height.
@@ -1312,21 +1312,21 @@ class CropToFixedSize(Augmenter):
 
     Examples
     --------
-    >>> aug = iaa.CropToFixedSize(width=100, height=100)
+    >>> aug = iaa.CropFixedSize(width=100, height=100)
 
     crops 100x100 image from the input image at random position.
 
     >>> aug = iaa.Sequential([
-            iaa.PadToFixedSize(width=100, height=100),
-            iaa.CropToFixedSize(width=100, height=100)
+            iaa.PadUptoFixedSize(width=100, height=100),
+            iaa.CropFixedSize(width=100, height=100)
         ])
 
-    pads to 100x100 pixel for treating some smaller images than 100x100 pixels, then crop 100x100 image.
+    pads upto 100x100 pixel for treating some smaller images than 100x100 pixels, then crop 100x100 image.
 
     """
 
-    def __init__(self, width, height, name=None, deterministic=False, random_state=None):
-        super(CropToFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
+    def __init__(self, width, height, pad_mode="constant", pad_cval=0, name=None, deterministic=False, random_state=None):
+        super(CropFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.size = width, height
         self.position = ( iap.Uniform(0.0,1.0), iap.Uniform(0.0,1.0) )
 
@@ -1338,8 +1338,8 @@ class CropToFixedSize(Augmenter):
         for i in sm.xrange(nb_images):
             image = images[i]
             ih, iw = image.shape[:2]
-            ia.do_assert(image.dtype == np.uint8, "CropToFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
-            ia.do_assert(w<=iw and h<=ih, "CropToFixedSize() can currently only process images larger than target size (both width and height).")
+            ia.do_assert(image.dtype == np.uint8, "CropFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
+            ia.do_assert(w<=iw and h<=ih, "CropFixedSize() can currently only process images larger than target size (both width and height).")
             
             offset_x, offset_y = offset_xs[i]*(iw-w+1), offset_ys[i]*(ih-h+1) # relative position to pixel.
             offset_x, offset_y = int(offset_x), int(offset_y)
@@ -1362,7 +1362,7 @@ class CropToFixedSize(Augmenter):
             offset_x, offset_y = offset_xs[i]*(iw-w+1), offset_ys[i]*(ih-h+1) # relative position to pixel.
 
             keypoints_cropped = keypoints_on_image.shift(x=-offset_x, y=-offset_y)
-            keypoints_cropped.shape = (h,w) + keypoints_cropped.shape[2:]
+            keypoints_cropped.shape = (h,w)
 
             result.append(keypoints_cropped)
 

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -19,8 +19,8 @@ List of augmenters:
     * CropAndPad
     * Crop
     * Pad
-    * PadUptoFixedSize
-    * CropFixedSize
+    * PadToFixedSize
+    * CropToFixedSize
 
 """
 from __future__ import print_function, division, absolute_import
@@ -1149,10 +1149,11 @@ def Crop(px=None, percent=None, keep_size=True, sample_independently=True, name=
     )
     return aug
 
-class PadUptoFixedSize(Augmenter):
+
+class PadToFixedSize(Augmenter):
 
     """
-    Augmenter that pads the images upto specified width/height only if specified width/height exceed the width/height of input images.
+    Augmenter that pads the images to specified width/height only if specified width/height is greater than the width/height of input images.
     The offset varies randomly within valid region (i.e. each input image is fully included in its output image).
 
     Parameters
@@ -1160,7 +1161,7 @@ class PadUptoFixedSize(Augmenter):
     width : int
         Minimum width of new images.
 
-    height : int 
+    height : int
         Minimum height of new images.
 
     pad_mode : ia.ALL or string or list of strings or StochasticParameter, optional(default="constant")
@@ -1180,16 +1181,24 @@ class PadUptoFixedSize(Augmenter):
 
     Examples
     --------
-    >>> aug = iaa.PadUptoFixedSize(width=100, height=100)
+    >>> aug = iaa.PadToFixedSize(width=100, height=100)
 
-    for edges smaller than 100 pixels, pads up to 100 pixels, does nothing for the other edges.
+    for edges smaller than 100 pixels, pads to 100 pixels, does nothing for the other edges.
+
+    >>> aug = iaa.Sequential([
+            iaa.PadToFixedSize(width=100, height=100),
+            iaa.CropToFixedSize(width=100, height=100)
+        ])
+
+    pads to 100x100 pixel for smaller images, and crops to 100x100 pixel for larger images.
+    The output images have fixed size, 100x100 pixel.
 
     """
 
     def __init__(self, width, height, pad_mode="constant", pad_cval=0, name=None, deterministic=False, random_state=None):
-        super(PadUptoFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
+        super(PadToFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.size = width, height
-        self.position = ( iap.Uniform(0.0,1.0), iap.Uniform(0.0,1.0) )
+        self.position = (iap.Uniform(0.0, 1.0), iap.Uniform(0.0, 1.0))
 
         pad_modes_available = set(["constant", "edge", "linear_ramp", "maximum", "median", "minimum", "reflect", "symmetric", "wrap"])
         if pad_mode == ia.ALL:
@@ -1214,19 +1223,19 @@ class PadUptoFixedSize(Augmenter):
         pad_xs, pad_ys, pad_modes, pad_cvals = self._draw_samples(nb_images, random_state)
         for i in sm.xrange(nb_images):
             image = images[i]
-            ia.do_assert(image.dtype == np.uint8, "PadUptoFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
+            ia.do_assert(image.dtype == np.uint8, "PadToFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
             ih, iw = image.shape[:2]
-            
-            if iw<w or ih<h:
-                if iw<w:
+
+            if iw < w or ih < h:
+                if iw < w:
                     pad_x0 = int(pad_xs[i]*(w-iw+1))
                     pad_x1 = w-iw-pad_x0
                 else:
                     pad_x0 = 0
                     pad_x1 = 0
-                
-                if ih<h:
-                    pad_y0 = int(pad_ys[i]*(h-ih+1)) if ih<h else 0
+
+                if ih < h:
+                    pad_y0 = int(pad_ys[i]*(h-ih+1))
                     pad_y1 = h-ih-pad_y0
                 else:
                     pad_y0 = 0
@@ -1235,7 +1244,7 @@ class PadUptoFixedSize(Augmenter):
                 if image.ndim == 2:
                     pad_vals = ((pad_y0, pad_y1), (pad_x0, pad_x1))
                 else:
-                    pad_vals = ((pad_y0, pad_y1), (pad_x0, pad_x1), (0,0))
+                    pad_vals = ((pad_y0, pad_y1), (pad_x0, pad_x1), (0, 0))
 
                 pad_mode = pad_modes[i]
                 if pad_mode == "constant":
@@ -1253,16 +1262,16 @@ class PadUptoFixedSize(Augmenter):
         result = []
         nb_images = len(keypoints_on_images)
         w, h = self.size
-        pad_xs, pad_ys, pad_modes, pad_cvals = self._draw_samples(nb_images, random_state)
+        pad_xs, pad_ys, _, _ = self._draw_samples(nb_images, random_state)
         for i in sm.xrange(nb_images):
             keypoints_on_image = keypoints_on_images[i]
             ih, iw = keypoints_on_image.shape[:2]
 
-            pad_x = int(pad_xs[i]*(w-iw+1)) if iw<w else 0
-            pad_y = int(pad_ys[i]*(h-ih+1)) if ih<h else 0
+            pad_x = int(pad_xs[i]*(w-iw+1)) if iw < w else 0
+            pad_y = int(pad_ys[i]*(h-ih+1)) if ih < h else 0
 
             keypoints_padded = keypoints_on_image.shift(x=pad_x, y=pad_y)
-            keypoints_padded.shape = (max(ih,h),max(iw,w))
+            keypoints_padded.shape = (max(ih, h), max(iw, w)) + keypoints_padded.shape[2:]
 
             result.append(keypoints_padded)
 
@@ -1276,29 +1285,29 @@ class PadUptoFixedSize(Augmenter):
 
         pad_xs = self.position[0].draw_samples(nb_images, random_state=ia.new_random_state(seed + 0))
         pad_ys = self.position[1].draw_samples(nb_images, random_state=ia.new_random_state(seed + 1))
-        
+
         pad_modes = self.pad_mode.draw_samples(nb_images, random_state=ia.new_random_state(seed + 2))
         pad_cvals = self.pad_cval.draw_samples(nb_images, random_state=ia.new_random_state(seed + 3))
         pad_cvals = np.clip(np.round(pad_cvals), 0, 255).astype(np.uint8)
-        
+
         return pad_xs, pad_ys, pad_modes, pad_cvals
 
     def get_parameters(self):
         return [self.position, self.pad_mode, self.pad_cval]
 
-class CropFixedSize(Augmenter):
+
+class CropToFixedSize(Augmenter):
 
     """
-    Augmenter that crops the images to specified width/height.
-    Width/Height of input images is supposed to be larger than specified width/height.
+    Augmenter that crops the images to specified width/height only if specified width/height is less than the width/height of input images.
     The offset varies randomly within valid region (i.e. each output image is fully included in its input image).
-    
+
     Parameters
     ----------
     width : int
         Fixed width of new images.
 
-    height : int 
+    height : int
         Fixed height of new images.
 
     name : string, optional(default=None)
@@ -1312,23 +1321,24 @@ class CropFixedSize(Augmenter):
 
     Examples
     --------
-    >>> aug = iaa.CropFixedSize(width=100, height=100)
+    >>> aug = iaa.CropToFixedSize(width=100, height=100)
 
-    crops 100x100 image from the input image at random position.
+    for edges larger than 100 pixels, crops to 100 pixels, does nothing for the other edges.
 
     >>> aug = iaa.Sequential([
-            iaa.PadUptoFixedSize(width=100, height=100),
-            iaa.CropFixedSize(width=100, height=100)
+            iaa.PadToFixedSize(width=100, height=100),
+            iaa.CropToFixedSize(width=100, height=100)
         ])
 
-    pads upto 100x100 pixel for treating some smaller images than 100x100 pixels, then crop 100x100 image.
+    pads to 100x100 pixel for smaller images, and crops to 100x100 pixel for larger images.
+    The output images have fixed size, 100x100 pixel.
 
     """
 
-    def __init__(self, width, height, pad_mode="constant", pad_cval=0, name=None, deterministic=False, random_state=None):
-        super(CropFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
+    def __init__(self, width, height, name=None, deterministic=False, random_state=None):
+        super(CropToFixedSize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.size = width, height
-        self.position = ( iap.Uniform(0.0,1.0), iap.Uniform(0.0,1.0) )
+        self.position = (iap.Uniform(0.0, 1.0), iap.Uniform(0.0, 1.0))
 
     def _augment_images(self, images, random_state, parents, hooks):
         result = []
@@ -1337,15 +1347,18 @@ class CropFixedSize(Augmenter):
         offset_xs, offset_ys = self._draw_samples(nb_images, random_state)
         for i in sm.xrange(nb_images):
             image = images[i]
+            ia.do_assert(image.dtype == np.uint8, "CropToFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
             ih, iw = image.shape[:2]
-            ia.do_assert(image.dtype == np.uint8, "CropFixedSize() can currently only process images of dtype uint8 (got %s)" % (image.dtype,))
-            ia.do_assert(w<=iw and h<=ih, "CropFixedSize() can currently only process images larger than target size (both width and height).")
-            
-            offset_x, offset_y = offset_xs[i]*(iw-w+1), offset_ys[i]*(ih-h+1) # relative position to pixel.
-            offset_x, offset_y = int(offset_x), int(offset_y)
 
-            image_cropped = image[offset_y:offset_y+h, offset_x:offset_x+w, :]
-            result.append(image_cropped)
+            if ih > h:
+                offset_y = int(offset_ys[i]*(ih-h+1))
+                image = image[offset_y:offset_y+h, :, :]
+
+            if iw > w:
+                offset_x = int(offset_xs[i]*(iw-w+1))
+                image = image[:, offset_x:offset_x+w, :]
+
+            result.append(image)
 
         result = np.array(result, dtype=np.uint8)
 
@@ -1359,10 +1372,12 @@ class CropFixedSize(Augmenter):
         for i in sm.xrange(nb_images):
             keypoints_on_image = keypoints_on_images[i]
             ih, iw = keypoints_on_image.shape[:2]
-            offset_x, offset_y = offset_xs[i]*(iw-w+1), offset_ys[i]*(ih-h+1) # relative position to pixel.
+
+            offset_x = int(offset_xs[i]*(iw-w+1)) if iw > w else 0
+            offset_y = int(offset_ys[i]*(ih-h+1)) if ih > h else 0
 
             keypoints_cropped = keypoints_on_image.shift(x=-offset_x, y=-offset_y)
-            keypoints_cropped.shape = (h,w)
+            keypoints_cropped.shape = (min(ih, h), min(iw, w)) + keypoints_cropped.shape[2:]
 
             result.append(keypoints_cropped)
 
@@ -1375,7 +1390,7 @@ class CropFixedSize(Augmenter):
         seed = random_state.randint(0, 10**6, 1)[0]
         offset_xs = self.position[0].draw_samples(nb_images, random_state=ia.new_random_state(seed + 0))
         offset_ys = self.position[1].draw_samples(nb_images, random_state=ia.new_random_state(seed + 1))
-        
+
         return offset_xs, offset_ys
 
     def get_parameters(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -208,6 +208,9 @@ def main():
     # TODO test_CropAndPad()
     test_Pad()
     test_Crop()
+    # TODO test_PadUptoFixedSize()
+    # TODO test_CropFixedSize()
+
 
     # these functions use various augmenters, so test them last
     test_2d_inputs()

--- a/tests/test.py
+++ b/tests/test.py
@@ -208,8 +208,8 @@ def main():
     # TODO test_CropAndPad()
     test_Pad()
     test_Crop()
-    # TODO test_PadUptoFixedSize()
-    # TODO test_CropFixedSize()
+    # TODO test_PadToFixedSize()
+    # TODO test_CropToFixedSize()
 
 
     # these functions use various augmenters, so test them last

--- a/tests/test.py
+++ b/tests/test.py
@@ -208,9 +208,8 @@ def main():
     # TODO test_CropAndPad()
     test_Pad()
     test_Crop()
-    # TODO test_PadUptoFixedSize()
-    # TODO test_CropFixedSize()
-
+    # TODO test_PadToFixedSize()
+    # TODO test_CropToFixedSize()
 
     # these functions use various augmenters, so test them last
     test_2d_inputs()

--- a/tests/test.py
+++ b/tests/test.py
@@ -208,8 +208,8 @@ def main():
     # TODO test_CropAndPad()
     test_Pad()
     test_Crop()
-    # TODO test_PadToFixedSize()
-    # TODO test_CropToFixedSize()
+    # TODO test_PadUptoFixedSize()
+    # TODO test_CropFixedSize()
 
 
     # these functions use various augmenters, so test them last


### PR DESCRIPTION
Add augmenter, PadUptoFixedSize and CropFixedSize, related to https://github.com/aleju/imgaug/issues/31.

These augmenters help to convert images variable size to fixed size, without any interpolation.

TODOs:
- implement _augment_heatmaps()
- write test code.

Examples:
```
>>> aug = iaa.CropFixedSize(width=100, height=100)
```
crops 100x100 image from the input image at random position.

```
>>> aug = iaa.Sequential([
        iaa.PadUptoFixedSize(width=100, height=100),
        iaa.CropFixedSize(width=100, height=100)
    ])
```
pads upto 100x100 pixel for treating some smaller images than 100x100 pixels, then crop 100x100 image.
