### PR TITLE
Add fit_output (False/True) option to Affine augmenters

### DIFF
--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -645,6 +645,7 @@ class Affine(Augmenter):
                                     input_shape[2]))
         else:
             output_shape = np.ceil((out_height, out_width))
+        output_shape = tuple(output_shape.tolist())
         # fit output image in new shape
         translation = (- minc, - minr)
         matrix_to_fit = tf.SimilarityTransform(translation=translation)

--- a/tests/test.py
+++ b/tests/test.py
@@ -8572,6 +8572,12 @@ def test_Affine():
     assert len(aug.mode.a) == 2 and "constant" in aug.mode.a and "edge" in aug.mode.a
 
     # ------------
+    # fit_output
+    # ------------
+    aug = iaa.Affine(scale=1.0, translate_px=100, fit_output=True)
+    assert aug.fit_output is True
+
+    # ------------
     # exceptions for bad inputs
     # ------------
     # scale
@@ -8649,7 +8655,7 @@ def test_Affine():
     # ----------
     # get_parameters
     # ----------
-    aug = iaa.Affine(scale=1, translate_px=2, rotate=3, shear=4, order=1, cval=0, mode="constant", backend="cv2")
+    aug = iaa.Affine(scale=1, translate_px=2, rotate=3, shear=4, order=1, cval=0, mode="constant", backend="cv2", fit_output=True)
     params = aug.get_parameters()
     assert isinstance(params[0], iap.Deterministic)  # scale
     assert isinstance(params[1], iap.Deterministic)  # translate
@@ -8663,6 +8669,7 @@ def test_Affine():
     assert params[5].value == 0  # cval
     assert params[6].value == "constant"  # mode
     assert params[7] == "cv2"  # backend
+    assert params[8] is True  # fit_output
 
 
 def test_AffineCv2():

--- a/tests/test.py
+++ b/tests/test.py
@@ -8576,6 +8576,15 @@ def test_Affine():
     # ------------
     aug = iaa.Affine(scale=1.0, translate_px=100, fit_output=True)
     assert aug.fit_output is True
+    observed = aug.augment_images(images)
+    expected = images
+    assert np.array_equal(observed, expected)
+    observed = aug.augment_keypoints(keypoints)
+    expected = keypoints
+    assert keypoints_equal(observed, expected)
+    observed = aug.augment_heatmaps([heatmaps])[0]
+    expected = heatmaps
+    assert np.array_equal(observed.get_arr(), expected.get_arr())
 
     # ------------
     # exceptions for bad inputs


### PR DESCRIPTION
Close https://github.com/aleju/imgaug/pull/50

## Note

There is no longer a dependency on the change of scikit-image.

## Sample

![sample_affine_fit_output](https://user-images.githubusercontent.com/4310419/46032678-43397080-c137-11e8-8529-5ebc830f3e42.png)

```
#!/usr/bin/env python

from scipy.misc import face
from itertools import product

import imgaug.augmenters as iaa
import matplotlib.pyplot as plt


img = face()


i = 0
i += 1
plt .subplot(2, 4, i)
plt .imshow(img)
plt .title('original')
for fit_output, backend in product([False, True], ['auto', 'skimage', 'cv2']):
    print(fit_output, backend)

    augmenter = iaa.Affine(
        scale=0.7,
        translate_px=5,
        rotate=60,
        shear=0.1,
        fit_output=fit_output,
        backend=backend,
    )
    img_aug = augmenter.augment_image(img)

    i += 1
    plt .subplot(2, 4, i)
    plt .imshow(img_aug)
    plt .title('fit_output={}, backend={}'.format(fit_output, backend))

plt .show()
```