### PR TITLE
Update imgaug.py

### DIFF
--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -55,7 +55,7 @@ DEFAULT_FONT_FP = os.path.join(
 # here (and in all augmenters) instead of np.random.
 CURRENT_RANDOM_STATE = np.random.RandomState(42)
 SEED_MIN_VALUE = 0
-SEED_MAX_VALUE = 2**32 - 1
+SEED_MAX_VALUE = 2**31
 
 
 # to check if a dtype instance is among these dtypes, use e.g. `dtype.type in NP_FLOAT_TYPES`


### PR DESCRIPTION
Hello,
I have recently downloaded the latest version which is `0.2.7` and I am using python `3.7.1`

I was using this with pytorch and jupyter-notebook and I got this error : 

`ValueError                                Traceback (most recent call last)
<ipython-input-7-9624fe884c38> in <module>
----> 1 for data, target in train_loader:

F:\Anaconda3\lib\site-packages\torch\utils\data\dataloader.py in __next__(self)
    613         if self.num_workers == 0:  # same-process loading
    614             indices = next(self.sample_iter)  # may raise StopIteration
--> 615             batch = self.collate_fn([self.dataset[i] for i in indices])
    616             if self.pin_memory:
    617                 batch = pin_memory_batch(batch)

F:\Anaconda3\lib\site-packages\torch\utils\data\dataloader.py in <listcomp>(.0)
    613         if self.num_workers == 0:  # same-process loading
    614             indices = next(self.sample_iter)  # may raise StopIteration
--> 615             batch = self.collate_fn([self.dataset[i] for i in indices])
    616             if self.pin_memory:
    617                 batch = pin_memory_batch(batch)

F:\Anaconda3\lib\site-packages\torchvision\datasets\folder.py in __getitem__(self, index)
    101         sample = self.loader(path)
    102         if self.transform is not None:
--> 103             sample = self.transform(sample)
    104         if self.target_transform is not None:
    105             target = self.target_transform(target)

F:\Anaconda3\lib\site-packages\torchvision\transforms\transforms.py in __call__(self, img)
     47     def __call__(self, img):
     48         for t in self.transforms:
---> 49             img = t(img)
     50         return img
     51 

<ipython-input-5-82dfa4ba7f15> in __call__(self, img)
     61         img = np.array(img)
     62 
---> 63         return self.aug.augment_image(img)

F:\Anaconda3\lib\site-packages\imgaug-0.2.7-py3.7.egg\imgaug\augmenters\meta.py in augment_image(self, image, hooks)
    530         ia.do_assert(image.ndim in [2, 3],
    531                      "Expected image to have shape (height, width, [channels]), got shape %s." % (image.shape,))
--> 532         return self.augment_images([image], hooks=hooks)[0]
    533 
    534     def augment_images(self, images, parents=None, hooks=None):

F:\Anaconda3\lib\site-packages\imgaug-0.2.7-py3.7.egg\imgaug\augmenters\meta.py in augment_images(self, images, parents, hooks)
    635                     random_state=ia.copy_random_state(self.random_state),
    636                     parents=parents,
--> 637                     hooks=hooks
    638                 )
    639                 # move "forward" the random state, so that the next call to

F:\Anaconda3\lib\site-packages\imgaug-0.2.7-py3.7.egg\imgaug\augmenters\meta.py in _augment_images(self, images, random_state, parents, hooks)
   1930                         images=images,
   1931                         parents=parents + [self],
-> 1932                         hooks=hooks
   1933                     )
   1934         return images

F:\Anaconda3\lib\site-packages\imgaug-0.2.7-py3.7.egg\imgaug\augmenters\meta.py in augment_images(self, images, parents, hooks)
    635                     random_state=ia.copy_random_state(self.random_state),
    636                     parents=parents,
--> 637                     hooks=hooks
    638                 )
    639                 # move "forward" the random state, so that the next call to

F:\Anaconda3\lib\site-packages\imgaug-0.2.7-py3.7.egg\imgaug\augmenters\color.py in _augment_images(self, images, random_state, parents, hooks)
    285 
    286         result = images
--> 287         images_hsv = self.colorspace_changer._augment_images(images, ia.derive_random_state(random_state),
    288                                                              parents + [self], hooks)
    289 

F:\Anaconda3\lib\site-packages\imgaug-0.2.7-py3.7.egg\imgaug\imgaug.py in derive_random_state(random_state)
    408 
    409     """
--> 410     return derive_random_states(random_state, n=1)[0]
    411 
    412 

F:\Anaconda3\lib\site-packages\imgaug-0.2.7-py3.7.egg\imgaug\imgaug.py in derive_random_states(random_state, n)
    430 
    431     """
--> 432     seed_ = random_state.randint(SEED_MIN_VALUE, SEED_MAX_VALUE, 1)[0]
    433     return [new_random_state(seed_+i) for i in sm.xrange(n)]
    434 

mtrand.pyx in mtrand.RandomState.randint()

ValueError: high is out of bounds for int32`

`SEED_MAX_VALUE` is `2**32-1` 

And I am following this notebook : https://colab.research.google.com/drive/109vu3F1LTzD1gdVV6cho9fKGx7lzbFll

After I got this error, I tried to recreate this error in a separate python file in hopes for finding a solution, with this code : 
`import numpy as np
rd = np.random.RandomState(1)
seed_ = rd.randint(0,2**32-1,1)[0]`

Which gave me : 
`Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mtrand.pyx", line 991, in mtrand.RandomState.randint
ValueError: high is out of bounds for int32` 

The same ValueError as above. 

To fix it, I used `2**31` instead of `2**32-1` and it worked.
 `2**31+1` gives the same as above ValueError.

Thank you ! :)