### PR TITLE
Fix doctests and move to xdoctest

### DIFF
--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division, absolute_import
-
 import copy as copy_module
 from collections import defaultdict
 from abc import ABCMeta, abstractmethod
@@ -8,6 +7,7 @@ import numpy as np
 import six
 import six.moves as sm
 import scipy
+import scipy.stats
 
 from . import imgaug as ia
 from .external.opensimplex import OpenSimplex
@@ -751,6 +751,74 @@ class Normal(StochasticParameter):
 
     def __str__(self):
         return "Normal(loc=%s, scale=%s)" % (self.loc, self.scale)
+
+
+class TruncNormal(StochasticParameter):
+    """
+    Parameter that resembles a truncated normal distribution.
+
+    A truncated normal distribution is very close to a normal distribution
+    except the domain is smoothly bounded.
+
+    This is a wrapper around scipy.stats.truncnorm.
+
+    Parameters
+    ----------
+    loc : number or imgaug.parameters.StochasticParameter
+        The mean of the normal distribution.
+        If StochasticParameter, the mean will be sampled once per call
+        to :func:`imgaug.parameters.Normal._draw_samples`.
+
+    scale : number or imgaug.parameters.StochasticParameter
+        The standard deviation of the normal distribution.
+        If StochasticParameter, the scale will be sampled once per call
+        to :func:`imgaug.parameters.Normal._draw_samples`.
+
+    low : number or imgaug.parameters.StochasticParameter
+        The minimum value of the truncated normal distribution.
+        If StochasticParameter, the scale will be sampled once per call
+        to :func:`imgaug.parameters.Normal._draw_samples`.
+
+    high : number or imgaug.parameters.StochasticParameter
+        The maximum value of the truncated normal distribution.
+        If StochasticParameter, the scale will be sampled once per call
+        to :func:`imgaug.parameters.Normal._draw_samples`.
+
+    Examples
+    --------
+    >>> param = TruncNormal(0, 5.0, low=-10, high=10)
+    >>> samples = param.draw_samples(100, random_state=np.random.RandomState(0))
+    >>> assert np.all(samples >= -10)
+    >>> assert np.all(samples <= 10)
+
+    """
+    def __init__(self, loc, scale, low=-np.inf, high=np.inf):
+        super(TruncNormal, self).__init__()
+
+        self.loc = handle_continuous_param(loc, "loc")
+        self.scale = handle_continuous_param(scale, "scale", value_range=(0, None))
+        self.low = handle_continuous_param(low, "low")
+        self.high = handle_continuous_param(high, "high")
+
+    def _draw_samples(self, size, random_state):
+        loc = self.loc.draw_sample(random_state=random_state)
+        scale = self.scale.draw_sample(random_state=random_state)
+        low = self.low.draw_sample(random_state=random_state)
+        high = self.high.draw_sample(random_state=random_state)
+        if low > high:
+            low, high = high, low
+        ia.do_assert(scale >= 0, "Expected scale to be in range [0, inf), got %s." % (scale,))
+        a = (low - loc) / scale
+        b = (high - loc) / scale
+        rv = scipy.stats.truncnorm(a=a, b=b, loc=loc, scale=scale)
+        return rv.rvs(size=size, random_state=random_state)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return "Normal(loc=%s, scale=%s, low=%s, high=%s)" % (
+            self.loc, self.scale, self.low, self.high)
 
 
 class Laplace(StochasticParameter):


### PR DESCRIPTION
Currently the imgaug doctests don't run. They probably don't run because writing correct doctests is tricky. The builtin Python doctest module uses regex parsing, which puts a lot of burden on the developer to make sure the syntax can be parsed by a system based on heuristics.

However, it really shouldn't be hard to make doctests run. That's why I wrote [xdoctest](https://github.com/Erotemic/xdoctest). It uses the same parser used by the Python interpreter to statically (i.e. absolutely no side effects) parse your source files, extract the docstrings, further extract the doctests, and finally structure the doctests in such a way that they can easily be run. 

I see your codebase has doctests which is great! However, it would be even better if they ran with the CI server. I can help move towards this. 

When I first ran xdoctest on your codebase I saw that there were a lot of errors because `iaa` was undefined. This makes sense because the doctests never actually imported those files (and when running via xdoctest you inherit the global scope of the file in which the doctest was defined). The most robust fix would be to actually insert `from imgaug import augmenters as iaa` at the top of every doctest. However, that would be a lot of changes. Fortunately, because I'm the author of xdoctest, I know my way around the code and in [PR33](https://github.com/Erotemic/xdoctest/pull/33) I just put in logic that allows the user to specify (via the xdoctest CLI) a chuck of code that is executed before every doctest (I'm trying to get the pytorch doctests running as well, and that repo also has the same issues).

After writing that patch and fixing the `iaa` errors, the number of failing doctests went from 64 failed to 13 failed. 

```
python -m xdoctest imgaug.imgaug angle_between_vectors:0
python -m xdoctest imgaug.imgaug imresize_many_images:0
python -m xdoctest imgaug.imgaug HooksImages:0
python -m xdoctest imgaug.imgaug KeypointsOnImage:0
python -m xdoctest imgaug.imgaug BoundingBoxesOnImage:0
python -m xdoctest imgaug.augmenters.meta Augmenter.augment_keypoints:0
python -m xdoctest imgaug.augmenters.meta Augmenter.augment_bounding_boxes:0
python -m xdoctest imgaug.augmenters.meta Augmenter.find_augmenters:0
python -m xdoctest imgaug.augmenters.meta Sequential:0
python -m xdoctest imgaug.augmenters.meta SomeOf:0
python -m xdoctest imgaug.augmenters.meta OneOf:0
python -m xdoctest imgaug.augmenters.arithmetic MultiplyElementwise:0
python -m xdoctest imgaug.augmenters.arithmetic CoarseDropout:0
```

One of the reasons to run doctests is to ensure that your examples are always up to date and have valid syntax. These failures motivate actually getting the doctests running. 

I was able to fix all of the above errors by either fixing an actual bug (e.g. calling augment_keypoints when you meant augment_bounding_boxes) or making a minor change (like defining the variable `img` / `A`).

I've added the relevant code to change pytest to use the xdoctest plugin instead of normal doctest. Note that it currently wont work on travis because I'll need to release xdoctest version 0.7.0 before the `--global-exec` argument is exposed. However, on my local machine running pytest runs all of the regular tests in addition to the doctests. 
 
Also note this is based on my trunc normal PR (which was the reason I wanted xdoctest to run in the first place), so github shows slightly more diff than there actually is. 