### PR TITLE
Add label manipulation in from_heatmap.

### DIFF
--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -5700,12 +5700,8 @@ class SegmentationMapOnImage(object):
             do_assert(len(class_indices) == heatmaps.arr_0to1.shape[2])
             arr_0to1 = heatmaps.arr_0to1
             arr_0to1_full = np.zeros((arr_0to1.shape[0], arr_0to1.shape[1], nb_classes), dtype=np.float32)
-            class_indices_set = set(class_indices)
-            heatmap_channel = 0
-            for c in sm.xrange(nb_classes):
-                if c in class_indices_set:
-                    arr_0to1_full[:, :, c] = arr_0to1[:, :, heatmap_channel]
-                    heatmap_channel += 1
+            for heatmap_channel, mapped_channel in enumerate(class_indices):
+                arr_0to1_full[:, :, mapped_channel] = arr_0to1[:, :, heatmap_channel]
             return SegmentationMapOnImage(arr_0to1_full, shape=heatmaps.shape)
 
     def copy(self):


### PR DESCRIPTION
This is in regard to issue #261 

I took the flipping out the augmentation pipeline, but want it as an imgaug augmenter. 
Therefore, I followed my original idea and switch the indices that are passed to class_indices in the `from_heatmaps` method.
In the method I noticed, that the passed `class_indices` are not actually used as a mapping. Instead it is only checked if they are inside the set and the class label is still just the element label.

The following change implements class_indices as an actual mapping. This would allow for very simple class label manipulation.

Because of the `do_assert(len(class_indices) == heatmaps.arr_0to1.shape[2])`, I believe it is valid to also rewrite the logic a little differently. 

It would not support copying the same heatmap channel to multiple class labels.
