### PR TITLE
Improve segmentation map augmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,67 +189,104 @@
   images (instead of only height/width). #349
 
 
-# Segmentation Maps
-
-## Improved Segmentation Map Augmentation
+## Improved Segmentation Map Augmentation #302
 
 Augmentation of Segmentation Maps is now faster and more memory efficient.
 This required some breaking changes to `SegmentationMapOnImage`.
-To adapt to the new version, the following steps should be sufficient for most users:
-* Rename all calls of `SegmentationMapOnImage` to `SegmentationMapsOnImage` (Map -> Maps).
-* Rename all calls of `SegmentationMapsOnImage.get_arr_int()` to `SegmentationMapsOnImage.get_arr()`.
-* Remove the argument `nb_classes` from all calls of `SegmentationMapsOnImage`.
-* Remove the arguments `background_id` and `background_threshold` from all calls as these are no longer supported.
-* Ensure that the input array to `SegmentationMapsOnImage` is always an int-like (int, uint or bool).
-  Float arrays are no longer accepted.
-* Ensure that if `SegmentationMapsOnImage.arr` is accessed anywhere, the respective code can handle the new `int32` `(H,W,#maps)` array form.
-  Previously it was `float32` and the channel-axis had the same size as the max class id (+1) that could appear in the map.
+To adapt to the new version, the following steps should be sufficient for most
+users:
 
+* Rename all calls of `SegmentationMapOnImage` to `SegmentationMapsOnImage`
+  (Map -> Maps).
+* Rename all calls of `SegmentationMapsOnImage.get_arr_int()` to
+  `SegmentationMapsOnImage.get_arr()`.
+* Remove the argument `nb_classes` from all calls of `SegmentationMapsOnImage`.
+* Remove the arguments `background_id` and `background_threshold` from all
+  calls as these are no longer supported.
+* Ensure that the input array to `SegmentationMapsOnImage` is always an
+  int-like (int, uint or bool).
+  Float arrays are no longer accepted.
+* Ensure that if `SegmentationMapsOnImage.arr` is accessed anywhere, the
+  respective code can handle the new `int32` `(H,W,#maps)` array form.
+  Previously it was `float32` and the channel-axis had the same size as the
+  max class id (+1) that could appear in the map.
 
 Changes:
 
 - Changes to class `SegmentationMapOnImage`:
     - Renamed `SegmentationMapOnImage` to plural `SegmentationMapsOnImage`
       and deprecated the old name.
-      This was changed due to the input array now being allowed to contain several
-      channels, with each such channel containing one full segmentation map.
-    - **[rarely breaking]** Changed `SegmentationMapsOnImage.__init__` to no longer accept float arrays as `arr` argument.
-    - **[breaking]** Changed `SegmentationMapsOnImage.__init__` to no longer accept `uint32` and larger itemsizes as `arr` argument, only `uint16` and below is accepted.
-      For `int` the maximum is `int32`.
-    - Changed `SegmentationMapsOnImage.__init__` to always accept `(H,W,C)` `arr` arguments.
-    - **[breaking]** Changed  `SegmentationMapsOnImage.arr` to always be `int32` `(H,W,#maps)` (previously: `float32` `(H,W,#nb_classes)`).
+      This was changed due to the input array now being allowed to contain
+      several channels, with each such channel containing one full segmentation
+      map.
+    - **[rarely breaking]** Changed `SegmentationMapsOnImage.__init__` to no
+      longer accept float arrays as `arr` argument.
+    - **[breaking]** Changed `SegmentationMapsOnImage.__init__` to no longer
+      accept `uint32` and larger itemsizes as `arr` argument, only `uint16`
+      and below is accepted. For `int` the maximum is `int32`.
+    - Changed `SegmentationMapsOnImage.__init__` to always accept `(H,W,C)`
+      `arr` arguments.
+    - **[breaking]** Changed  `SegmentationMapsOnImage.arr` to always be
+      `int32` `(H,W,#maps)` (previously: `float32` `(H,W,#nb_classes)`).
     - Deprecated `nb_classes` argument in `SegmentationMapsOnImage.__init__`.
       The argument is now ignored.
-    - Added `SegmentationMapsOnImage.get_arr()`, which always returns a segmentation map array with similar dtype and number of dimensions as was originally input when creating a class instance.
+    - Added `SegmentationMapsOnImage.get_arr()`, which always returns a
+      segmentation map array with similar dtype and number of dimensions as
+      was originally input when creating a class instance.
     - Deprecated `SegmentationMapsOnImage.get_arr_int()`.
       The method is now an alias for `get_arr()`.
     - `SegmentationMapsOnImage.draw()`:
         - **[breaking]** Removed argument `return_foreground_mask`.
         - **[breaking]** Removed optional output for foreground masks.
-        - **[breaking]** Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
-        - Refactored to be a wrapper around `SegmentationMapsOnImage.draw_on_image()`.
+        - **[breaking]** Changed output of drawn image to be a list of arrays
+          instead of a single array (one per `C` in input array `(H,W,C)`).
+        - Refactored to be a wrapper around
+          `SegmentationMapsOnImage.draw_on_image()`.
     - `SegmentationMapsOnImage.draw_on_image()`:
         - **[breaking]** Removed argument `background_class_id`.
         - **[breaking]** Removed argument `background_threshold`.
-        - **[breaking]** Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
-    - Changed `SegmentationMapsOnImage.resize()` to use nearest neighbour interpolaton by default.
-    - **[rarely breaking]** Changed `SegmentationMapsOnImage.copy()` to create a shallow copy instead of being an alias for `deepcopy()`.
-    - Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.copy()`.
-    - Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.deepcopy()`.
-    - Refactored `SegmentationMapsOnImage.pad()`, `SegmentationMapsOnImage.pad_to_aspect_ratio()`
-      and `SegmentationMapsOnImage.resize()` to generate new object instances via
+        - **[breaking]** Changed output of drawn image to be a list of arrays
+          instead of a single array (one per `C` in input array `(H,W,C)`).
+    - Changed `SegmentationMapsOnImage.resize()` to use nearest neighbour
+      interpolaton by default.
+    - **[rarely breaking]** Changed `SegmentationMapsOnImage.copy()` to create
+      a shallow copy instead of being an alias for `deepcopy()`.
+    - Added optional arguments `arr` and `shape` to
+      `SegmentationMapsOnImage.copy()`.
+    - Added optional arguments `arr` and `shape` to
       `SegmentationMapsOnImage.deepcopy()`.
-    - **[rarely breaking]** Renamed `SegmentationMapsOnImage.input_was` to `SegmentationMapsOnImage._input_was`.
-    - **[rarely breaking]** Changed `SegmentationMapsOnImage._input_was` to always save `(input array dtype, input array ndim)` instead of mixtures of strings/ints that varied by dtype kind.
-    - **[rarely breaking]** Restrict `shape` argument in `SegmentationMapsOnImage.__init__` to tuples instead of accepting all iterables.
-    - **[breaking]** Removed `SegmentationMapsOnImage.to_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
-    - **[breaking]** Removed `SegmentationMapsOnImage.from_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
+    - Refactored `SegmentationMapsOnImage.pad()`,
+      `SegmentationMapsOnImage.pad_to_aspect_ratio()` and
+      `SegmentationMapsOnImage.resize()` to generate new object instances via
+      `SegmentationMapsOnImage.deepcopy()`.
+    - **[rarely breaking]** Renamed `SegmentationMapsOnImage.input_was` to
+      `SegmentationMapsOnImage._input_was`.
+    - **[rarely breaking]** Changed `SegmentationMapsOnImage._input_was` to
+      always save `(input array dtype, input array ndim)` instead of mixtures
+      of strings/ints that varied by dtype kind.
+    - **[rarely breaking]** Restrict `shape` argument in
+      `SegmentationMapsOnImage.__init__` to tuples instead of accepting all
+      iterables.
+    - **[breaking]** Removed `SegmentationMapsOnImage.to_heatmaps()` as the
+      new segmentation map class is too different to sustain the old heatmap
+      conversion methods.
+    - **[breaking]** Removed `SegmentationMapsOnImage.from_heatmaps()` as the
+      new segmentation map class is too different to sustain the old heatmap
+      conversion methods.
 - Changes to class `Augmenter`:
-    - **[breaking]** Automatic segmentation map normalization from arrays or lists of arrays now expects a single `(N,H,W,C)` array (before: `(N,H,W)`) or a list of `(H,W,C)` arrays (before: `(H,W)`).
-      This affects valid segmentation map inputs for `Augmenter.augment()` and its alias `Augmenter.__call__()`, `imgaug.augmentables.batches.UnnormalizedBatch()` and `imgaug.augmentables.normalization.normalize_segmentation_maps()`.
+    - **[breaking]** Automatic segmentation map normalization from arrays or
+      lists of arrays now expects a single `(N,H,W,C)` array (before:
+      `(N,H,W)`) or a list of `(H,W,C)` arrays (before: `(H,W)`).
+      This affects valid segmentation map inputs for `Augmenter.augment()`
+      and its alias `Augmenter.__call__()`,
+      `imgaug.augmentables.batches.UnnormalizedBatch()` and
+      `imgaug.augmentables.normalization.normalize_segmentation_maps()`.
     - Added `Augmenter._augment_segmentation_maps()`.
-    - Changed `Augmenter.augment_segmentation_maps()` to no longer be a wrapper around `Augmenter.augment_heatmaps()` and instead call `Augmenter._augment_segmentation_maps()`.
-- Added special segmentation map handling to all augmenters that modified segmentation maps
+    - Changed `Augmenter.augment_segmentation_maps()` to no longer be a
+    wrapper around `Augmenter.augment_heatmaps()` and instead call
+    `Augmenter._augment_segmentation_maps()`.
+- Added special segmentation map handling to all augmenters that modified
+  segmentation maps
   (`Sequential`, `SomeOf`, `Sometimes`, `WithChannels`,
    `Lambda`, `AssertLambda`, `AssertShape`,
    `Alpha`, `AlphaElementwise`, `WithColorspace`, `Fliplr`, `Flipud`, `Affine`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,74 @@
   images (instead of only height/width). #349
 
 
+# Segmentation Maps
+
+- [breaking] Renamed `SegmentationMapOnImage` to plural `SegmentationMapsOnImage`
+  (as the input array may not contain several channels, with each channel
+   containing one full segmentation map).
+- [rarely breaking] Changed `SegmentationMapsOnImage.__init__` to no longer accept float arrays as `arr` argument.
+- [breaking] Changed `SegmentationMapsOnImage.__init__` to no longer accept `uint32` and larger itemsizes as `arr` argument, only `uint16` and below is accepted.
+  For `int` the maximum is `int32`.
+- Changed `SegmentationMapsOnImage.__init__` to always accept `(H,W,C)` `arr` arguments.
+- [breaking] Changed  `SegmentationMapsOnImage.arr` to always be 3-dimensional (`(H,W,C)`) instead of 2-dimensional (`(H,W)`).
+- [breaking] Removed `nb_classes` from `SegmentationMapsOnImage.__init__`.
+- [breaking] Removed `SegmentationMapsOnImage.get_arr_int()`.
+- `SegmentationMapsOnImage.draw()`:
+    - [breaking] Removed argument `return_foreground_mask`.
+    - [breaking] Removed optional output for foreground masks.
+    - [breaking] Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
+    - Refactored to be a wrapper around `SegmentationMapsOnImage.draw_on_image()`.
+- `SegmentationMapsOnImage.draw_on_image()`:
+    - [breaking] Removed argument `background_class_id`.
+    - [breaking] Removed argument `background_threshold`.
+    - [breaking] Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
+- Changed `SegmentationMapsOnImage.resize()` to use nearest neighbour interpolaton by default.
+- [rarely breaking] Changed `SegmentationMapsOnImage.copy()` to create a shallow copy instead of being an alias for `deepcopy()`.
+- Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.copy()`.
+- Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.deepcopy()`.
+- Refactored `SegmentationMapsOnImage.pad()`, `SegmentationMapsOnImage.pad_to_aspect_ratio()`
+  and `SegmentationMapsOnImage.resize()` to generate new object instances via
+  `SegmentationMapsOnImage.deepcopy()`.
+- [rarely breaking] Changed `SegmentationMapsOnImage.input_was` to always save `(input array dtype, input array ndim)` instead of mixtures of strings/ints that varied by dtype kind.
+- [rarely breaking] Restrict `shape` argument in `SegmentationMapsOnImage.__init__` to tuples instead of accepting all iterables.
+- [breaking] Removed `SegmentationMapsOnImage.to_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
+- [breaking] Removed `SegmentationMapsOnImage.from_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
+- [breaking] Removed `SegmentationMapsOnImage.get_arr_int()`.
+- Added `SegmentationMapsOnImage.get_arr()`, which always returns a segmentation map array with similar dtype and number of dimensions as was originally input when creating a class instance.
+- [breaking] Automatic segmentation map normalization from arrays or lists of arrays now expects a single `(N,H,W,C)` array (before: `(N,H,W)`) or a list of `(H,W,C)` arrays (before: `(H,W)`).
+  This affects valid segmentation map inputs for `Augmenter.augment()` and its alias `Augmenter.__call__()`, `imgaug.augmentables.batches.UnnormalizedBatch()` and `imgaug.augmentables.normalization.normalize_segmentation_maps()`.
+- Added `Augmenter._augment_segmentation_maps()`.
+- Changed `Augmenter.augment_segmentation_maps()` to no longer be a wrapper around `Augmenter.augment_heatmaps()` and instead call `Augmenter._augment_segmentation_maps()`.
+- Added special segmentation map handling to `Sequential`.
+- Added special segmentation map handling to `SomeOf`.
+- Added special segmentation map handling to `Sometimes`.
+- Added special segmentation map handling to `WithChannels`.
+- [breaking] Added segmentation map argument and handling to `Lambda`.
+  This changes the order of arguments in `Lambda.__init__()` and hence
+  breaks if one relied on that order.
+- [breaking] Added segmentation map argument and handling to `AssertLambda`.
+  This changes the order of arguments in `AssertLambda.__init__()` and hence
+  breaks if one relied on that order.
+- [breaking] Added segmentation map argument and handling to `AssertShape`.
+  This changes the order of arguments in `AssertShape.__init__()` and hence
+  breaks if one relied on that order.
+- Added special segmentation map handling to `Alpha`.
+- Added special segmentation map handling to `AlphaElementwise`.
+- Added special segmentation map handling to `WithColorspace`.
+- Added special segmentation map handling to `Fliplr`.
+- Added special segmentation map handling to `Flipud`.
+- Added special segmentation map handling to `Affine`.
+- Added special segmentation map handling to `AffineCv2`.
+- Added special segmentation map handling to `PiecewiseAffine`.
+- Added special segmentation map handling to `PerspectiveTransform`.
+- Added special segmentation map handling to `ElasticTransformation`.
+- Added special segmentation map handling to `Rot90`.
+- Added special segmentation map handling to `Resize`.
+- Added special segmentation map handling to `CropAndPad`.
+- Added special segmentation map handling to `PadToFixedSize`.
+- Added special segmentation map handling to `CropToFixedSize`.
+- Added special segmentation map handling to `KeepSizeByResize`.
+
 ## Fixes
  
 * Fixed an issue with `Polygon.clip_out_of_image()`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,8 +219,8 @@ Changes:
       This was changed due to the input array now being allowed to contain
       several channels, with each such channel containing one full segmentation
       map.
-    - **[rarely breaking]** Changed `SegmentationMapsOnImage.__init__` to no
-      longer accept float arrays as `arr` argument.
+    - Changed `SegmentationMapsOnImage.__init__` to produce a deprecation
+      warning for float arrays as `arr` argument.
     - **[breaking]** Changed `SegmentationMapsOnImage.__init__` to no longer
       accept `uint32` and larger itemsizes as `arr` argument, only `uint16`
       and below is accepted. For `int` the maximum is `int32`.
@@ -236,8 +236,11 @@ Changes:
     - Deprecated `SegmentationMapsOnImage.get_arr_int()`.
       The method is now an alias for `get_arr()`.
     - `SegmentationMapsOnImage.draw()`:
-        - **[breaking]** Removed argument `return_foreground_mask`.
-        - **[breaking]** Removed optional output for foreground masks.
+        - **[breaking]** Removed argument `return_foreground_mask` and
+          corresponding optional output. To generate a foreground mask
+          for the `c`-th segmentation map on a given image (usually `c=0`),
+          use `segmentation_map.arr[:, :, c] != 0`, assuming that `0` is
+          the integer index of your background class. 
         - **[breaking]** Changed output of drawn image to be a list of arrays
           instead of a single array (one per `C` in input array `(H,W,C)`).
         - Refactored to be a wrapper around
@@ -248,7 +251,7 @@ Changes:
         - **[breaking]** Changed output of drawn image to be a list of arrays
           instead of a single array (one per `C` in input array `(H,W,C)`).
     - Changed `SegmentationMapsOnImage.resize()` to use nearest neighbour
-      interpolaton by default.
+      interpolation by default.
     - **[rarely breaking]** Changed `SegmentationMapsOnImage.copy()` to create
       a shallow copy instead of being an alias for `deepcopy()`.
     - Added optional arguments `arr` and `shape` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,10 @@ Changes:
           instead of a single array (one per `C` in input array `(H,W,C)`).
         - Refactored to be a wrapper around
           `SegmentationMapsOnImage.draw_on_image()`.
+        - The `size` argument may now be any of: A single `None` (keep shape),
+          a single integer (use as height and width), a single float (relative
+          change to shape) or a tuple of these values. ("shape" here denotes
+          the value of the `.shape` attribute.)
     - `SegmentationMapsOnImage.draw_on_image()`:
         - **[breaking]** The argument `background_threshold` is now deprecated
           and ignored. Providing it will lead to a deprecation warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@
   for `Voronoi(DropoutPointsSampler(RelativeRegularGridPointsSampler))`. #348
 * Add to `Resize` the ability to resize the shorter and longer sides of
   images (instead of only height/width). #349
+* Improved the docstrings of most augmenters and added code examples. #302
 
 
 ## Improved Segmentation Map Augmentation #302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,7 @@ Changes:
       warning for float arrays as `arr` argument.
     - **[breaking]** Changed `SegmentationMapsOnImage.__init__` to no longer
       accept `uint32` and larger itemsizes as `arr` argument, only `uint16`
-      and below is accepted. For `int` the maximum is `int32`.
+      and below is accepted. For `int` the allowed maximum is `int32`.
     - Changed `SegmentationMapsOnImage.__init__` to always accept `(H,W,C)`
       `arr` arguments.
     - **[breaking]** Changed  `SegmentationMapsOnImage.arr` to always be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,11 @@ users:
 * Ensure that the input array to `SegmentationMapsOnImage` is always an
   int-like (int, uint or bool).
   Float arrays are no longer accepted.
+* Adapt all calls `SegmentationMapsOnImage.draw()` and
+  `SegmentationMapsOnImage.draw_on_image()`, as both of these now return a
+  list of drawn images instead of a single array. (For a segmentation map
+  array of shape `(H,W,C)` they return `C` drawn images. In most cases `C=1`,
+  so simply call `draw()[0]` or `draw_on_image()[0]`.)
 * Ensure that if `SegmentationMapsOnImage.arr` is accessed anywhere, the
   respective code can handle the new `int32` `(H,W,#maps)` array form.
   Previously it was `float32` and the channel-axis had the same size as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,8 +246,10 @@ Changes:
         - Refactored to be a wrapper around
           `SegmentationMapsOnImage.draw_on_image()`.
     - `SegmentationMapsOnImage.draw_on_image()`:
-        - **[breaking]** Removed argument `background_class_id`.
-        - **[breaking]** Removed argument `background_threshold`.
+        - **[breaking]** The argument `background_class_id` is now deprecated
+          and ignored. Providing it will lead to a deprecation warning.
+        - **[breaking]** The argument `background_threshold` is now deprecated
+          and ignored. Providing it will lead to a deprecation warning.
         - **[breaking]** Changed output of drawn image to be a list of arrays
           instead of a single array (one per `C` in input array `(H,W,C)`).
     - Changed `SegmentationMapsOnImage.resize()` to use nearest neighbour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,53 @@
 * Add to `Resize` the ability to resize the shorter and longer sides of
   images (instead of only height/width). #349
 * Improved the docstrings of most augmenters and added code examples. #302
+* Changes to support numpy 1.17 #302
+    * [rarely breaking] Deactivated support for `int64` in
+      `imgaug.dtypes.clip_()`. This is due to numpy 1.17 turning `int64` to
+      `float64` in `numpy.clip()` (possible that this happened in some way
+      before 1.17 too).
+    * [rarely breaking] Changed `imgaug.dtypes.clip()` to never clip `int32`
+      in-place, as `numpy.clip()` turns it into `float64` since 1.17 (possible
+      that this happend in some way before 1.17 too).
+    * [rarely breaking] Deactivated support for `int64` in
+      `ReplaceElementwise`. See `clip` issue above.
+    * [rarely breaking] Changed `parameters.DiscreteUniform` to always return
+      arrays of dtype `int32`. Previously it would automatically return
+      `int64`.
+    * [rarely breaking] Changed `parameters.Deterministic` to always return
+      `int32` for integers and always `float32` for floats.
+    * [rarely breaking] Changed `parameters.Choice` to limit integer
+      dtypes to `int32` or lower, uints to `uint32` or lower and floats
+      to `float32` or lower. 
+    * [rarely breaking] Changed `parameters.Binomial` and `parameters.Poisson`
+      to always return `int32`.
+    * [rarely breaking] Changed `parameters.Normal`,
+      `parameters.TruncatedNormal`, `parameters.Laplace`,
+      `parameters.ChiSquare`, `parameters.Weibull`, `parameters.Uniform` and
+      `parameters.Beta` to always return `float32`.
+    * [rarely breaking] Changed `augmenters.arithmetic.Add`,
+      `augmenters.arithmetic.AddElementwise`, `augmenters.arithmetic.Multiply`
+      and `augmenters.arithmetic.MultiplyElementwise` to no longer internally
+      increase itemsize of dtypes by a factor of 2 for
+      dtypes `uint16`, `int8` and `uint16`. For `Multiply*` this also
+      covers `float16` and `float32`. This protects against crashes due to
+      clipping `int64` or `uint64` data. In rare cases this can lead to
+      overflows if `image + random samples` or `image * random samples`
+      exceeds the value range of `int32` or `uint32`. This change may affect
+      various other augmenters that are wrappers around the mentioned ones,
+      e.g. `AdditiveGaussianNoise`.
+    * [rarely breaking] Decreased support of dtypes `uint16`, `int8`,
+      `int16`, `float16`, `float32` and `bool` in `augmenters.arithmetic.Add`,
+      `AddElementwise`, `Multiply` and `MultiplyElementwise` from "yes" to
+      "limited".
+    * [rarely breaking] Decreased support of dtype `int64` in
+      `augmenters.arithmetic.ReplaceElementwise` from "yes" to "no". This also
+      affects all `*Noise` augmenters (e.g. `AdditiveGaussianNoise`,
+      `ImpulseNoise`), all `Dropout` augmenters, all `Salt` augmenters and
+      all `Pepper` augmenters.
+    * [rarely breaking] Changed `augmenters.contrast.adjust_contrast_log`
+      and thereby `LogContrast` to no longer support dtypes `uint32`, `uint64`,
+      `int32` and `int64`.
 
 
 ## Improved Segmentation Map Augmentation #302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,8 +251,6 @@ Changes:
         - Refactored to be a wrapper around
           `SegmentationMapsOnImage.draw_on_image()`.
     - `SegmentationMapsOnImage.draw_on_image()`:
-        - **[breaking]** The argument `background_class_id` is now deprecated
-          and ignored. Providing it will lead to a deprecation warning.
         - **[breaking]** The argument `background_threshold` is now deprecated
           and ignored. Providing it will lead to a deprecation warning.
         - **[breaking]** Changed output of drawn image to be a list of arrays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,7 +239,8 @@ Changes:
     - Refactored `SegmentationMapsOnImage.pad()`, `SegmentationMapsOnImage.pad_to_aspect_ratio()`
       and `SegmentationMapsOnImage.resize()` to generate new object instances via
       `SegmentationMapsOnImage.deepcopy()`.
-    - **[rarely breaking]** Changed `SegmentationMapsOnImage.input_was` to always save `(input array dtype, input array ndim)` instead of mixtures of strings/ints that varied by dtype kind.
+    - **[rarely breaking]** Renamed `SegmentationMapsOnImage.input_was` to `SegmentationMapsOnImage._input_was`.
+    - **[rarely breaking]** Changed `SegmentationMapsOnImage._input_was` to always save `(input array dtype, input array ndim)` instead of mixtures of strings/ints that varied by dtype kind.
     - **[rarely breaking]** Restrict `shape` argument in `SegmentationMapsOnImage.__init__` to tuples instead of accepting all iterables.
     - **[breaking]** Removed `SegmentationMapsOnImage.to_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
     - **[breaking]** Removed `SegmentationMapsOnImage.from_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,73 +191,73 @@
 
 # Segmentation Maps
 
-- Renamed `SegmentationMapOnImage` to plural `SegmentationMapsOnImage`
-  and deprecated the old name.
-  This was changed due to the input array now being allowed to contain several
-  channels, with each such channel containing one full segmentation map.
-- [rarely breaking] Changed `SegmentationMapsOnImage.__init__` to no longer accept float arrays as `arr` argument.
-- [breaking] Changed `SegmentationMapsOnImage.__init__` to no longer accept `uint32` and larger itemsizes as `arr` argument, only `uint16` and below is accepted.
-  For `int` the maximum is `int32`.
-- Changed `SegmentationMapsOnImage.__init__` to always accept `(H,W,C)` `arr` arguments.
-- [breaking] Changed  `SegmentationMapsOnImage.arr` to always be 3-dimensional (`(H,W,C)`) instead of 2-dimensional (`(H,W)`).
-- Deprecated `nb_classes` argument in `SegmentationMapsOnImage.__init__`.
-  The argument is now ignored.
-- Added `SegmentationMapsOnImage.get_arr()`, which always returns a segmentation map array with similar dtype and number of dimensions as was originally input when creating a class instance.
-- Deprecated `SegmentationMapsOnImage.get_arr_int()`.
-  The method is now an alias for `get_arr()`.
-- `SegmentationMapsOnImage.draw()`:
-    - [breaking] Removed argument `return_foreground_mask`.
-    - [breaking] Removed optional output for foreground masks.
-    - [breaking] Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
-    - Refactored to be a wrapper around `SegmentationMapsOnImage.draw_on_image()`.
-- `SegmentationMapsOnImage.draw_on_image()`:
-    - [breaking] Removed argument `background_class_id`.
-    - [breaking] Removed argument `background_threshold`.
-    - [breaking] Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
-- Changed `SegmentationMapsOnImage.resize()` to use nearest neighbour interpolaton by default.
-- [rarely breaking] Changed `SegmentationMapsOnImage.copy()` to create a shallow copy instead of being an alias for `deepcopy()`.
-- Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.copy()`.
-- Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.deepcopy()`.
-- Refactored `SegmentationMapsOnImage.pad()`, `SegmentationMapsOnImage.pad_to_aspect_ratio()`
-  and `SegmentationMapsOnImage.resize()` to generate new object instances via
-  `SegmentationMapsOnImage.deepcopy()`.
-- [rarely breaking] Changed `SegmentationMapsOnImage.input_was` to always save `(input array dtype, input array ndim)` instead of mixtures of strings/ints that varied by dtype kind.
-- [rarely breaking] Restrict `shape` argument in `SegmentationMapsOnImage.__init__` to tuples instead of accepting all iterables.
-- [breaking] Removed `SegmentationMapsOnImage.to_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
-- [breaking] Removed `SegmentationMapsOnImage.from_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
-- [breaking] Automatic segmentation map normalization from arrays or lists of arrays now expects a single `(N,H,W,C)` array (before: `(N,H,W)`) or a list of `(H,W,C)` arrays (before: `(H,W)`).
-  This affects valid segmentation map inputs for `Augmenter.augment()` and its alias `Augmenter.__call__()`, `imgaug.augmentables.batches.UnnormalizedBatch()` and `imgaug.augmentables.normalization.normalize_segmentation_maps()`.
-- Added `Augmenter._augment_segmentation_maps()`.
-- Changed `Augmenter.augment_segmentation_maps()` to no longer be a wrapper around `Augmenter.augment_heatmaps()` and instead call `Augmenter._augment_segmentation_maps()`.
-- Added special segmentation map handling to `Sequential`.
-- Added special segmentation map handling to `SomeOf`.
-- Added special segmentation map handling to `Sometimes`.
-- Added special segmentation map handling to `WithChannels`.
-- [rarely breaking] Added segmentation map argument and handling to `Lambda`.
-  This changes the order of arguments in `Lambda.__init__()` and hence
-  breaks if one relied on that order.
-- [rarely breaking] Added segmentation map argument and handling to `AssertLambda`.
-  This changes the order of arguments in `AssertLambda.__init__()` and hence
-  breaks if one relied on that order.
-- [rarely breaking] Added segmentation map argument and handling to `AssertShape`.
-  This changes the order of arguments in `AssertShape.__init__()` and hence
-  breaks if one relied on that order.
-- Added special segmentation map handling to `Alpha`.
-- Added special segmentation map handling to `AlphaElementwise`.
-- Added special segmentation map handling to `WithColorspace`.
-- Added special segmentation map handling to `Fliplr`.
-- Added special segmentation map handling to `Flipud`.
-- Added special segmentation map handling to `Affine`.
-- Added special segmentation map handling to `AffineCv2`.
-- Added special segmentation map handling to `PiecewiseAffine`.
-- Added special segmentation map handling to `PerspectiveTransform`.
-- Added special segmentation map handling to `ElasticTransformation`.
-- Added special segmentation map handling to `Rot90`.
-- Added special segmentation map handling to `Resize`.
-- Added special segmentation map handling to `CropAndPad`.
-- Added special segmentation map handling to `PadToFixedSize`.
-- Added special segmentation map handling to `CropToFixedSize`.
-- Added special segmentation map handling to `KeepSizeByResize`.
+## Improved Segmentation Map Augmentation
+
+Augmentation of Segmentation Maps is now faster and more memory efficient.
+This required some breaking changes to `SegmentationMapOnImage`.
+To adapt to the new version, the following steps should be sufficient for most users:
+* Rename all calls of `SegmentationMapOnImage` to `SegmentationMapsOnImage` (Map -> Maps).
+* Rename all calls of `SegmentationMapsOnImage.get_arr_int()` to `SegmentationMapsOnImage.get_arr()`.
+* Remove the argument `nb_classes` from all calls of `SegmentationMapsOnImage`.
+* Remove the arguments `background_id` and `background_threshold` from all calls as these are no longer supported.
+* Ensure that the input array to `SegmentationMapsOnImage` is always an int-like (int, uint or bool).
+  Float arrays are no longer accepted.
+* Ensure that if `SegmentationMapsOnImage.arr` is accessed anywhere, the respective code can handle the new `int32` `(H,W,#maps)` array form.
+  Previously it was `float32` and the channel-axis had the same size as the max class id (+1) that could appear in the map.
+
+
+Changes:
+
+- Changes to class `SegmentationMapOnImage`:
+    - Renamed `SegmentationMapOnImage` to plural `SegmentationMapsOnImage`
+      and deprecated the old name.
+      This was changed due to the input array now being allowed to contain several
+      channels, with each such channel containing one full segmentation map.
+    - **[rarely breaking]** Changed `SegmentationMapsOnImage.__init__` to no longer accept float arrays as `arr` argument.
+    - **[breaking]** Changed `SegmentationMapsOnImage.__init__` to no longer accept `uint32` and larger itemsizes as `arr` argument, only `uint16` and below is accepted.
+      For `int` the maximum is `int32`.
+    - Changed `SegmentationMapsOnImage.__init__` to always accept `(H,W,C)` `arr` arguments.
+    - **[breaking]** Changed  `SegmentationMapsOnImage.arr` to always be `int32` `(H,W,#maps)` (previously: `float32` `(H,W,#nb_classes)`).
+    - Deprecated `nb_classes` argument in `SegmentationMapsOnImage.__init__`.
+      The argument is now ignored.
+    - Added `SegmentationMapsOnImage.get_arr()`, which always returns a segmentation map array with similar dtype and number of dimensions as was originally input when creating a class instance.
+    - Deprecated `SegmentationMapsOnImage.get_arr_int()`.
+      The method is now an alias for `get_arr()`.
+    - `SegmentationMapsOnImage.draw()`:
+        - **[breaking]** Removed argument `return_foreground_mask`.
+        - **[breaking]** Removed optional output for foreground masks.
+        - **[breaking]** Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
+        - Refactored to be a wrapper around `SegmentationMapsOnImage.draw_on_image()`.
+    - `SegmentationMapsOnImage.draw_on_image()`:
+        - **[breaking]** Removed argument `background_class_id`.
+        - **[breaking]** Removed argument `background_threshold`.
+        - **[breaking]** Changed output of drawn image to be a list of arrays instead of a single array (one per `C` in input array `(H,W,C)`).
+    - Changed `SegmentationMapsOnImage.resize()` to use nearest neighbour interpolaton by default.
+    - **[rarely breaking]** Changed `SegmentationMapsOnImage.copy()` to create a shallow copy instead of being an alias for `deepcopy()`.
+    - Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.copy()`.
+    - Added optional arguments `arr` and `shape` to `SegmentationMapsOnImage.deepcopy()`.
+    - Refactored `SegmentationMapsOnImage.pad()`, `SegmentationMapsOnImage.pad_to_aspect_ratio()`
+      and `SegmentationMapsOnImage.resize()` to generate new object instances via
+      `SegmentationMapsOnImage.deepcopy()`.
+    - **[rarely breaking]** Changed `SegmentationMapsOnImage.input_was` to always save `(input array dtype, input array ndim)` instead of mixtures of strings/ints that varied by dtype kind.
+    - **[rarely breaking]** Restrict `shape` argument in `SegmentationMapsOnImage.__init__` to tuples instead of accepting all iterables.
+    - **[breaking]** Removed `SegmentationMapsOnImage.to_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
+    - **[breaking]** Removed `SegmentationMapsOnImage.from_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
+- Changes to class `Augmenter`:
+    - **[breaking]** Automatic segmentation map normalization from arrays or lists of arrays now expects a single `(N,H,W,C)` array (before: `(N,H,W)`) or a list of `(H,W,C)` arrays (before: `(H,W)`).
+      This affects valid segmentation map inputs for `Augmenter.augment()` and its alias `Augmenter.__call__()`, `imgaug.augmentables.batches.UnnormalizedBatch()` and `imgaug.augmentables.normalization.normalize_segmentation_maps()`.
+    - Added `Augmenter._augment_segmentation_maps()`.
+    - Changed `Augmenter.augment_segmentation_maps()` to no longer be a wrapper around `Augmenter.augment_heatmaps()` and instead call `Augmenter._augment_segmentation_maps()`.
+- Added special segmentation map handling to all augmenters that modified segmentation maps
+  (`Sequential`, `SomeOf`, `Sometimes`, `WithChannels`,
+   `Lambda`, `AssertLambda`, `AssertShape`,
+   `Alpha`, `AlphaElementwise`, `WithColorspace`, `Fliplr`, `Flipud`, `Affine`,
+   `AffineCv2`, `PiecewiseAffine`, `PerspectiveTransform`, `ElasticTransformation`,
+   `Rot90`, `Resize`, `CropAndPad`, `PadToFixedSize`, `CropToFixedSize`,
+   `KeepSizeByResize`).
+   - **[rarely breaking]** This changes the order of arguments in
+     `Lambda.__init__()`, `AssertLambda.__init__()`, `AssertShape.__init__()`
+     and hence breaks if one relied on that order.
 
 ## Fixes
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,16 +191,20 @@
 
 # Segmentation Maps
 
-- [breaking] Renamed `SegmentationMapOnImage` to plural `SegmentationMapsOnImage`
-  (as the input array may not contain several channels, with each channel
-   containing one full segmentation map).
+- Renamed `SegmentationMapOnImage` to plural `SegmentationMapsOnImage`
+  and deprecated the old name.
+  This was changed due to the input array now being allowed to contain several
+  channels, with each such channel containing one full segmentation map.
 - [rarely breaking] Changed `SegmentationMapsOnImage.__init__` to no longer accept float arrays as `arr` argument.
 - [breaking] Changed `SegmentationMapsOnImage.__init__` to no longer accept `uint32` and larger itemsizes as `arr` argument, only `uint16` and below is accepted.
   For `int` the maximum is `int32`.
 - Changed `SegmentationMapsOnImage.__init__` to always accept `(H,W,C)` `arr` arguments.
 - [breaking] Changed  `SegmentationMapsOnImage.arr` to always be 3-dimensional (`(H,W,C)`) instead of 2-dimensional (`(H,W)`).
-- [breaking] Removed `nb_classes` from `SegmentationMapsOnImage.__init__`.
-- [breaking] Removed `SegmentationMapsOnImage.get_arr_int()`.
+- Deprecated `nb_classes` argument in `SegmentationMapsOnImage.__init__`.
+  The argument is now ignored.
+- Added `SegmentationMapsOnImage.get_arr()`, which always returns a segmentation map array with similar dtype and number of dimensions as was originally input when creating a class instance.
+- Deprecated `SegmentationMapsOnImage.get_arr_int()`.
+  The method is now an alias for `get_arr()`.
 - `SegmentationMapsOnImage.draw()`:
     - [breaking] Removed argument `return_foreground_mask`.
     - [breaking] Removed optional output for foreground masks.
@@ -221,8 +225,6 @@
 - [rarely breaking] Restrict `shape` argument in `SegmentationMapsOnImage.__init__` to tuples instead of accepting all iterables.
 - [breaking] Removed `SegmentationMapsOnImage.to_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
 - [breaking] Removed `SegmentationMapsOnImage.from_heatmaps()` as the new segmentation map class is too different to sustain the old heatmap conversion methods.
-- [breaking] Removed `SegmentationMapsOnImage.get_arr_int()`.
-- Added `SegmentationMapsOnImage.get_arr()`, which always returns a segmentation map array with similar dtype and number of dimensions as was originally input when creating a class instance.
 - [breaking] Automatic segmentation map normalization from arrays or lists of arrays now expects a single `(N,H,W,C)` array (before: `(N,H,W)`) or a list of `(H,W,C)` arrays (before: `(H,W)`).
   This affects valid segmentation map inputs for `Augmenter.augment()` and its alias `Augmenter.__call__()`, `imgaug.augmentables.batches.UnnormalizedBatch()` and `imgaug.augmentables.normalization.normalize_segmentation_maps()`.
 - Added `Augmenter._augment_segmentation_maps()`.
@@ -231,13 +233,13 @@
 - Added special segmentation map handling to `SomeOf`.
 - Added special segmentation map handling to `Sometimes`.
 - Added special segmentation map handling to `WithChannels`.
-- [breaking] Added segmentation map argument and handling to `Lambda`.
+- [rarely breaking] Added segmentation map argument and handling to `Lambda`.
   This changes the order of arguments in `Lambda.__init__()` and hence
   breaks if one relied on that order.
-- [breaking] Added segmentation map argument and handling to `AssertLambda`.
+- [rarely breaking] Added segmentation map argument and handling to `AssertLambda`.
   This changes the order of arguments in `AssertLambda.__init__()` and hence
   breaks if one relied on that order.
-- [breaking] Added segmentation map argument and handling to `AssertShape`.
+- [rarely breaking] Added segmentation map argument and handling to `AssertShape`.
   This changes the order of arguments in `AssertShape.__init__()` and hence
   breaks if one relied on that order.
 - Added special segmentation map handling to `Alpha`.

--- a/checks/check_segmentation_maps.py
+++ b/checks/check_segmentation_maps.py
@@ -9,21 +9,21 @@ from imgaug import augmenters as iaa
 def main():
     quokka = ia.quokka(size=0.5)
     h, w = quokka.shape[0:2]
-    c = 4
-    segmap = np.zeros((h, w, c), dtype=np.float32)
-    segmap[70:120, 90:150, 0] = 1.0
-    segmap[30:70, 50:65, 1] = 1.0
-    segmap[20:50, 55:85, 2] = 1.0
-    segmap[120:140, 0:20, 3] = 1.0
+    c = 1
+    segmap = np.zeros((h, w, c), dtype=np.int32)
+    segmap[70:120, 90:150, 0] = 1
+    segmap[30:70, 50:65, 0] = 2
+    segmap[20:50, 55:85, 0] = 3
+    segmap[120:140, 0:20, 0] = 4
 
-    segmap = ia.SegmentationMapOnImage(segmap, quokka.shape)
+    segmap = ia.SegmentationMapsOnImage(segmap, quokka.shape)
 
     print("Affine...")
     aug = iaa.Affine(translate_px={"x": 20}, mode="constant", cval=128)
     quokka_aug = aug.augment_image(quokka)
     segmaps_aug = aug.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -35,9 +35,9 @@ def main():
     print("Affine with mode=edge...")
     aug = iaa.Affine(translate_px={"x": 20}, mode="edge")
     quokka_aug = aug.augment_image(quokka)
-    segmaps_aug = aug.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -50,9 +50,9 @@ def main():
     aug = iaa.PiecewiseAffine(scale=0.04)
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -65,9 +65,9 @@ def main():
     aug = iaa.PerspectiveTransform(scale=0.04)
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -80,9 +80,9 @@ def main():
     aug = iaa.ElasticTransformation(alpha=3.0, sigma=0.5)
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -95,9 +95,9 @@ def main():
     aug = iaa.ElasticTransformation(alpha=10.0, sigma=3.0)
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -110,9 +110,9 @@ def main():
     aug = iaa.CropAndPad(px=(-10, 10, 15, -15), pad_mode="constant", pad_cval=128)
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -125,9 +125,9 @@ def main():
     aug = iaa.CropAndPad(px=(-10, 10, 15, -15), pad_mode="edge")
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([
@@ -140,9 +140,9 @@ def main():
     aug = iaa.Resize(0.5, interpolation="nearest")
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(ia.draw_grid([segmaps_drawn, segmaps_aug_drawn], cols=2))
 
@@ -150,9 +150,9 @@ def main():
     aug = iaa.Alpha(0.7, iaa.Affine(rotate=20))
     aug_det = aug.to_deterministic()
     quokka_aug = aug_det.augment_image(quokka)
-    segmaps_aug = aug_det.augment_segmentation_maps([segmap])[0]
-    segmaps_drawn = segmap.draw_on_image(quokka)
-    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
 
     ia.imshow(
         np.hstack([

--- a/imgaug/augmentables/batches.py
+++ b/imgaug/augmentables/batches.py
@@ -38,11 +38,11 @@ class UnnormalizedBatch(object):
 
     segmentation_maps : None \
             or (N,H,W) ndarray \
-            or imgaug.augmentables.segmaps.SegmentationMapOnImage \
+            or imgaug.augmentables.segmaps.SegmentationMapsOnImage \
             or iterable of (H,W) ndarray \
-            or iterable of imgaug.augmentables.segmaps.SegmentationMapOnImage
+            or iterable of imgaug.augmentables.segmaps.SegmentationMapsOnImage
         The segmentation maps to augment.
-        If anything else than ``SegmentationMapOnImage``, then the number of
+        If anything else than ``SegmentationMapsOnImage``, then the number of
         segmaps must match the number of images provided via parameter
         `images`. The number is contained either in ``N`` or the first
         iterable's size.
@@ -290,7 +290,7 @@ class Batch(object):
         The heatmaps to augment.
 
     segmentation_maps : None or list of \
-                        imgaug.augmentables.segmaps.SegmentationMapOnImage
+                        imgaug.augmentables.segmaps.SegmentationMapsOnImage
         The segmentation maps to augment.
 
     keypoints : None or list of imgaug.augmentables.kps.KeypointOnImage

--- a/imgaug/augmentables/batches.py
+++ b/imgaug/augmentables/batches.py
@@ -110,12 +110,14 @@ class UnnormalizedBatch(object):
         required for valid polygons).
         The following datatypes will be interpreted as a single polygon on a
         single image:
+
           * ``imgaug.augmentables.polys.Polygon``
           * ``iterable of tuple of number``
           * ``iterable of imgaug.augmentables.kps.Keypoint``
 
         The following datatypes will be interpreted as multiple polygons on a
         single image:
+
           * ``imgaug.augmentables.polys.PolygonsOnImage``
           * ``iterable of imgaug.augmentables.polys.Polygon``
           * ``iterable of iterable of tuple of number``
@@ -124,6 +126,7 @@ class UnnormalizedBatch(object):
 
         The following datatypes will be interpreted as multiple polygons on
         multiple images:
+
           * ``(N,#polys,#points,2) ndarray``
           * ``iterable of (#polys,#points,2) ndarray``
           * ``iterable of iterable of (#points,2) ndarray``

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -1290,7 +1290,7 @@ class LineString(object):
 
         This is similar to
         :func:`imgaug.augmentables.lines.LineString.draw_mask`.
-        The result is wrapped in a ``SegmentationMapOnImage`` object
+        The result is wrapped in a ``SegmentationMapsOnImage`` object
         instead of just an array.
 
         Parameters
@@ -1311,12 +1311,12 @@ class LineString(object):
 
         Returns
         -------
-        imgaug.augmentables.segmaps.SegmentationMapOnImage
+        imgaug.augmentables.segmaps.SegmentationMapsOnImage
             Segmentation map object containing drawn line string.
 
         """
-        from .segmaps import SegmentationMapOnImage
-        return SegmentationMapOnImage(
+        from .segmaps import SegmentationMapsOnImage
+        return SegmentationMapsOnImage(
             self.draw_mask(
                 image_shape, size_lines=size_lines, size_points=size_points,
                 raise_if_out_of_image=raise_if_out_of_image),

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -1,14 +1,14 @@
 from __future__ import print_function, division, absolute_import
 
-import warnings
-
 import numpy as np
 import six.moves as sm
 
 from .. import imgaug as ia
+from .. import dtypes as iadt
+from ..augmenters import blend as blendlib
 
 
-class SegmentationMapOnImage(object):
+class SegmentationMapsOnImage(object):
     """
     Object representing a segmentation map associated with an image.
 
@@ -19,35 +19,19 @@ class SegmentationMapOnImage(object):
 
     Parameters
     ----------
-    arr : (H,W) ndarray or (H,W,1) ndarray or (H,W,C) ndarray
-        Array representing the segmentation map. May have datatypes bool, integer or float.
+    arr : (H,W) ndarray or (H,W,C) ndarray
+        Array representing the segmentation map(s). May have dtypes bool,
+        int or uint.
 
-            * If bool: Assumed to be of shape (H,W), (H,W,1) or (H,W,C). If (H,W) or (H,W,1) it
-              is assumed to be for the case of having a single class (where any False denotes
-              background). Otherwise there are assumed to be C channels, one for each class,
-              with each of them containing a mask for that class. The masks may overlap.
-            * If integer: Assumed to be of shape (H,W) or (H,W,1). Each pixel is assumed to
-              contain an integer denoting the class index. Classes are assumed to be
-              non-overlapping. The number of classes cannot be guessed from this input, hence
-              nb_classes must be set.
-            * If float: Assumed to b eof shape (H,W), (H,W,1) or (H,W,C) with meanings being
-              similar to the case of `bool`. Values are expected to fall always in the range
-              0.0 to 1.0 and are usually expected to be either 0.0 or 1.0 upon instantiation
-              of a new segmentation map. Classes may overlap.
-
-    shape : iterable of int
-        Shape of the corresponding image (NOT the segmentation map array). This is expected
-        to be ``(H, W)`` or ``(H, W, C)`` with ``C`` usually being 3. If there is no corresponding image,
-        then use the segmentation map's shape instead.
-
-    nb_classes : int or None
-        Total number of unique classes that may appear in an segmentation map, i.e. the max
-        class index plus 1. This may be None if the input array is of type bool or float. The number
-        of classes however must be provided if the input array is of type int, as then the
-        number of classes cannot be guessed.
+    shape : tuple of int
+        Shape of the corresponding image (NOT of the segmentation map array).
+        This is expected to be ``(H, W)`` or ``(H, W, C)`` with ``C`` usually
+        being 3. If there is no corresponding image, then use the segmentation
+        map's shape instead.
 
     """
 
+    # TODO replace this by matplotlib colormap
     DEFAULT_SEGMENT_COLORS = [
         (0, 0, 0),  # black
         (230, 25, 75),  # red
@@ -94,107 +78,62 @@ class SegmentationMapOnImage(object):
         (64, 64, 64),  # dark grey
     ]
 
-    def __init__(self, arr, shape, nb_classes=None):
-        ia.do_assert(ia.is_np_array(arr), "Expected to get numpy array, got %s." % (type(arr),))
+    def __init__(self, arr, shape):
+        ia.do_assert(ia.is_np_array(arr),
+                     "Expected to get numpy array, got %s." % (type(arr),))
+        assert isinstance(shape, tuple)
 
         if arr.dtype.name == "bool":
             ia.do_assert(arr.ndim in [2, 3])
-            self.input_was = ("bool", arr.ndim)
+            self.input_was = (arr.dtype, arr.ndim)
             if arr.ndim == 2:
                 arr = arr[..., np.newaxis]
-            arr = arr.astype(np.float32)
         elif arr.dtype.kind in ["i", "u"]:
-            ia.do_assert(arr.ndim == 2 or (arr.ndim == 3 and arr.shape[2] == 1))
-            ia.do_assert(nb_classes is not None)
-            ia.do_assert(nb_classes > 0)
+            ia.do_assert(arr.ndim in [2, 3])
             ia.do_assert(np.min(arr.flat[0:100]) >= 0)
-            ia.do_assert(np.max(arr.flat[0:100]) < nb_classes)
-            self.input_was = ("int", arr.dtype.type, arr.ndim)
-            if arr.ndim == 3:
-                arr = arr[..., 0]
-            # TODO improve efficiency here by building only sub-heatmaps for classes actually
-            # present in the image. This would also get rid of nb_classes.
-            arr = np.eye(nb_classes)[arr]  # from class indices to one hot
-            arr = arr.astype(np.float32)
-        elif arr.dtype.kind == "f":
-            ia.do_assert(arr.ndim == 3)
-            self.input_was = ("float", arr.dtype.type, arr.ndim)
-            arr = arr.astype(np.float32)
+            if arr.dtype.kind == "u":
+                # allow only <=uint16 due to conversion to int32
+                assert arr.dtype.itemsize <= 2, (
+                    "When using uint arrays as segmentation maps, only uint8 "
+                    "and uint16 are allowed. Got dtype %s." % (arr.dtype.name,)
+                )
+
+            self.input_was = (arr.dtype, arr.ndim)
+            if arr.ndim == 2:
+                arr = arr[..., np.newaxis]
         else:
-            raise Exception(("Input was expected to be an ndarray any bool, int, uint or float dtype. "
-                             + "Got dtype %s.") % (arr.dtype.name,))
-        ia.do_assert(arr.ndim == 3)
-        ia.do_assert(arr.dtype.name == "float32")
+            raise Exception((
+                "Input was expected to be an array of dtype 'bool', 'int' "
+                "or 'uint'. Got dtype '%s'.") % (arr.dtype.name,))
+
+        if arr.dtype.name != "int32":
+            arr = arr.astype(np.int32)
+
         self.arr = arr
 
         # don't allow arrays here as an alternative to tuples as input
         # as allowing arrays introduces risk to mix up 'arr' and 'shape' args
         self.shape = shape
 
-        self.nb_classes = nb_classes if nb_classes is not None else arr.shape[2]
-
-    def get_arr_int(self, background_threshold=0.01, background_class_id=None):
+    def get_arr(self):
         """
-        Get the segmentation map array as an integer array of shape (H, W).
-
-        Each pixel in that array contains an integer value representing the pixel's class.
-        If multiple classes overlap, the one with the highest local float value is picked.
-        If that highest local value is below `background_threshold`, the method instead uses
-        the background class id as the pixel's class value.
-        By default, class id 0 is the background class. This may only be changed if the original
-        input to the segmentation map object was an integer map.
-
-        Parameters
-        ----------
-        background_threshold : float, optional
-            At each pixel, each class-heatmap has a value between 0.0 and 1.0. If none of the
-            class-heatmaps has a value above this threshold, the method uses the background class
-            id instead.
-
-        background_class_id : None or int, optional
-            Class id to fall back to if no class-heatmap passes the threshold at a spatial
-            location. May only be provided if the original input was an integer mask and in these
-            cases defaults to 0. If the input were float or boolean masks, the background class id
-            may not be set as it is assumed that the background is implicitly defined
-            as 'any spatial location that has zero-like values in all masks'.
+        Return the segmentation map array similar to its input dtype and shape.
 
         Returns
         -------
-        result : (H,W) ndarray
-            Segmentation map array (int32).
-            If the original input consisted of boolean or float masks, then the highest possible
-            class id is ``1+C``, where ``C`` is the number of provided float/boolean masks. The value
-            ``0`` in the integer mask then denotes the background class.
+        ndarray
+            Segmentation map array. Same dtype and number of dimensions as was
+            originally used when the instance was created.
 
         """
-        if self.input_was[0] in ["bool", "float"]:
-            ia.do_assert(background_class_id is None,
-                         "The background class id may only be changed if the original input to SegmentationMapOnImage "
-                         + "was an *integer* based segmentation map.")
+        input_dtype, input_ndim = self.input_was
+        arr_input = iadt.restore_dtypes_(np.copy(self.arr), input_dtype)
+        if input_ndim == 2:
+            assert arr_input.shape[2] == 1
+            return arr_input[:, :, 0]
+        return arr_input
 
-        if background_class_id is None:
-            background_class_id = 0
-
-        channelwise_max_idx = np.argmax(self.arr, axis=2)
-        # for bool and float input masks, we assume that the background is implicitly given,
-        # i.e. anything where all masks/channels have zero-like values
-        # for int, we assume that the background class is explicitly given and has the index 0
-        if self.input_was[0] in ["bool", "float"]:
-            result = 1 + channelwise_max_idx
-        else:  # integer mask was provided
-            result = channelwise_max_idx
-        if background_threshold is not None and background_threshold > 0:
-            probs = np.amax(self.arr, axis=2)
-            result[probs < background_threshold] = background_class_id
-
-        return result.astype(np.int32)
-
-    # TODO
-    # def get_arr_bool(self, allow_overlapping=False, threshold=0.5, background_threshold=0.01, background_class_id=0):
-    #    raise NotImplementedError()
-
-    def draw(self, size=None, background_threshold=0.01, background_class_id=None, colors=None,
-             return_foreground_mask=False):
+    def draw(self, size=None, colors=None):
         """
         Render the segmentation map as an RGB image.
 
@@ -205,62 +144,28 @@ class SegmentationMapOnImage(object):
             See :func:`imgaug.imgaug.imresize_single_image` for details.
             If set to None, no resizing is performed and the size of the segmentation map array is used.
 
-        background_threshold : float, optional
-            See :func:`imgaug.SegmentationMapOnImage.get_arr_int`.
-
-        background_class_id : None or int, optional
-            See :func:`imgaug.SegmentationMapOnImage.get_arr_int`.
-
         colors : None or list of tuple of int, optional
             Colors to use. One for each class to draw. If None, then default colors will be used.
 
-        return_foreground_mask : bool, optional
-            Whether to return a mask of the same size as the drawn segmentation map, containing
-            True at any spatial location that is not the background class and False everywhere else.
-
         Returns
         -------
-        segmap_drawn : (H,W,3) ndarray
-            Rendered segmentation map (dtype is uint8).
-
-        foreground_mask : (H,W) ndarray
-            Mask indicating the locations of foreground classes (dtype is bool).
-            This value is only returned if `return_foreground_mask` is True.
+        list of (H,W,3) ndarray
+            Rendered segmentation map (dtype is ``uint8``).
+            One per ``C`` in the original input array ``(H,W,C)``.
 
         """
-        arr = self.get_arr_int(background_threshold=background_threshold, background_class_id=background_class_id)
-        nb_classes = 1 + np.max(arr)
-        segmap_drawn = np.zeros((arr.shape[0], arr.shape[1], 3), dtype=np.uint8)
-        if colors is None:
-            colors = SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS
-        ia.do_assert(nb_classes <= len(colors),
-                     "Can't draw all %d classes as it would exceed the maximum number of %d available colors." % (
-                         nb_classes, len(colors),))
+        size = self.arr.shape[0:2] if size is None else size[0:2]
+        image = np.zeros((size[0], size[1], 3), dtype=np.uint8)
+        return self.draw_on_image(
+            image,
+            alpha=1.0,
+            resize="segmentation_map",
+            colors=colors,
+            draw_background=True
+        )
 
-        ids_in_map = np.unique(arr)
-        for c, color in zip(sm.xrange(nb_classes), colors):
-            if c in ids_in_map:
-                class_mask = (arr == c)
-                segmap_drawn[class_mask] = color
-
-        if return_foreground_mask:
-            background_class_id = 0 if background_class_id is None else background_class_id
-            foreground_mask = (arr != background_class_id)
-        else:
-            foreground_mask = None
-
-        if size is not None:
-            segmap_drawn = ia.imresize_single_image(segmap_drawn, size, interpolation="nearest")
-            if foreground_mask is not None:
-                foreground_mask = ia.imresize_single_image(
-                    foreground_mask.astype(np.uint8), size, interpolation="nearest") > 0
-
-        if foreground_mask is not None:
-            return segmap_drawn, foreground_mask
-        return segmap_drawn
-
-    def draw_on_image(self, image, alpha=0.75, resize="segmentation_map", background_threshold=0.01,
-                      background_class_id=None, colors=None, draw_background=False):
+    def draw_on_image(self, image, alpha=0.75, resize="segmentation_map",
+                      colors=None, draw_background=False):
         """
         Draw the segmentation map as an overlay over an image.
 
@@ -278,12 +183,6 @@ class SegmentationMapOnImage(object):
             the segmentation map can be resized. This parameter controls which of the two will be
             resized to the other's size.
 
-        background_threshold : float, optional
-            See :func:`imgaug.SegmentationMapOnImage.get_arr_int`.
-
-        background_class_id : None or int, optional
-            See :func:`imgaug.SegmentationMapOnImage.get_arr_int`.
-
         colors : None or list of tuple of int, optional
             Colors to use. One for each class to draw. If None, then default colors will be used.
 
@@ -295,45 +194,65 @@ class SegmentationMapOnImage(object):
 
         Returns
         -------
-        mix : (H,W,3) ndarray
-            Rendered overlays (dtype is uint8).
+        list of (H,W,3) ndarray
+            Rendered segmentation maps (``uint8``). One per channel of the
+            segmentation map array.
 
         """
-        # assert RGB image
         ia.do_assert(image.ndim == 3)
         ia.do_assert(image.shape[2] == 3)
-        ia.do_assert(image.dtype.type == np.uint8)
-
+        ia.do_assert(image.dtype.name == "uint8")
         ia.do_assert(0 - 1e-8 <= alpha <= 1.0 + 1e-8)
         ia.do_assert(resize in ["segmentation_map", "image"])
-
-        if resize == "image":
-            image = ia.imresize_single_image(image, self.arr.shape[0:2], interpolation="cubic")
-
-        segmap_drawn, foreground_mask = self.draw(
-            background_threshold=background_threshold,
-            background_class_id=background_class_id,
-            size=image.shape[0:2] if resize == "segmentation_map" else None,
-            colors=colors,
-            return_foreground_mask=True
+        colors = (
+            colors
+            if colors is not None
+            else SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS
         )
 
-        if draw_background:
-            mix = np.clip(
-                (1-alpha) * image + alpha * segmap_drawn,
-                0,
-                255
-            ).astype(np.uint8)
-        else:
-            foreground_mask = foreground_mask[..., np.newaxis]
-            mix = np.zeros_like(image)
-            mix += (~foreground_mask).astype(np.uint8) * image
-            mix += foreground_mask.astype(np.uint8) * np.clip(
-                (1-alpha) * image + alpha * segmap_drawn,
-                0,
-                255
-            ).astype(np.uint8)
-        return mix
+        if resize == "image":
+            image = ia.imresize_single_image(
+                image, self.arr.shape[0:2], interpolation="cubic")
+
+        segmaps_drawn = []
+        arr_channelwise = np.dsplit(self.arr, self.arr.shape[2])
+        for arr in arr_channelwise:
+            assert arr.shape[2] == 1
+            arr = arr[:, :, 0]
+
+            nb_classes = 1 + np.max(arr)
+            segmap_drawn = np.zeros((arr.shape[0], arr.shape[1], 3),
+                                    dtype=np.uint8)
+            ia.do_assert(
+                nb_classes <= len(colors),
+                "Can't draw all %d classes as it would exceed the maximum "
+                "number of %d available colors." % (nb_classes, len(colors),))
+
+            ids_in_map = np.unique(arr)
+            for c, color in zip(sm.xrange(nb_classes), colors):
+                if c in ids_in_map:
+                    class_mask = (arr == c)
+                    segmap_drawn[class_mask] = color
+
+            segmap_drawn = ia.imresize_single_image(
+                segmap_drawn, image.shape[0:2], interpolation="nearest")
+
+            segmap_on_image = blendlib.blend_alpha(segmap_drawn, image, alpha)
+
+            if draw_background:
+                mix = segmap_on_image
+            else:
+                foreground_mask = ia.imresize_single_image(
+                    (arr != 0), image.shape[0:2], interpolation="nearest")
+                # without this, the merge below does nothing
+                foreground_mask = np.atleast_3d(foreground_mask)
+
+                mix = (
+                    (~foreground_mask) * image
+                    + foreground_mask * segmap_on_image
+                )
+            segmaps_drawn.append(mix)
+        return segmaps_drawn
 
     def pad(self, top=0, right=0, bottom=0, left=0, mode="constant", cval=0.0):
         """
@@ -342,33 +261,38 @@ class SegmentationMapOnImage(object):
         Parameters
         ----------
         top : int, optional
-            Amount of pixels to add at the top side of the segmentation map. Must be 0 or greater.
+            Amount of pixels to add at the top side of the segmentation map.
+            Must be 0 or greater.
 
         right : int, optional
-            Amount of pixels to add at the right side of the segmentation map. Must be 0 or greater.
+            Amount of pixels to add at the right side of the segmentation map.
+            Must be 0 or greater.
 
         bottom : int, optional
-            Amount of pixels to add at the bottom side of the segmentation map. Must be 0 or greater.
+            Amount of pixels to add at the bottom side of the segmentation map.
+            Must be 0 or greater.
 
         left : int, optional
-            Amount of pixels to add at the left side of the segmentation map. Must be 0 or greater.
+            Amount of pixels to add at the left side of the segmentation map.
+            Must be 0 or greater.
 
         mode : str, optional
             Padding mode to use. See :func:`numpy.pad` for details.
 
         cval : number, optional
-            Value to use for padding if `mode` is ``constant``. See :func:`numpy.pad` for details.
+            Value to use for padding if `mode` is ``constant``.
+            See :func:`numpy.pad` for details.
 
         Returns
         -------
-        segmap : imgaug.SegmentationMapOnImage
-            Padded segmentation map of height ``H'=H+top+bottom`` and width ``W'=W+left+right``.
+        imgaug.SegmentationMapsOnImage
+            Padded segmentation map of height ``H'=H+top+bottom`` and
+            width ``W'=W+left+right``.
 
         """
-        arr_padded = ia.pad(self.arr, top=top, right=right, bottom=bottom, left=left, mode=mode, cval=cval)
-        segmap = SegmentationMapOnImage(arr_padded, shape=self.shape)
-        segmap.input_was = self.input_was
-        return segmap
+        arr_padded = ia.pad(self.arr, top=top, right=right, bottom=bottom,
+                            left=left, mode=mode, cval=cval)
+        return self.deepcopy(arr=arr_padded)
 
     def pad_to_aspect_ratio(self, aspect_ratio, mode="constant", cval=0.0, return_pad_amounts=False):
         """
@@ -398,10 +322,10 @@ class SegmentationMapOnImage(object):
 
         Returns
         -------
-        segmap : imgaug.SegmentationMapOnImage
-            Padded segmentation map as SegmentationMapOnImage object.
+        imgaug.SegmentationMapsOnImage
+            Padded segmentation map as SegmentationMapsOnImage object.
 
-        pad_amounts : tuple of int
+        tuple of int
             Amounts by which the segmentation map was padded on each side, given as a
             tuple ``(top, right, bottom, left)``.
             This tuple is only returned if `return_pad_amounts` was set to True.
@@ -409,19 +333,17 @@ class SegmentationMapOnImage(object):
         """
         arr_padded, pad_amounts = ia.pad_to_aspect_ratio(self.arr, aspect_ratio=aspect_ratio, mode=mode, cval=cval,
                                                          return_pad_amounts=True)
-        segmap = SegmentationMapOnImage(arr_padded, shape=self.shape)
-        segmap.input_was = self.input_was
+        segmap = self.deepcopy(arr=arr_padded)
         if return_pad_amounts:
             return segmap, pad_amounts
-        else:
-            return segmap
+        return segmap
 
-    @ia.deprecated(alt_func="SegmentationMapOnImage.resize()",
+    @ia.deprecated(alt_func="SegmentationMapsOnImage.resize()",
                    comment="resize() has the exactly same interface.")
     def scale(self, *args, **kwargs):
         return self.resize(*args, **kwargs)
 
-    def resize(self, sizes, interpolation="cubic"):
+    def resize(self, sizes, interpolation="nearest"):
         """
         Resize the segmentation map array to the provided size given the provided interpolation.
 
@@ -433,135 +355,77 @@ class SegmentationMapOnImage(object):
 
         interpolation : None or str or int, optional
             The interpolation to use during resize.
+            Nearest neighbour interpolation (``"nearest"``) is almost always
+            the best choice.
             See :func:`imgaug.imgaug.imresize_single_image` for details.
-            Note: The segmentation map is internally stored as multiple float-based heatmaps,
-            making smooth interpolations potentially more reasonable than nearest neighbour
-            interpolation.
 
         Returns
         -------
-        segmap : imgaug.SegmentationMapOnImage
+        imgaug.SegmentationMapsOnImage
             Resized segmentation map object.
 
         """
-        arr_resized = ia.imresize_single_image(self.arr, sizes, interpolation=interpolation)
+        arr_resized = ia.imresize_single_image(self.arr, sizes,
+                                               interpolation=interpolation)
+        return self.deepcopy(arr_resized)
 
-        # cubic interpolation can lead to values outside of [0.0, 1.0],
-        # see https://github.com/opencv/opencv/issues/7195
-        # TODO area interpolation too?
-        arr_resized = np.clip(arr_resized, 0.0, 1.0)
-        segmap = SegmentationMapOnImage(arr_resized, shape=self.shape)
-        segmap.input_was = self.input_was
-        return segmap
-
-    def to_heatmaps(self, only_nonempty=False, not_none_if_no_nonempty=False):
-        """
-        Convert segmentation map to heatmaps object.
-
-        Each segmentation map class will be represented as a single heatmap channel.
-
-        Parameters
-        ----------
-        only_nonempty : bool, optional
-            If True, then only heatmaps for classes that appear in the segmentation map will be
-            generated. Additionally, a list of these class ids will be returned.
-
-        not_none_if_no_nonempty : bool, optional
-            If `only_nonempty` is True and for a segmentation map no channel was non-empty,
-            this function usually returns None as the heatmaps object. If however this parameter
-            is set to True, a heatmaps object with one channel (representing class 0)
-            will be returned as a fallback in these cases.
-
-        Returns
-        -------
-        imgaug.HeatmapsOnImage or None
-            Segmentation map as a heatmaps object.
-            If `only_nonempty` was set to True and no class appeared in the segmentation map,
-            then this is None.
-
-        class_indices : list of int
-            Class ids (0 to C-1) of the classes that were actually added to the heatmaps.
-            Only returned if `only_nonempty` was set to True.
-
-        """
-        # TODO get rid of this deferred import
-        from imgaug.augmentables.heatmaps import HeatmapsOnImage
-
-        if not only_nonempty:
-            return HeatmapsOnImage.from_0to1(self.arr, self.shape, min_value=0.0, max_value=1.0)
-        else:
-            nonempty_mask = np.sum(self.arr, axis=(0, 1)) > 0 + 1e-4
-            if np.sum(nonempty_mask) == 0:
-                if not_none_if_no_nonempty:
-                    nonempty_mask[0] = True
-                else:
-                    return None, []
-
-            class_indices = np.arange(self.arr.shape[2])[nonempty_mask]
-            channels = self.arr[..., class_indices]
-            return HeatmapsOnImage(channels, self.shape, min_value=0.0, max_value=1.0), class_indices
-
-    @staticmethod
-    def from_heatmaps(heatmaps, class_indices=None, nb_classes=None):
-        """
-        Convert heatmaps to segmentation map.
-
-        Assumes that each class is represented as a single heatmap channel.
-
-        Parameters
-        ----------
-        heatmaps : imgaug.HeatmapsOnImage
-            Heatmaps to convert.
-
-        class_indices : None or list of int, optional
-            List of class indices represented by each heatmap channel. See also the
-            secondary output of :func:`imgaug.SegmentationMapOnImage.to_heatmap`.
-            If this is provided, it must have the same length as the number of heatmap channels.
-
-        nb_classes : None or int, optional
-            Number of classes. Must be provided if class_indices is set.
-
-        Returns
-        -------
-        imgaug.SegmentationMapOnImage
-            Segmentation map derived from heatmaps.
-
-        """
-        if class_indices is None:
-            return SegmentationMapOnImage(heatmaps.arr_0to1, shape=heatmaps.shape)
-        else:
-            ia.do_assert(nb_classes is not None)
-            ia.do_assert(min(class_indices) >= 0)
-            ia.do_assert(max(class_indices) < nb_classes)
-            ia.do_assert(len(class_indices) == heatmaps.arr_0to1.shape[2])
-            arr_0to1 = heatmaps.arr_0to1
-            arr_0to1_full = np.zeros((arr_0to1.shape[0], arr_0to1.shape[1], nb_classes), dtype=np.float32)
-            for heatmap_channel, mapped_channel in enumerate(class_indices):
-                arr_0to1_full[:, :, mapped_channel] = arr_0to1[:, :, heatmap_channel]
-            return SegmentationMapOnImage(arr_0to1_full, shape=heatmaps.shape)
-
-    def copy(self):
+    # TODO how best to handle changes to input_was due to changed 'arr'?
+    def copy(self, arr=None, shape=None):
         """
         Create a shallow copy of the segmentation map object.
 
+        Parameters
+        ----------
+        arr : None or (H,W) ndarray or (H,W,C) ndarray, optional
+            Optionally the `arr` attribute to use for the new segmentation map
+            instance. Will be copied from the old instance if not provided.
+            See :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            for details.
+
+        shape : None or tuple of int, optional
+            Optionally the shape attribute to use for the the new segmentation
+            map instance. Will be copied from the old instance if not provided.
+            See :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            for details.
+
         Returns
         -------
-        imgaug.SegmentationMapOnImage
+        imgaug.SegmentationMapsOnImage
             Shallow copy.
 
         """
-        return self.deepcopy()
+        segmap = SegmentationMapsOnImage(
+            self.arr if arr is None else arr,
+            shape=self.shape if shape is None else shape)
+        segmap.input_was = self.input_was
+        return segmap
 
-    def deepcopy(self):
+    def deepcopy(self, arr=None, shape=None):
         """
         Create a deep copy of the segmentation map object.
 
+        Parameters
+        ----------
+        arr : None or (H,W) ndarray or (H,W,C) ndarray, optional
+            Optionally the `arr` attribute to use for the new segmentation map
+            instance. Will be copied from the old instance if not provided.
+            See :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            for details.
+
+        shape : None or tuple of int, optional
+            Optionally the shape attribute to use for the the new segmentation
+            map instance. Will be copied from the old instance if not provided.
+            See :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            for details.
+
         Returns
         -------
-        imgaug.SegmentationMapOnImage
+        imgaug.SegmentationMapsOnImage
             Deep copy.
 
         """
-        segmap = SegmentationMapOnImage(self.arr, shape=self.shape, nb_classes=self.nb_classes)
+        segmap = SegmentationMapsOnImage(
+            np.copy(self.arr if arr is None else arr),
+            shape=self.shape if shape is None else shape)
         segmap.input_was = self.input_was
         return segmap

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -8,6 +8,12 @@ from .. import dtypes as iadt
 from ..augmenters import blend as blendlib
 
 
+@ia.deprecated(alt_func="SegmentationMapsOnImage",
+               comment="(Note the plural 'Maps' instead of old 'Map'.)")
+def SegmentationMapOnImage(*args, **kwargs):
+    return SegmentationMapsOnImage(*args, **kwargs)
+
+
 class SegmentationMapsOnImage(object):
     """
     Object representing a segmentation map associated with an image.
@@ -28,6 +34,9 @@ class SegmentationMapsOnImage(object):
         This is expected to be ``(H, W)`` or ``(H, W, C)`` with ``C`` usually
         being 3. If there is no corresponding image, then use the segmentation
         map's shape instead.
+
+    nb_classes : None or int, optional
+        Deprecated.
 
     """
 
@@ -78,7 +87,7 @@ class SegmentationMapsOnImage(object):
         (64, 64, 64),  # dark grey
     ]
 
-    def __init__(self, arr, shape):
+    def __init__(self, arr, shape, nb_classes=None):
         ia.do_assert(ia.is_np_array(arr),
                      "Expected to get numpy array, got %s." % (type(arr),))
         assert isinstance(shape, tuple)
@@ -115,6 +124,12 @@ class SegmentationMapsOnImage(object):
         # as allowing arrays introduces risk to mix up 'arr' and 'shape' args
         self.shape = shape
 
+        if nb_classes is not None:
+            ia.warn_deprecated(
+                "Providing nb_classes to SegmentationMapOnImage is no longer "
+                "necessary and hence deprecated. The argument is ignored "
+                "and can be safely removed.")
+
     def get_arr(self):
         """
         Return the segmentation map array similar to its input dtype and shape.
@@ -132,6 +147,10 @@ class SegmentationMapsOnImage(object):
             assert arr_input.shape[2] == 1
             return arr_input[:, :, 0]
         return arr_input
+
+    @ia.deprecated(alt_func="SegmentationMapsOnImage.get_arr()")
+    def get_arr_int(self, *args, **kwargs):
+        return self.get_arr()
 
     def draw(self, size=None, colors=None):
         """

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -94,7 +94,7 @@ class SegmentationMapsOnImage(object):
 
         if arr.dtype.name == "bool":
             ia.do_assert(arr.ndim in [2, 3])
-            self.input_was = (arr.dtype, arr.ndim)
+            self._input_was = (arr.dtype, arr.ndim)
             if arr.ndim == 2:
                 arr = arr[..., np.newaxis]
         elif arr.dtype.kind in ["i", "u"]:
@@ -107,7 +107,7 @@ class SegmentationMapsOnImage(object):
                     "and uint16 are allowed. Got dtype %s." % (arr.dtype.name,)
                 )
 
-            self.input_was = (arr.dtype, arr.ndim)
+            self._input_was = (arr.dtype, arr.ndim)
             if arr.ndim == 2:
                 arr = arr[..., np.newaxis]
         else:
@@ -141,7 +141,7 @@ class SegmentationMapsOnImage(object):
             originally used when the instance was created.
 
         """
-        input_dtype, input_ndim = self.input_was
+        input_dtype, input_ndim = self._input_was
         arr_input = iadt.restore_dtypes_(np.copy(self.arr), input_dtype)
         if input_ndim == 2:
             assert arr_input.shape[2] == 1
@@ -388,7 +388,7 @@ class SegmentationMapsOnImage(object):
                                                interpolation=interpolation)
         return self.deepcopy(arr_resized)
 
-    # TODO how best to handle changes to input_was due to changed 'arr'?
+    # TODO how best to handle changes to _input_was due to changed 'arr'?
     def copy(self, arr=None, shape=None):
         """
         Create a shallow copy of the segmentation map object.
@@ -416,7 +416,7 @@ class SegmentationMapsOnImage(object):
         segmap = SegmentationMapsOnImage(
             self.arr if arr is None else arr,
             shape=self.shape if shape is None else shape)
-        segmap.input_was = self.input_was
+        segmap._input_was = self._input_was
         return segmap
 
     def deepcopy(self, arr=None, shape=None):
@@ -446,5 +446,5 @@ class SegmentationMapsOnImage(object):
         segmap = SegmentationMapsOnImage(
             np.copy(self.arr if arr is None else arr),
             shape=self.shape if shape is None else shape)
-        segmap.input_was = self.input_was
+        segmap._input_was = self._input_was
         return segmap

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -196,8 +196,26 @@ class SegmentationMapsOnImage(object):
             One per ``C`` in the original input array ``(H,W,C)``.
 
         """
-        size = self.arr.shape[0:2] if size is None else size[0:2]
-        image = np.zeros((size[0], size[1], 3), dtype=np.uint8)
+        def _handle_sizeval(sizeval, arr_axis_size):
+            if sizeval is None:
+                return arr_axis_size
+            elif ia.is_single_float(sizeval):
+                return max(int(arr_axis_size * sizeval), 1)
+            elif ia.is_single_integer(sizeval):
+                return sizeval
+            else:
+                raise ValueError("Expected float or int, got %s." % (
+                    type(sizeval),))
+
+        if size is None:
+            size = [size, size]
+        elif not ia.is_iterable(size):
+            size = [size, size]
+
+        height = _handle_sizeval(size[0], self.arr.shape[0])
+        width = _handle_sizeval(size[1], self.arr.shape[1])
+        image = np.zeros((height, width, 3), dtype=np.uint8)
+
         return self.draw_on_image(
             image,
             alpha=1.0,

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -120,6 +120,13 @@ class SegmentationMapsOnImage(object):
                     "When using uint arrays as segmentation maps, only uint8 "
                     "and uint16 are allowed. Got dtype %s." % (arr.dtype.name,)
                 )
+            elif arr.dtype.kind == "i":
+                # allow only <=uint16 due to conversion to int32
+                assert arr.dtype.itemsize <= 4, (
+                    "When using int arrays as segmentation maps, only int8, "
+                    "int16 and int32 are allowed. Got dtype %s." % (
+                        arr.dtype.name,)
+                )
 
             self._input_was = (arr.dtype, arr.ndim)
             if arr.ndim == 2:

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -198,7 +198,8 @@ class SegmentationMapsOnImage(object):
         )
 
     def draw_on_image(self, image, alpha=0.75, resize="segmentation_map",
-                      colors=None, draw_background=False):
+                      colors=None, draw_background=False,
+                      background_class_id=None, background_threshold=None):
         """
         Draw the segmentation map as an overlay over an image.
 
@@ -225,6 +226,16 @@ class SegmentationMapsOnImage(object):
             will be identical with the image's RGB color at the corresponding spatial location
             and no color overlay will be applied.
 
+        background_threshold : None, optional
+            Deprecated.
+            This value is ignored. Setting it will produce a deprecation
+            warning.
+
+        background_class_id : None, optional
+            Deprecated.
+            This value is ignored. Setting it will produce a deprecation
+            warning.
+
         Returns
         -------
         list of (H,W,3) ndarray
@@ -232,6 +243,16 @@ class SegmentationMapsOnImage(object):
             segmentation map array.
 
         """
+        if background_threshold is not None:
+            ia.warn_deprecated(
+                "The argument `background_threshold` is deprecated and "
+                "ignored. Please don't use it anymore.")
+
+        if background_class_id is not None:
+            ia.warn_deprecated(
+                "The argument `background_class_id` is deprecated and "
+                "ignored. Please don't use it anymore.")
+
         ia.do_assert(image.ndim == 3)
         ia.do_assert(image.shape[2] == 3)
         ia.do_assert(image.dtype.name == "uint8")

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -156,7 +156,9 @@ class SegmentationMapsOnImage(object):
 
         """
         input_dtype, input_ndim = self._input_was
-        arr_input = iadt.restore_dtypes_(np.copy(self.arr), input_dtype)
+        # The internally used int32 has a wider value range than any other
+        # input dtype, hence we can simply convert via astype() here.
+        arr_input = self.arr.astype(input_dtype)
         if input_ndim == 2:
             assert arr_input.shape[2] == 1
             return arr_input[:, :, 0]

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -346,7 +346,7 @@ class SegmentationMapsOnImage(object):
                             left=left, mode=mode, cval=cval)
         return self.deepcopy(arr=arr_padded)
 
-    def pad_to_aspect_ratio(self, aspect_ratio, mode="constant", cval=0.0, return_pad_amounts=False):
+    def pad_to_aspect_ratio(self, aspect_ratio, mode="constant", cval=0, return_pad_amounts=False):
         """
         Pad the segmentation map on its sides so that its matches a target aspect ratio.
 

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -201,7 +201,7 @@ class SegmentationMapsOnImage(object):
 
     def draw_on_image(self, image, alpha=0.75, resize="segmentation_map",
                       colors=None, draw_background=False,
-                      background_class_id=None, background_threshold=None):
+                      background_class_id=0, background_threshold=None):
         """
         Draw the segmentation map as an overlay over an image.
 
@@ -228,12 +228,11 @@ class SegmentationMapsOnImage(object):
             will be identical with the image's RGB color at the corresponding spatial location
             and no color overlay will be applied.
 
-        background_threshold : None, optional
-            Deprecated.
-            This value is ignored. Setting it will produce a deprecation
-            warning.
+        background_class_id : int, optional
+            Class id to interpret as the background class. See
+            `draw_background`.
 
-        background_class_id : None, optional
+        background_threshold : None, optional
             Deprecated.
             This value is ignored. Setting it will produce a deprecation
             warning.
@@ -248,11 +247,6 @@ class SegmentationMapsOnImage(object):
         if background_threshold is not None:
             ia.warn_deprecated(
                 "The argument `background_threshold` is deprecated and "
-                "ignored. Please don't use it anymore.")
-
-        if background_class_id is not None:
-            ia.warn_deprecated(
-                "The argument `background_class_id` is deprecated and "
                 "ignored. Please don't use it anymore.")
 
         ia.do_assert(image.ndim == 3)
@@ -299,7 +293,9 @@ class SegmentationMapsOnImage(object):
                 mix = segmap_on_image
             else:
                 foreground_mask = ia.imresize_single_image(
-                    (arr != 0), image.shape[0:2], interpolation="nearest")
+                    (arr != background_class_id),
+                    image.shape[0:2],
+                    interpolation="nearest")
                 # without this, the merge below does nothing
                 foreground_mask = np.atleast_3d(foreground_mask)
 

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -92,6 +92,20 @@ class SegmentationMapsOnImage(object):
                      "Expected to get numpy array, got %s." % (type(arr),))
         assert isinstance(shape, tuple)
 
+        if arr.dtype.kind == "f":
+            ia.warn_deprecated(
+                "Got a float array as the segmentation map in "
+                "SegmentationMapsOnImage. That is deprecated. Please provide "
+                "instead a (H,W,[C]) array of dtype bool_, int or uint, where "
+                "C denotes the segmentation map index."
+            )
+
+            if arr.ndim == 2:
+                arr = (arr > 0.5)
+            else:
+                assert arr.ndim == 3
+                arr = np.argmax(arr, axis=2).astype(np.int32)
+
         if arr.dtype.name == "bool":
             ia.do_assert(arr.ndim in [2, 3])
             self._input_was = (arr.dtype, arr.ndim)

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -140,7 +140,7 @@ class SegmentationMapsOnImage(object):
 
         if nb_classes is not None:
             ia.warn_deprecated(
-                "Providing nb_classes to SegmentationMapOnImage is no longer "
+                "Providing nb_classes to SegmentationMapsOnImage is no longer "
                 "necessary and hence deprecated. The argument is ignored "
                 "and can be safely removed.")
 

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -4,7 +4,6 @@ import numpy as np
 import six.moves as sm
 
 from .. import imgaug as ia
-from .. import dtypes as iadt
 from ..augmenters import blend as blendlib
 
 

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -306,7 +306,7 @@ class SegmentationMapsOnImage(object):
             segmaps_drawn.append(mix)
         return segmaps_drawn
 
-    def pad(self, top=0, right=0, bottom=0, left=0, mode="constant", cval=0.0):
+    def pad(self, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
         """
         Pad the segmentation map on its top/right/bottom/left side.
 

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -673,10 +673,12 @@ class BilateralBlur(meta.Augmenter):  # pylint: disable=locally-disabled, unused
 
     Examples
     --------
-    >>> aug = iaa.BilateralBlur(d=(3, 10), sigma_color=(10, 250), sigma_space=(10, 250))
+    >>> aug = iaa.BilateralBlur(
+    >>>     d=(3, 10), sigma_color=(10, 250), sigma_space=(10, 250))
 
-    blurs all images using a bilateral filter with max distance 3 to 10
-    and wide ranges for sigma_color and sigma_space.
+    Blur all images using a bilateral filter with a `max distance` sampled
+    uniformly from the interval ``[3, 10]`` and wide ranges for `sigma_color`
+    and `sigma_space`.
 
     """
 
@@ -721,7 +723,7 @@ class BilateralBlur(meta.Augmenter):  # pylint: disable=locally-disabled, unused
 # TODO add k sizing via float/percentage
 def MotionBlur(k=5, angle=(0, 360), direction=(-1.0, 1.0), order=1, name=None, deterministic=False, random_state=None):
     """
-    Augmenter that sharpens images and overlays the result with the original image.
+    Blur images in a way that fakes camera or object movements.
 
     dtype support::
 
@@ -782,12 +784,12 @@ def MotionBlur(k=5, angle=(0, 360), direction=(-1.0, 1.0), order=1, name=None, d
     --------
     >>> aug = iaa.MotionBlur(k=15)
 
-    Create a motion blur augmenter with kernel size of 15x15.
+    Apply motion blur with a kernel size of ``15x15`` pixels to images.
 
     >>> aug = iaa.MotionBlur(k=15, angle=[-45, 45])
 
-    Create a motion blur augmenter with kernel size of 15x15 and a blur angle of either -45 or 45 degrees (randomly
-    picked per image).
+    Apply motion blur with a kernel size of ``15x15`` pixels and a blur angle
+    of either ``-45`` or ``45`` degrees (randomly picked per image).
 
     """
     # TODO allow (1, None) and set to identity matrix if k == 1

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -150,6 +150,16 @@ class WithColorspace(meta.Augmenter):
             )
         return result
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        result = segmaps
+        if hooks is None or hooks.is_propagating(segmaps, augmenter=self, parents=parents, default=True):
+            result = self.children.augment_segmentation_maps(
+                result,
+                parents=parents + [self],
+                hooks=hooks,
+            )
+        return result
+
     def _augment_keypoints(self, keypoints_on_images, random_state, parents,
                            hooks):
         result = keypoints_on_images
@@ -1084,6 +1094,7 @@ class AddToHueAndSaturation(meta.Augmenter):
 
     @classmethod
     def _generate_lut_table(cls):
+        # FIXME is int8 here correct? shouldn't these be uint8?
         table = (np.zeros((256*2, 256), dtype=np.int8),
                  np.zeros((256*2, 256), dtype=np.int8))
         value_range = np.arange(0, 256, dtype=np.int16)

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -103,11 +103,18 @@ class WithColorspace(meta.Augmenter):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.WithColorspace(to_colorspace="HSV", from_colorspace="RGB",
-    >>>                          children=iaa.WithChannels(0, iaa.Add(10)))
+    >>> aug = iaa.WithColorspace(
+    >>>     to_colorspace="HSV",
+    >>>     from_colorspace="RGB",
+    >>>     children=iaa.WithChannels(
+    >>>         0,
+    >>>         iaa.Add((0, 50))
+    >>>     )
+    >>> )
 
-    This augmenter will add 10 to Hue value in HSV colorspace,
-    then change the colorspace back to the original (RGB).
+    Convert to ``HSV`` colorspace, add a value between ``0`` and ``50``
+    (uniformly sampled per image) to the Hue channel, then convert back to the
+    input colorspace (``RGB``).
 
     """
 
@@ -252,13 +259,15 @@ class WithHueAndSaturation(meta.Augmenter):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.WithHueAndSaturation(iaa.WithChannels(0, iaa.Add(10)))
+    >>> aug = iaa.WithHueAndSaturation(
+    >>>     iaa.WithChannels(0, iaa.Add((0, 50)))
+    >>> )
 
-    This creates an augmenter that will add 10 to the hue value in HSV
-    colorspace. It automatically accounts for the hue being in angular
-    representation, i.e. if the angle goes beyond 360deg, it will start again
-    at 0deg. The colorspace is finally converted back to RGB (the default
-    setting).
+    Create an augmenter that will add a random value between ``0`` and ``50``
+    (uniformly sampled per image) hue channel in HSV colorspace. It
+    automatically accounts for the hue being in angular representation, i.e.
+    if the angle goes beyond 360 degrees, it will start again at 0 degrees.
+    The colorspace is finally converted back to ``RGB`` (default setting).
 
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.WithHueAndSaturation([
@@ -269,11 +278,11 @@ class WithHueAndSaturation(meta.Augmenter):
     >>>     ])
     >>> ])
 
-    Creates an augmenter that adds a random value sampled from uniformly
+    Create an augmenter that adds a random value sampled uniformly
     from the range ``[-30, 10]`` to the hue and multiplies the saturation
     by a random factor sampled uniformly from ``[0.5, 1.5]``. It also
     modifies the contrast of the saturation channel. After these steps,
-    the HSV image is converted back to RGB.
+    the ``HSV`` image is converted back to ``RGB``.
 
     """
 
@@ -409,15 +418,13 @@ def MultiplyHueAndSaturation(mul=None, mul_hue=None, mul_saturation=None,
                              name=None, deterministic=False,
                              random_state=None):
     """
-    Augmenter that multiplies hue and saturation by random values.
+    Multipy hue and saturation by random values.
 
     The augmenter first transforms images to HSV colorspace, then multiplies
     the pixel values in the H and S channels and afterwards converts back to
     RGB.
 
     This augmenter is a wrapper around ``WithHueAndSaturation``.
-    The performance is expected to be worse than the one
-    of ``AddToHueAndSaturation``.
 
     dtype support::
 
@@ -481,8 +488,8 @@ def MultiplyHueAndSaturation(mul=None, mul_hue=None, mul_saturation=None,
         If this value is a float ``p``, then for ``p`` percent of all images
         `per_channel` will be treated as ``True``, otherwise as ``False``.
 
-        This parameter has no effect is `mul_hue` and/or `mul_saturation`
-        are used instead of `value`.
+        This parameter has no effect if `mul_hue` and/or `mul_saturation`
+        are used instead of `mul`.
 
     from_colorspace : str, optional
         See :func:`imgaug.augmenters.color.ChangeColorspace.__init__`.
@@ -501,10 +508,20 @@ def MultiplyHueAndSaturation(mul=None, mul_hue=None, mul_saturation=None,
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.MultiplyHueAndSaturation((0.5, 1.5), per_channel=True)
 
-    Multiplies the hue and saturation with random values between 0.5 and 1.5
+    Multiply hue and saturation by random values between ``0.5`` and ``1.5``
     (independently per channel and the same value for all pixels within
     that channel). The hue will be automatically projected to an angular
     representation.
+
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.MultiplyHueAndSaturation(mul_hue=(0.5, 1.5))
+
+    Multiply only the hue by random values between ``0.5`` and ``1.5``.
+
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.MultiplyHueAndSaturation(mul_saturation=(0.5, 1.5))
+
+    Multiply only the saturation by random values between ``0.5`` and ``1.5``.
 
     """
     if mul is not None:
@@ -599,7 +616,7 @@ def MultiplyHueAndSaturation(mul=None, mul_hue=None, mul_saturation=None,
 def MultiplyHue(mul=(-1.0, 1.0), from_colorspace="RGB", name=None,
                 deterministic=False, random_state=None):
     """
-    Augmenter that multiplies the hue of images by random values.
+    Multiply the hue of images by random values.
 
     The augmenter first transforms images to HSV colorspace, then multiplies
     the pixel values in the H channel and afterwards converts back to
@@ -646,8 +663,8 @@ def MultiplyHue(mul=(-1.0, 1.0), from_colorspace="RGB", name=None,
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.MultiplyHue((0.5, 1.5))
 
-    Multiplies the hue with random values between 0.5 and 1.5.
-    The hue will be automatically projected to an angular representation.
+    Multiply the hue channel of images using random values between ``0.5``
+    and ``1.5``.
 
     """
     if name is None:
@@ -662,7 +679,7 @@ def MultiplyHue(mul=(-1.0, 1.0), from_colorspace="RGB", name=None,
 def MultiplySaturation(mul=(0.0, 3.0), from_colorspace="RGB", name=None,
                        deterministic=False, random_state=None):
     """
-    Augmenter that multiplies the saturation of images by random values.
+    Multiply the saturation of images by random values.
 
     The augmenter first transforms images to HSV colorspace, then multiplies
     the pixel values in the H channel and afterwards converts back to
@@ -706,7 +723,8 @@ def MultiplySaturation(mul=(0.0, 3.0), from_colorspace="RGB", name=None,
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.MultiplySaturation((0.5, 1.5))
 
-    Multiplies the saturation with random values between 0.5 and 1.5.
+    Multiply the saturation channel of images using random values between
+    ``0.5`` and ``1.5``.
 
     """
     if name is None:
@@ -776,7 +794,7 @@ def AddToHueAndSaturation(value=0, per_channel=False, from_colorspace="RGB",
 
 class AddToHueAndSaturation(meta.Augmenter):
     """
-    Augmenter that increases/decreases hue and saturation by random values.
+    Increases or decreases hue and saturation by random values.
 
     The augmenter first transforms images to HSV colorspace, then adds random
     values to the H and S channels and afterwards converts back to RGB.
@@ -876,12 +894,11 @@ class AddToHueAndSaturation(meta.Augmenter):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.AddToHueAndSaturation((-20, 20), per_channel=True)
+    >>> aug = iaa.AddToHueAndSaturation((-50, 50), per_channel=True)
 
-    Adds random values between -20 and 20 to the hue and saturation
+    Add random values between ``-50`` and ``50`` to the hue and saturation
     (independently per channel and the same value for all pixels within
-    that channel). The hue will be automatically projected to an angular
-    representation.
+    that channel).
 
     """
 
@@ -1157,11 +1174,11 @@ def AddToHue(value=(-255, 255), from_colorspace="RGB", name=None,
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.AddToHue((-20, 20))
+    >>> aug = iaa.AddToHue((-50, 50))
 
-    Samples random values from the discrete uniform range ``[-20..20]``,
-    converts them to angular representation and adds them to the hue, i.e.
-    to the H channel in HSV colorspace.
+    Sample random values from the discrete uniform range ``[-50..50]``,
+    convert them to angular representation and add them to the hue, i.e.
+    to the ``H`` channel in ``HSV`` colorspace.
 
     """
     if name is None:
@@ -1223,10 +1240,11 @@ def AddToSaturation(value=(-75, 75), from_colorspace="RGB", name=None,
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.AddToSaturation((-20, 20))
+    >>> aug = iaa.AddToSaturation((-50, 50))
 
-    Samples random values from the discrete uniform range ``[-20..20]``,
-    and adds them to the saturation, i.e. to the S channel in HSV colorspace.
+    Sample random values from the discrete uniform range ``[-50..50]``,
+    and add them to the saturation, i.e. to the ``S`` channel in ``HSV``
+    colorspace.
 
     """
     if name is None:
@@ -1734,12 +1752,21 @@ class _AbstractColorQuantization(meta.Augmenter):
 
 class KMeansColorQuantization(_AbstractColorQuantization):
     """
-    Augmenter to quantize colors using k-Means clustering.
+    Quantize colors using k-Means clustering.
 
-    **Note**: This augmenter expects input images to be either grayscale
-    or to have 3 or 4 channels and use colorspace `from_colorspace`. If images
-    have 4 channels, it is assumed that the 4th channel is an alpha channel
-    and it will not be quantized.
+    This "collects" the colors from the input image, groups them into
+    ``k`` clusters using k-Means clustering and replaces the colors in the
+    input image using the cluster centroids.
+
+    This is slower than ``UniformColorQuantization``, but adapts dynamically
+    to the color range in the input image.
+
+    .. note::
+
+        This augmenter expects input images to be either grayscale
+        or to have 3 or 4 channels and use colorspace `from_colorspace`. If
+        images have 4 channels, it is assumed that the 4th channel is an alpha
+        channel and it will not be quantized.
 
     dtype support::
 
@@ -1817,32 +1844,32 @@ class KMeansColorQuantization(_AbstractColorQuantization):
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.KMeansColorQuantization()
 
-    Creates an augmenter to apply k-Means color quantization to images using a
+    Create an augmenter to apply k-Means color quantization to images using a
     random amount of colors, sampled uniformly from the interval ``[2..16]``.
     It assumes the input image colorspace to be ``RGB`` and clusters colors
     randomly in ``RGB`` or ``Lab`` colorspace.
 
     >>> aug = iaa.KMeansColorQuantization(n_colors=8)
 
-    Creates an augmenter that quantizes images to (up to) eight colors.
+    Create an augmenter that quantizes images to (up to) eight colors.
 
-    >>> aug = iaa.KMeansColorQuantization(n_colors=(4, 32))
+    >>> aug = iaa.KMeansColorQuantization(n_colors=(4, 16))
 
-    Creates an augmenter that quantizes images to (up to) ``n`` colors,
+    Create an augmenter that quantizes images to (up to) ``n`` colors,
     where ``n`` is randomly and uniformly sampled from the discrete interval
-    ``[4, 32]``.
+    ``[4..16]``.
 
     >>> aug = iaa.KMeansColorQuantization(
     >>>     from_colorspace=iaa.ChangeColorspace.BGR)
 
-    Creates an augmenter that quantizes input images that are in
+    Create an augmenter that quantizes input images that are in
     ``BGR`` colorspace. The quantization happens in ``RGB`` or ``Lab``
-    colorspace into which the images are temporarily converted.
+    colorspace, into which the images are temporarily converted.
 
     >>> aug = iaa.KMeansColorQuantization(
     >>>     to_colorspace=[iaa.ChangeColorspace.RGB, iaa.ChangeColorspace.HSV])
 
-    Creates an augmenter that quantizes images by clustering colors randomly
+    Create an augmenter that quantizes images by clustering colors randomly
     in either ``RGB`` or ``HSV`` colorspace. The assumed input colorspace
     of images is ``RGB``.
 
@@ -1952,6 +1979,7 @@ def quantize_colors_kmeans(image, n_colors, n_max_iter=10, eps=1.0):
     # is non-deterministic (tested). In C++ the function has an rgn argument,
     # but not in python. In python there also seems to be no way to read out
     # cv2's RNG state, so we can't set it back after executing this function.
+    # TODO this is quite hacky
     cv2.setRNGSeed(1)
     _compactness, labels, centers = cv2.kmeans(
         colors, n_colors, None, criteria, attempts, cv2.KMEANS_RANDOM_CENTERS)
@@ -1967,16 +1995,23 @@ def quantize_colors_kmeans(image, n_colors, n_max_iter=10, eps=1.0):
 
 
 class UniformColorQuantization(_AbstractColorQuantization):
-    """Augmenter to quantize colors into N bins with regular distance.
+    """Quantize colors into N bins with regular distance.
 
     For ``uint8`` images the equation is ``floor(v/q)*q + q/2`` with
     ``q = 256/N``, where ``v`` is a pixel intensity value and ``N`` is
     the target number of colors after quantization.
 
-    **Note**: This augmenter expects input images to be either grayscale
-    or to have 3 or 4 channels and use colorspace `from_colorspace`. If images
-    have 4 channels, it is assumed that the 4th channel is an alpha channel
-    and it will not be quantized.
+    This augmenter is faster than ``KMeansColorQuantization``, but the
+    set of possible output colors is constant (i.e. independent of the
+    input images). It may produce unsatisfying outputs for input images
+    that are made up of very similar colors.
+
+    .. note::
+
+        This augmenter expects input images to be either grayscale
+        or to have 3 or 4 channels and use colorspace `from_colorspace`. If
+        images have 4 channels, it is assumed that the 4th channel is an alpha
+        channel and it will not be quantized.
 
     dtype support::
 
@@ -2052,24 +2087,25 @@ class UniformColorQuantization(_AbstractColorQuantization):
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.UniformColorQuantization()
 
-    Creates an augmenter to apply uniform color quantization to images using a
-    random amount of colors, sampled uniformly from the interval ``[2..16]``.
+    Create an augmenter to apply uniform color quantization to images using a
+    random amount of colors, sampled uniformly from the discrete interval
+    ``[2..16]``.
 
     >>> aug = iaa.UniformColorQuantization(n_colors=8)
 
-    Creates an augmenter that quantizes images to (up to) eight colors.
+    Create an augmenter that quantizes images to (up to) eight colors.
 
-    >>> aug = iaa.UniformColorQuantization(n_colors=(4, 32))
+    >>> aug = iaa.UniformColorQuantization(n_colors=(4, 16))
 
-    Creates an augmenter that quantizes images to (up to) ``n`` colors,
+    Create an augmenter that quantizes images to (up to) ``n`` colors,
     where ``n`` is randomly and uniformly sampled from the discrete interval
-    ``[4, 32]``.
+    ``[4..16]``.
 
     >>> aug = iaa.UniformColorQuantization(
     >>>     from_colorspace=iaa.ChangeColorspace.BGR,
     >>>     to_colorspace=[iaa.ChangeColorspace.RGB, iaa.ChangeColorspace.HSV])
 
-    Creates an augmenter that uniformly quantizes images in either ``RGB``
+    Create an augmenter that uniformly quantizes images in either ``RGB``
     or ``HSV`` colorspace (randomly picked per image). The input colorspace
     of all images has to be ``BGR``.
 

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -182,6 +182,7 @@ def adjust_contrast_sigmoid(arr, gain, cutoff):
 
 
 # TODO quite similar to the other adjust_contrast_*() functions, make DRY
+# TODO add dtype gating
 def adjust_contrast_log(arr, gain):
     """
     Adjust contrast by scaling each pixel value to ``255 * gain * log_2(1 + I_ij/255)``.
@@ -190,12 +191,12 @@ def adjust_contrast_log(arr, gain):
 
         * ``uint8``: yes; fully tested (1) (2) (3)
         * ``uint16``: yes; tested (2) (3)
-        * ``uint32``: yes; tested (2) (3)
-        * ``uint64``: yes; tested (2) (3) (4)
+        * ``uint32``: no; tested (2) (3) (8)
+        * ``uint64``: no; tested (2) (3) (4) (8)
         * ``int8``: limited; tested (2) (3) (5)
         * ``int16``: limited; tested (2) (3) (5)
-        * ``int32``: limited; tested (2) (3) (5)
-        * ``int64``: limited; tested (2) (3) (4) (5)
+        * ``int32``: no; tested (2) (3) (5) (8)
+        * ``int64``: no; tested (2) (3) (4) (5) (8)
         * ``float16``: limited; tested (5)
         * ``float32``: limited; tested (5)
         * ``float64``: limited; tested (5)
@@ -215,6 +216,8 @@ def adjust_contrast_log(arr, gain):
         - (5) Must not contain negative values. Values >=0 are fully supported.
         - (6) Leads to error in scikit-image.
         - (7) Does not make sense for contrast adjustments.
+        - (8) No longer supported since numpy 1.17. Previously: 'yes' for
+              ``uint32``, ``uint64``; 'limited' for ``int32``, ``int64``.
 
     Parameters
     ----------

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -323,7 +323,7 @@ def adjust_contrast_linear(arr, alpha):
 
 def GammaContrast(gamma=1, per_channel=False, name=None, deterministic=False, random_state=None):
     """
-    Adjust contrast by scaling each pixel value to ``255 * ((I_ij/255)**gamma)``.
+    Adjust image contrast by scaling pixel values to ``255*((v/255)**gamma)``.
 
     Values in the range ``gamma=(0.5, 2.0)`` seem to be sensible.
 
@@ -360,6 +360,20 @@ def GammaContrast(gamma=1, per_channel=False, name=None, deterministic=False, ra
     _ContrastFuncWrapper
         Augmenter to perform gamma contrast adjustment.
 
+    Examples
+    --------
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.GammaContrast((0.5, 2.0))
+
+    Modify the contrast of images according to ``255*((v/255)**gamma)``,
+    where ``v`` is a pixel value and ``gamma`` is sampled uniformly from
+    the interval ``[0.5, 2.0]`` (once per image).
+
+    >>> aug = iaa.GammaContrast((0.5, 2.0), per_channel=True)
+
+    Same as in the previous example, but ``gamma`` is sampled once per image
+    *and* channel.
+
     """
     params1d = [iap.handle_continuous_param(gamma, "gamma", value_range=None, tuple_to_uniform=True,
                                             list_to_choice=True)]
@@ -378,9 +392,10 @@ def GammaContrast(gamma=1, per_channel=False, name=None, deterministic=False, ra
 
 def SigmoidContrast(gain=10, cutoff=0.5, per_channel=False, name=None, deterministic=False, random_state=None):
     """
-    Adjust contrast by scaling each pixel value to ``255 * 1/(1 + exp(gain*(cutoff - I_ij/255)))``.
+    Adjust image contrast to ``255*1/(1+exp(gain*(cutoff-I_ij/255)))``.
 
-    Values in the range ``gain=(5, 20)`` and ``cutoff=(0.25, 0.75)`` seem to be sensible.
+    Values in the range ``gain=(5, 20)`` and ``cutoff=(0.25, 0.75)`` seem to
+    be sensible.
 
     dtype support::
 
@@ -426,6 +441,23 @@ def SigmoidContrast(gain=10, cutoff=0.5, per_channel=False, name=None, determini
     _ContrastFuncWrapper
         Augmenter to perform sigmoid contrast adjustment.
 
+    Examples
+    --------
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.SigmoidContrast(gain=(3, 10), cutoff=(0.4, 0.6))
+
+    Modify the contrast of images according to
+    ``255*1/(1+exp(gain*(cutoff-v/255)))``, where ``v`` is a pixel value,
+    ``gain`` is sampled uniformly from the interval ``[3, 10]`` (once per
+    image) and ``cutoff`` is sampled uniformly from the interval
+    ``[0.4, 0.6]`` (also once per image).
+
+    >>> aug = iaa.SigmoidContrast(
+    >>>     gain=(3, 10), cutoff=(0.4, 0.6), per_channel=True)
+
+    Same as in the previous example, but ``gain`` and ``cutoff`` are each
+    sampled once per image *and* channel.
+
     """
     # TODO add inv parameter?
     params1d = [
@@ -447,7 +479,10 @@ def SigmoidContrast(gain=10, cutoff=0.5, per_channel=False, name=None, determini
 
 def LogContrast(gain=1, per_channel=False, name=None, deterministic=False, random_state=None):
     """
-    Adjust contrast by scaling each pixel value to ``255 * gain * log_2(1 + I_ij/255)``.
+    Adjust image contrast by scaling pixels to ``255*gain*log_2(1+v/255)``.
+
+    This augmenter is fairly similar to
+    ``imgaug.augmenters.arithmetic.Multiply``.
 
     dtype support::
 
@@ -484,6 +519,20 @@ def LogContrast(gain=1, per_channel=False, name=None, deterministic=False, rando
     _ContrastFuncWrapper
         Augmenter to perform logarithmic contrast adjustment.
 
+    Examples
+    --------
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.LogContrast(gain=(0.6, 1.4))
+
+    Modify the contrast of images according to ``255*gain*log_2(1+v/255)``,
+    where ``v`` is a pixel value and ``gain`` is sampled uniformly from the
+    interval ``[0.6, 1.4]`` (once per image).
+
+    >>> aug = iaa.LogContrast(gain=(0.6, 1.4), per_channel=True)
+
+    Same as in the previous example, but ``gain`` is sampled once per image
+    *and* channel.
+
     """
     # TODO add inv parameter?
     params1d = [iap.handle_continuous_param(gain, "gain", value_range=(0, None), tuple_to_uniform=True,
@@ -502,7 +551,7 @@ def LogContrast(gain=1, per_channel=False, name=None, deterministic=False, rando
 
 
 def LinearContrast(alpha=1, per_channel=False, name=None, deterministic=False, random_state=None):
-    """Adjust contrast by scaling each pixel value to ``127 + alpha*(I_ij-127)``.
+    """Adjust contrast by scaling each pixel to ``127 + alpha*(v-127)``.
 
     dtype support::
 
@@ -537,6 +586,20 @@ def LinearContrast(alpha=1, per_channel=False, name=None, deterministic=False, r
     -------
     _ContrastFuncWrapper
         Augmenter to perform contrast adjustment by linearly scaling the distance to 128.
+
+    Examples
+    --------
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.LinearContrast((0.4, 1.6))
+
+    Modify the contrast of images according to `127 + alpha*(v-127)``,
+    where ``v`` is a pixel value and ``alpha`` is sampled uniformly from the
+    interval ``[0.4, 1.6]`` (once per image).
+
+    >>> aug = iaa.LinearContrast((0.4, 1.6), per_channel=True)
+
+    Same as in the previous example, but ``alpha`` is sampled once per image
+    *and* channel.
 
     """
     params1d = [
@@ -672,9 +735,16 @@ class _IntensityChannelBasedApplier(object):
 # TODO add parameter `tile_grid_size_percent`
 class AllChannelsCLAHE(meta.Augmenter):
     """
-    Contrast Limited Adaptive Histogram Equalization, applied to all channels of the input images.
+    Apply CLAHE to all channels of images in their original colorspaces.
 
-    CLAHE performs histogram equilization within image patches, i.e. over local neighbourhoods.
+    CLAHE (Contrast Limited Adaptive Histogram Equalization) performs
+    histogram equilization within image patches, i.e. over local
+    neighbourhoods.
+
+    In contrast to ``imgaug.augmenters.contrast.CLAHE``, this augmenter
+    operates directly on all channels of the input images. It does not
+    perform any colorspace transformations and does not focus on specific
+    channels (e.g. ``L`` in ``Lab`` colorspace).
 
     dtype support::
 
@@ -724,6 +794,26 @@ class AllChannelsCLAHE(meta.Augmenter):
 
     random_state : None or int or numpy.random.RandomState, optional
         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.AllChannelsCLAHE()
+
+    Create an augmenter that applies CLAHE to all channels of input images.
+
+    >>> aug = iaa.AllChannelsCLAHE(clip_limit=(1, 10))
+
+    Same as in the previous example, but the `clip_limit` used by CLAHE is
+    uniformly sampled per image from the interval ``[1, 10]``. Some images
+    will therefore have stronger contrast than others (i.e. higher clip limit
+    values).
+
+    >>> aug = iaa.AllChannelsCLAHE(clip_limit=(1, 10), per_channel=True)
+
+    Same as in the previous example, but the `clip_limit` is sampled per
+    image *and* channel, leading to different levels of contrast for each
+    channel.
 
     """
     def __init__(self, clip_limit=40, tile_grid_size_px=8, tile_grid_size_px_min=3, per_channel=False, name=None,
@@ -798,20 +888,28 @@ class AllChannelsCLAHE(meta.Augmenter):
 
 class CLAHE(meta.Augmenter):
     """
-    Contrast Limited Adaptive Histogram Equalization.
+    Apply CLAHE to L/V/L channels in HLS/HSV/Lab colorspaces.
 
-    This augmenter applies CLAHE to images, a form of histogram equalization that normalizes within local image
-    patches.
-    The augmenter transforms input images to a target colorspace (e.g. ``Lab``), extracts an intensity-related channel
-    from the converted images (e.g. ``L`` for ``Lab``), applies CLAHE to the channel and then converts the resulting
-    image back to the original colorspace.
+    This augmenter applies CLAHE (Contrast Limited Adaptive Histogram
+    Equalization) to images, a form of histogram equalization that normalizes
+    within local image patches.
+    The augmenter transforms input images to a target colorspace (e.g.
+    ``Lab``), extracts an intensity-related channel from the converted
+    images (e.g. ``L`` for ``Lab``), applies CLAHE to the channel and then
+    converts the resulting image back to the original colorspace.
 
-    Grayscale images (images without channel axis or with only one channel axis) are automatically handled,
-    `from_colorspace` does not have to be adjusted for them. For images with four channels (e.g. ``RGBA``), the fourth
-    channel is ignored in the colorspace conversion (e.g. from an ``RGBA`` image, only the ``RGB`` part is converted,
-    normalized, converted back and concatenated with the input ``A`` channel).
-    Images with unusual channel numbers (2, 5 or more than 5) are normalized channel-by-channel (same behaviour as
-    ``AllChannelsCLAHE``, though a warning will be raised).
+    Grayscale images (images without channel axis or with only one channel
+    axis) are automatically handled, `from_colorspace` does not have to be
+    adjusted for them. For images with four channels (e.g. ``RGBA``), the
+    fourth channel is ignored in the colorspace conversion (e.g. from an
+    ``RGBA`` image, only the ``RGB`` part is converted, normalized, converted
+    back and concatenated with the input ``A`` channel). Images with unusual
+    channel numbers (2, 5 or more than 5) are normalized channel-by-channel
+    (same behaviour as ``AllChannelsCLAHE``, though a warning will be raised).
+
+    If you want to apply CLAHE to each channel of the original input image's
+    colorspace (without any colorspace conversion), use
+    ``imgaug.augmenters.contrast.AllChannelsCLAHE`` instead.
 
     dtype support::
 
@@ -892,37 +990,46 @@ class CLAHE(meta.Augmenter):
 
     Examples
     --------
+    >>> import imgaug.augmenters as iaa
     >>> aug = iaa.CLAHE()
 
-    Creates a standard CLAHE augmenter.
+    Create a standard CLAHE augmenter.
 
-    >>> aug = iaa.CLAHE(clip_limit=(1, 50))
+    >>> aug = iaa.CLAHE(clip_limit=(1, 10))
 
-    Creates a CLAHE augmenter with a clip limit uniformly sampled from ``[1..50]``, where ``1`` is rather low contrast
-    and ``50`` is rather high contrast.
+    Create a CLAHE augmenter with a clip limit uniformly sampled from
+    ``[1..10]``, where ``1`` is rather low contrast and ``10`` is rather
+    high contrast.
 
     >>> aug = iaa.CLAHE(tile_grid_size_px=(3, 21))
 
-    Creates a CLAHE augmenter with kernel sizes of ``SxS``, where ``S`` is uniformly sampled from ``[3..21]``.
-    Sampling happens once per image.
+    Create a CLAHE augmenter with kernel sizes of ``SxS``, where ``S`` is
+    uniformly sampled from ``[3..21]``. Sampling happens once per image.
 
-    >>> aug = iaa.CLAHE(tile_grid_size_px=iap.Discretize(iap.Normal(loc=7, scale=2)), tile_grid_size_px_min=3)
+    >>> aug = iaa.CLAHE(
+    >>>     tile_grid_size_px=iap.Discretize(iap.Normal(loc=7, scale=2)),
+    >>>     tile_grid_size_px_min=3)
 
-    Creates a CLAHE augmenter with kernel sizes of ``SxS``, where ``S`` is sampled from ``N(7, 2)``, but does not go
-    below ``3``.
+    Create a CLAHE augmenter with kernel sizes of ``SxS``, where ``S`` is
+    sampled from ``N(7, 2)``, but does not go below ``3``.
 
     >>> aug = iaa.CLAHE(tile_grid_size_px=((3, 21), [3, 5, 7]))
 
-    Creates a CLAHE augmenter with kernel sizes of ``HxW``, where ``H`` is uniformly sampled from ``[3..21]`` and
-    ``W`` is randomly picked from the list ``[3, 5, 7]``.
+    Create a CLAHE augmenter with kernel sizes of ``HxW``, where ``H`` is
+    uniformly sampled from ``[3..21]`` and ``W`` is randomly picked from the
+    list ``[3, 5, 7]``.
 
-    >>> aug = iaa.CLAHE(from_colorspace=iaa.CLAHE.BGR, to_colorspace=iaa.CLAHE.HSV)
+    >>> aug = iaa.CLAHE(
+    >>>     from_colorspace=iaa.CLAHE.BGR,
+    >>>     to_colorspace=iaa.CLAHE.HSV)
 
-    Creates a CLAHE augmenter that converts images from BGR colorspace to HSV colorspace and then applies the local
-    histogram equalization to the ``V`` channel of the images (before converting back to ``BGR``). Alternatively,
-    ``Lab`` (default) or ``HLS`` can be used as the target colorspace. Grayscale images (no channels / one channel)
-    are never converted and are instead directly normalized (i.e. `from_colorspace` does not have to be changed for
-    them).
+    Create a CLAHE augmenter that converts images from BGR colorspace to
+    HSV colorspace and then applies the local histogram equalization to the
+    ``V`` channel of the images (before converting back to ``BGR``).
+    Alternatively, ``Lab`` (default) or ``HLS`` can be used as the target
+    colorspace. Grayscale images (no channels / one channel) are never
+    converted and are instead directly normalized (i.e. `from_colorspace`
+    does not have to be changed for them).
 
     """
     RGB = _IntensityChannelBasedApplier.RGB
@@ -975,7 +1082,12 @@ class CLAHE(meta.Augmenter):
 
 class AllChannelsHistogramEqualization(meta.Augmenter):
     """
-    Augmenter to perform standard histogram equalization on images, applied to all channels of each input image.
+    Apply Histogram Eq. to all channels of images in their original colorspaces.
+
+    In contrast to ``imgaug.augmenters.contrast.HistogramEqualization``, this
+    augmenter operates directly on all channels of the input images. It does
+    not perform any colorspace transformations and does not focus on specific
+    channels (e.g. ``L`` in ``Lab`` colorspace).
 
     dtype support::
 
@@ -1007,6 +1119,21 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
 
     random_state : None or int or numpy.random.RandomState, optional
         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.AllChannelsHistogramEqualization()
+
+    Create an augmenter that applies histogram equalization to all channels
+    of input images in the original colorspaces.
+
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.Alpha((0.0, 1.0), iaa.AllChannelsHistogramEqualization())
+
+    Same as in the previous example, but alpha-blends the contrast-enhanced
+    augmented images with the original input images using random blend
+    strengths. This leads to random strengths of the contrast adjustment.
 
     """
     def __init__(self, name=None, deterministic=False, random_state=None):
@@ -1042,20 +1169,28 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
 
 class HistogramEqualization(meta.Augmenter):
     """
-    Augmenter to apply standard histogram equalization to images.
+    Apply Histogram Eq. to L/V/L channels of images in HLS/HSV/Lab colorspaces.
 
     This augmenter is similar to ``imgaug.augmenters.contrast.CLAHE``.
 
-    The augmenter transforms input images to a target colorspace (e.g. ``Lab``), extracts an intensity-related channel
-    from the converted images (e.g. ``L`` for ``Lab``), applies Histogram Equalization to the channel and then
-    converts the resulting image back to the original colorspace.
+    The augmenter transforms input images to a target colorspace (e.g.
+    ``Lab``), extracts an intensity-related channel from the converted images
+    (e.g. ``L`` for ``Lab``), applies Histogram Equalization to the channel
+    and then converts the resulting image back to the original colorspace.
 
-    Grayscale images (images without channel axis or with only one channel axis) are automatically handled,
-    `from_colorspace` does not have to be adjusted for them. For images with four channels (e.g. RGBA), the fourth
-    channel is ignored in the colorspace conversion (e.g. from an ``RGBA`` image, only the ``RGB`` part is converted,
-    normalized, converted back and concatenated with the input ``A`` channel).
-    Images with unusual channel numbers (2, 5 or more than 5) are normalized channel-by-channel (same behaviour as
-    ``AllChannelsHistogramEqualization``, though a warning will be raised).
+    Grayscale images (images without channel axis or with only one channel
+    axis) are automatically handled, `from_colorspace` does not have to be
+    adjusted for them. For images with four channels (e.g. RGBA), the fourth
+    channel is ignored in the colorspace conversion (e.g. from an ``RGBA``
+    image, only the ``RGB`` part is converted, normalized, converted back and
+    concatenated with the input ``A`` channel). Images with unusual channel
+    numbers (2, 5 or more than 5) are normalized channel-by-channel (same
+    behaviour as ``AllChannelsHistogramEqualization``, though a warning will
+    be raised).
+
+    If you want to apply HistogramEqualization to each channel of the original
+    input image's colorspace (without any colorspace conversion), use
+    ``imgaug.augmenters.contrast.AllChannelsHistogramEqualization`` instead.
 
     dtype support::
 
@@ -1102,18 +1237,26 @@ class HistogramEqualization(meta.Augmenter):
 
     Examples
     --------
+    >>> import imgaug.augmenters as iaa
     >>> aug = iaa.HistogramEqualization()
 
-    Creates a standard histogram equalization augmenter.
+    Create an augmenter that converts images to ``HLS``/``HSV``/``Lab``
+    colorspaces, extracts intensity-related channels (i.e. ``L``/``V``/``L``),
+    applies histogram equalization to these channels and converts back to the
+    input colorspace.
 
-    >>> aug = iaa.HistogramEqualization(from_colorspace=iaa.HistogramEqualization.BGR,
-    >>>                                 to_colorspace=iaa.HistogramEqualization.HSV)
+    >>> aug = iaa.Alpha((0.0, 1.0), iaa.HistogramEqualization())
 
-    Creates a histogram equalization augmenter that converts images from BGR colorspace to HSV colorspace and then
-    applies the local histogram equalization to the ``V`` channel of the images (before converting back to ``BGR``).
-    Alternatively, ``Lab`` (default) or ``HLS`` can be used as the target colorspace. Grayscale images
-    (no channels / one channel) are never converted and are instead directly normalized (i.e. `from_colorspace` does
-    not have to be changed for them).
+    Same as in the previous example, but alpha blends the result, leading
+    to various strengths of contrast normalization.
+
+    >>> aug = iaa.HistogramEqualization(
+    >>>     from_colorspace=iaa.HistogramEqualization.BGR,
+    >>>     to_colorspace=iaa.HistogramEqualization.HSV)
+
+    Same as in the first example, but the colorspace of input images has
+    to be ``BGR`` (instead of default ``RGB``) and the histogram equalization
+    is applied to the ``V`` channel in ``HSV`` colorspace.
 
     """
     RGB = _IntensityChannelBasedApplier.RGB

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -266,23 +266,42 @@ class Canny(meta.Augmenter):
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.Canny()
 
-    Creates an augmenter that generates random blends between images and
-    their canny edge representations. Apply the augmenter to images using
-    e.g. ``images_aug = aug(images=<list of numpy array>)``.
+    Create an augmenter that generates random blends between images and
+    their canny edge representations.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.Canny(sobel_kernel_size=(0, 7))
-
-    Creates a canny edge augmenter that initially preprocesses images using
-    a sobel filter with kernel size ``3x3`` to ``7x7`` and will sometimes
-    not modify images at all (if a value ``<=2`` is sampled).
-
-    >>> import imgaug.augmenters as iaa
     >>> aug = iaa.Canny(alpha=(0.0, 0.5))
 
-    Creates a canny edge augmenter that generates edge images with a blending
-    factor of max 50%, i.e. the original (non-edge) image is always at least
-    partially visible.
+    Create a canny edge augmenter that generates edge images with a blending
+    factor of max ``50%``, i.e. the original (non-edge) image is always at
+    least partially visible.
+
+    >>> aug = iaa.Canny(
+    >>>     alpha=(0.0, 0.5),
+    >>>     colorizer=iaa.RandomColorsBinaryImageColorizer(
+    >>>         color_true=255,
+    >>>         color_false=0
+    >>>     )
+    >>> )
+
+    Same as in the previous example, but the edge image always uses the
+    color white for edges and black for the background.
+
+    >>> aug = iaa.Canny(alpha=(0.5, 1.0), sobel_kernel_size=[3, 7])
+
+    Create a canny edge augmenter that initially preprocesses images using
+    a sobel filter with kernel size of either ``3x3`` or ``13x13`` and
+    alpha-blends with result using a strength of ``50%`` (both images
+    equally visible) to ``100%`` (only edge image visible).
+
+    >>> aug = iaa.Alpha(
+    >>>     (0.0, 1.0),
+    >>>     iaa.Canny(alpha=1),
+    >>>     iaa.MedianBlur(13)
+    >>> )
+
+    Create an augmenter that blends a canny edge image with a median-blurred
+    version of the input image. The median blur uses a fixed kernel size
+    of ``13x13`` pixels.
 
     """
 

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -107,6 +107,17 @@ class Fliplr(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
             heatmaps_i.arr_0to1 = arr_flipped
         return heatmaps
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        arrs_flipped = self._augment_images(
+            [segmaps_i.arr for segmaps_i in segmaps],
+            random_state=random_state,
+            parents=parents,
+            hooks=hooks
+        )
+        for segmaps_i, arr_flipped in zip(segmaps, arrs_flipped):
+            segmaps_i.arr = arr_flipped
+        return segmaps
+
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         nb_images = len(keypoints_on_images)
         samples = self.p.draw_samples((nb_images,), random_state=random_state)
@@ -198,6 +209,17 @@ class Flipud(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
         for heatmaps_i, arr_flipped in zip(heatmaps, arrs_flipped):
             heatmaps_i.arr_0to1 = arr_flipped
         return heatmaps
+
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        arrs_flipped = self._augment_images(
+            [segmaps_i.arr for segmaps_i in segmaps],
+            random_state=random_state,
+            parents=parents,
+            hooks=hooks
+        )
+        for segmaps_i, arr_flipped in zip(segmaps, arrs_flipped):
+            segmaps_i.arr = arr_flipped
+        return segmaps
 
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         nb_images = len(keypoints_on_images)

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -41,6 +41,12 @@ class Fliplr(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
     """
     Flip/mirror input images horizontally.
 
+    .. note ::
+
+        The default value for the probability is ``0.0``.
+        So, to flip *all* input image use ``Fliplr(1.0)`` and *not* just
+        ``Fliplr()``.
+
     dtype support::
 
         * ``uint8``: yes; fully tested
@@ -144,6 +150,12 @@ class Fliplr(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
 class Flipud(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variable, line-too-long
     """
     Flip/mirror input images vertically.
+
+    .. note ::
+
+        The default value for the probability is ``0.0``.
+        So, to flip *all* input image use ``Flipud(1.0)`` and *not* just
+        ``Flipud()``.
 
     dtype support::
 

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -2372,7 +2372,7 @@ class PerspectiveTransform(meta.Augmenter):
     def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
         result = segmaps
 
-        matrices, max_heights, max_widths = self._create_matrices(
+        matrices, max_heights, max_widths, _, _ = self._create_matrices(
             [segmaps_i.arr.shape for segmaps_i in segmaps],
             ia.copy_random_state(random_state)
         )
@@ -2383,7 +2383,7 @@ class PerspectiveTransform(meta.Augmenter):
         if self.keep_size:
             max_heights_imgs, max_widths_imgs = max_heights, max_widths
         else:
-            _, max_heights_imgs, max_widths_imgs = self._create_matrices(
+            _, max_heights_imgs, max_widths_imgs, _, _ = self._create_matrices(
                 [segmaps_i.shape for segmaps_i in segmaps],
                 ia.copy_random_state(random_state)
             )

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -1605,17 +1605,21 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
         a tuple of augmentables. It will return the same types of augmentables
         (only augmented) as input into the method. This behaviour
         is partly specific to the python version:
-          * In _python 3.6+_ (if ``return_batch=False``):
+
+          * In **python 3.6+** (if ``return_batch=False``):
+
             * Three or more augmentables may be used as input.
             * The return order matches the order of the named arguments, e.g.
-              ``B, D, C = augment(B=x, D=y, C=z)``.
+              ``x_aug, y_aug, z_aug = augment(X=x, Y=y, Z=z)``.
             * None of the provided named arguments has to be `image` or `images`.
-          * In _python <3.6_  (if ``return_batch=False``):
+
+          * In **python <3.6** (if ``return_batch=False``):
+
             * One or two augmentables may be used as input, not more than that.
-            * At least one the augmentables has to be `image` or `images`.
+            * At least one of the augmentables has to be `image` or `images`.
             * The augmented images are always returned first.
 
-        If `return_batch` was not set to ``False``, an instance of
+        If `return_batch` was set to ``True``, an instance of
         ``UnnormalizedBatch`` will be returned. The output is the same for
         all python version and any number or combination of augmentables may
         be provided.
@@ -1632,7 +1636,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
             optional
             The image to augment. Only this or `images` can be set, not both.
             If `return_batch` is ``False`` and the python version is below 3.6,
-            either this or `images` _must_ be provided.
+            either this or `images` **must** be provided.
 
         images : None \
             or (N,H,W,C) ndarray \
@@ -1642,7 +1646,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
             optional
             The images to augment. Only this or `image` can be set, not both.
             If `return_batch` is ``False`` and the python version is below 3.6,
-            either this or `image` _must_ be provided.
+            either this or `image` **must** be provided.
 
         heatmaps : None \
             or (N,H,W,C) ndarray \
@@ -1735,12 +1739,14 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
             required for valid polygons).
             The following datatypes will be interpreted as a single polygon on
             a single image:
+
               * ``imgaug.augmentables.polys.Polygon``
               * ``iterable of tuple of number``
               * ``iterable of imgaug.augmentables.kps.Keypoint``
 
             The following datatypes will be interpreted as multiple polygons
             on a single image:
+
               * ``imgaug.augmentables.polys.PolygonsOnImage``
               * ``iterable of imgaug.augmentables.polys.Polygon``
               * ``iterable of iterable of tuple of number``
@@ -1749,6 +1755,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
             The following datatypes will be interpreted as multiple polygons on
             multiple images:
+
               * ``(N,#polys,#points,2) ndarray``
               * ``iterable of (#polys,#points,2) ndarray``
               * ``iterable of iterable of (#points,2) ndarray``
@@ -4136,6 +4143,7 @@ def AssertLambda(func_images=None, func_heatmaps=None,
                   name=name, deterministic=deterministic, random_state=random_state)
 
 
+# FIXME check_segmentation_maps is not used
 def AssertShape(shape, check_images=True, check_heatmaps=True,
                 check_segmentation_maps=True, check_keypoints=True,
                 check_polygons=True,
@@ -4348,7 +4356,7 @@ def AssertShape(shape, check_images=True, check_heatmaps=True,
 
 class ChannelShuffle(Augmenter):
     """
-    Augmenter that randomly shuffles the channels in images.
+    Randomize the order of channels in input images.
 
     dtype support::
 
@@ -4389,13 +4397,17 @@ class ChannelShuffle(Augmenter):
 
     Examples
     --------
-    >>> aug = iaa.ChannelShuffle(0.25)
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.ChannelShuffle(0.35)
 
-    Shuffles channels for 25% of all images.
+    Shuffle all channels of 35% of all images.
 
-    >>> aug = iaa.ChannelShuffle(0.25, channels=[0, 1])
+    >>> aug = iaa.ChannelShuffle(0.35, channels=[0, 1])
 
-    Shuffles channels 0 and 1 with each other for 25% of all images.
+    Shuffle only channels ``0`` and ``1`` of 35% of all images. As the new
+    channel orders ``0, 1`` and ``1, 0`` are both valid outcomes of the
+    shuffling, it means that for ``0.35 * 0.5 = 0.175`` or 17.5% of all images
+    the order of channels ``0`` and ``1`` is inverted.
 
     """
 

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -2912,6 +2912,24 @@ class Sequential(Augmenter, list):
                     )
         return heatmaps
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        if hooks is None or hooks.is_propagating(segmaps, augmenter=self, parents=parents, default=True):
+            if self.random_order:
+                for index in random_state.permutation(len(self)):
+                    segmaps = self[index].augment_segmentation_maps(
+                        segmaps=segmaps,
+                        parents=parents + [self],
+                        hooks=hooks
+                    )
+            else:
+                for augmenter in self:
+                    segmaps = augmenter.augment_segmentation_maps(
+                        segmaps=segmaps,
+                        parents=parents + [self],
+                        hooks=hooks
+                    )
+        return segmaps
+
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         if hooks is None or hooks.is_propagating(keypoints_on_images,
                                                  augmenter=self, parents=parents, default=True):
@@ -3220,6 +3238,13 @@ class SomeOf(Augmenter, list):
         return self._augment_non_images(heatmaps, random_state,
                                         parents, hooks, _augfunc)
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        def _augfunc(augmenter_, segmaps_to_aug_, parents_, hooks_):
+            return augmenter_.augment_segmentation_maps(
+                segmaps_to_aug_, parents_, hooks_)
+        return self._augment_non_images(segmaps, random_state,
+                                        parents, hooks, _augfunc)
+
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         def _augfunc(augmenter_, koi_to_aug_, parents_, hooks_):
             return augmenter_.augment_keypoints(koi_to_aug_, parents_, hooks_)
@@ -3490,6 +3515,12 @@ class Sometimes(Augmenter):
         return self._augment_non_images(heatmaps, random_state,
                                         parents, hooks, _augfunc)
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        def _augfunc(augs_, inputs_, parents_, hooks_):
+            return augs_.augment_segmentation_maps(inputs_, parents_, hooks_)
+        return self._augment_non_images(segmaps, random_state,
+                                        parents, hooks, _augfunc)
+
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         def _augfunc(augs_, inputs_, parents_, hooks_):
             return augs_.augment_keypoints(inputs_, parents_, hooks_)
@@ -3680,6 +3711,12 @@ class WithChannels(Augmenter):
             return children_.augment_heatmaps(inputs_, parents_, hooks_)
         return self._augment_non_images(heatmaps, parents, hooks, _augfunc)
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        def _augfunc(children_, inputs_, parents_, hooks_):
+            return children_.augment_segmentation_maps(
+                inputs_, parents_, hooks_)
+        return self._augment_non_images(segmaps, parents, hooks, _augfunc)
+
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         def _augfunc(children_, inputs_, parents_, hooks_):
             return children_.augment_keypoints(inputs_, parents_, hooks_)
@@ -3835,6 +3872,18 @@ class Lambda(Augmenter):
         If this is ``None`` instead of a function, the heatmaps will not be
         altered.
 
+    func_segmentation_maps : None or callable, optional
+        The function to call for each batch of segmentation maps.
+        It must follow the form
+
+            ``function(segmaps, random_state, parents, hooks)``
+
+        and return the changed segmaps (may be transformed in-place).
+        This is essentially the interface of
+        :func:`imgaug.augmenters.meta.Augmenter._augment_segmentation_maps`.
+        If this is ``None`` instead of a function, the segmentatio maps will
+        not be altered.
+
     func_keypoints : None or callable, optional
         The function to call for each batch of image keypoints.
         It must follow the form
@@ -3906,12 +3955,14 @@ class Lambda(Augmenter):
 
     """
 
-    def __init__(self, func_images=None, func_heatmaps=None, func_keypoints=None,
+    def __init__(self, func_images=None, func_heatmaps=None,
+                 func_segmentation_maps=None, func_keypoints=None,
                  func_polygons="keypoints",
                  name=None, deterministic=False, random_state=None):
         super(Lambda, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.func_images = func_images
         self.func_heatmaps = func_heatmaps
+        self.func_segmentation_maps = func_segmentation_maps
         self.func_keypoints = func_keypoints
         self.func_polygons = func_polygons
 
@@ -3924,13 +3975,25 @@ class Lambda(Augmenter):
         if self.func_heatmaps is not None:
             result = self.func_heatmaps(heatmaps, random_state, parents, hooks)
             ia.do_assert(ia.is_iterable(result),
-                         "Expected callback function for heatmaps to return list of imgaug.HeatmapsOnImage() "
+                         "Expected callback function for heatmaps to return list of imgaug.HeatmapsOnImage "
                          + "instances, got %s." % (type(result),))
             ia.do_assert(all([isinstance(el, ia.HeatmapsOnImage) for el in result]),
-                         "Expected callback function for heatmaps to return list of imgaug.HeatmapsOnImage() "
+                         "Expected callback function for heatmaps to return list of imgaug.HeatmapsOnImage "
                          + "instances, got %s." % ([type(el) for el in result],))
             return result
         return heatmaps
+
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        if self.func_segmentation_maps is not None:
+            result = self.func_segmentation_maps(segmaps, random_state, parents, hooks)
+            ia.do_assert(ia.is_iterable(result),
+                         "Expected callback function for segmentation maps to return list of imgaug.SegmentationMapsOnImage() "
+                         + "instances, got %s." % (type(result),))
+            ia.do_assert(all([isinstance(el, ia.SegmentationMapsOnImage) for el in result]),
+                         "Expected callback function for segmentation maps to return list of imgaug.SegmentationMapsOnImage() "
+                         + "instances, got %s." % ([type(el) for el in result],))
+            return result
+        return segmaps
 
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         if self.func_keypoints is not None:
@@ -3964,7 +4027,8 @@ class Lambda(Augmenter):
         return []
 
 
-def AssertLambda(func_images=None, func_heatmaps=None, func_keypoints=None,
+def AssertLambda(func_images=None, func_heatmaps=None,
+                 func_segmentation_maps=None, func_keypoints=None,
                  func_polygons=None, name=None, deterministic=False,
                  random_state=None):
     """
@@ -4006,6 +4070,13 @@ def AssertLambda(func_images=None, func_heatmaps=None, func_keypoints=None,
         It essentially reuses the interface of
         :func:`imgaug.augmenters.meta.Augmenter._augment_heatmaps`.
 
+    func_segmentation_maps : None or callable, optional
+        The function to call for each batch of segmentation maps.
+        It must follow the form ``function(segmaps, random_state, parents, hooks)``
+        and return either True (valid input) or False (invalid input).
+        It essentially reuses the interface of
+        :func:`imgaug.augmenters.meta.Augmenter._augment_segmentation_maps`.
+
     func_keypoints : None or callable, optional
         The function to call for each batch of keypoints.
         It must follow the form ``function(keypoints_on_images, random_state, parents, hooks)``
@@ -4040,6 +4111,11 @@ def AssertLambda(func_images=None, func_heatmaps=None, func_keypoints=None,
                      "Input heatmaps did not fulfill user-defined assertion in AssertLambda.")
         return heatmaps
 
+    def func_segmentation_maps_assert(segmaps, random_state, parents, hooks):
+        ia.do_assert(func_segmentation_maps(segmaps, random_state, parents, hooks),
+                     "Input segmentation maps did not fulfill user-defined assertion in AssertLambda.")
+        return segmaps
+
     def func_keypoints_assert(keypoints_on_images, random_state, parents, hooks):
         ia.do_assert(func_keypoints(keypoints_on_images, random_state, parents, hooks),
                      "Input keypoints did not fulfill user-defined assertion in AssertLambda.")
@@ -4054,13 +4130,15 @@ def AssertLambda(func_images=None, func_heatmaps=None, func_keypoints=None,
         name = "Unnamed%s" % (ia.caller_name(),)
     return Lambda(func_images_assert if func_images is not None else None,
                   func_heatmaps_assert if func_heatmaps is not None else None,
+                  func_segmentation_maps_assert if func_segmentation_maps is not None else None,
                   func_keypoints_assert if func_keypoints is not None else None,
                   func_polygons_assert if func_polygons is not None else None,
                   name=name, deterministic=deterministic, random_state=random_state)
 
 
 def AssertShape(shape, check_images=True, check_heatmaps=True,
-                check_keypoints=True, check_polygons=True,
+                check_segmentation_maps=True, check_keypoints=True,
+                check_polygons=True,
                 name=None, deterministic=False, random_state=None):
     """
     Augmenter to make assumptions about the shape of input image(s), heatmaps and keypoints.
@@ -4104,10 +4182,17 @@ def AssertShape(shape, check_images=True, check_heatmaps=True,
 
     check_heatmaps : bool, optional
         Whether to validate input heatmaps via the given shape.
-        The number of heatmaps will be checked and for each Heatmaps
+        The number of heatmaps will be checked and for each ``HeatmapsOnImage``
         instance its array's height and width, but not the channel
         count as the channel number denotes the expected number of channels
         in images.
+
+    check_segmentation_maps : bool, optional
+        Whether to validate input segmentation maps via the given shape.
+        The number of segmentation maps will be checked and for each
+        ``SegmentationMapsOnImage`` instance its array's height and width, but
+        not the channel count as the channel number denotes the expected number
+        of channels in images.
 
     check_keypoints : bool, optional
         Whether to validate input keypoints via the given shape.
@@ -4210,6 +4295,19 @@ def AssertShape(shape, check_images=True, check_heatmaps=True,
                     compare(observed, expected, j, i)
         return heatmaps
 
+    def func_segmentation_maps(segmaps, _random_state, _parents, _hooks):
+        if check_heatmaps:
+            if shape[0] is not None:
+                compare(len(segmaps), shape[0], 0, "ALL")
+
+            for i in sm.xrange(len(segmaps)):
+                segmaps_i = segmaps[i]
+                for j in sm.xrange(len(shape[0:2])):
+                    expected = shape[j+1]
+                    observed = segmaps_i.arr.shape[j]
+                    compare(observed, expected, j, i)
+        return segmaps
+
     def func_keypoints(keypoints_on_images, _random_state, _parents, _hooks):
         if check_keypoints:
             if shape[0] is not None:
@@ -4239,7 +4337,11 @@ def AssertShape(shape, check_images=True, check_heatmaps=True,
     if name is None:
         name = "Unnamed%s" % (ia.caller_name(),)
 
-    return Lambda(func_images, func_heatmaps, func_keypoints, func_polygons,
+    return Lambda(func_images=func_images,
+                  func_heatmaps=func_heatmaps,
+                  func_segmentation_maps=func_segmentation_maps,
+                  func_keypoints=func_keypoints,
+                  func_polygons=func_polygons,
                   name=name, deterministic=deterministic,
                   random_state=random_state)
 

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -4143,7 +4143,7 @@ def AssertLambda(func_images=None, func_heatmaps=None,
                   name=name, deterministic=deterministic, random_state=random_state)
 
 
-# FIXME check_segmentation_maps is not used
+# TODO add tests for segmaps
 def AssertShape(shape, check_images=True, check_heatmaps=True,
                 check_segmentation_maps=True, check_keypoints=True,
                 check_polygons=True,
@@ -4304,7 +4304,7 @@ def AssertShape(shape, check_images=True, check_heatmaps=True,
         return heatmaps
 
     def func_segmentation_maps(segmaps, _random_state, _parents, _hooks):
-        if check_heatmaps:
+        if check_segmentation_maps:
             if shape[0] is not None:
                 compare(len(segmaps), shape[0], 0, "ALL")
 

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -111,8 +111,8 @@ class AveragePooling(_AbstractPoolingBase):
     """
     Apply average pooling to images.
 
-    This pools images with kernel sizes ``H x W`` by averaging the pixel
-    values within these windows. For e.g. ``2 x 2`` this halves the image
+    This augmenter pools images with kernel sizes ``H x W`` by averaging the
+    pixel values within these windows. For e.g. ``2 x 2`` this halves the image
     size. Optionally, the augmenter will automatically re-upscale the image
     to the input size (by default this is activated).
 
@@ -176,34 +176,30 @@ class AveragePooling(_AbstractPoolingBase):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = AveragePooling(2)
+    >>> aug = iaa.AveragePooling(2)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``.
+    Create an augmenter that always pools with a kernel size of ``2 x 2``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = AveragePooling(2, keep_size=False)
+    >>> aug = iaa.AveragePooling(2, keep_size=False)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``
+    Create an augmenter that always pools with a kernel size of ``2 x 2``
     and does *not* resize back to the input image size, i.e. the resulting
     images have half the resolution.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = AveragePooling([2, 8])
+    >>> aug = iaa.AveragePooling([2, 8])
 
-    Creates an augmenter that always pools either with a kernel size
+    Create an augmenter that always pools either with a kernel size
     of ``2 x 2`` or ``8 x 8``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = AveragePooling((1, 7))
+    >>> aug = iaa.AveragePooling((1, 7))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``1 x 1`` (does nothing) to ``7 x 7``. The kernel sizes are always
     symmetric.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = AveragePooling(((1, 7), (1, 7)))
+    >>> aug = iaa.AveragePooling(((1, 7), (1, 7)))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``H x W`` where ``H`` and ``W`` are both sampled independently from the
     range ``[1..7]``. E.g. resulting kernel sizes could be ``3 x 7``
     or ``5 x 1``.
@@ -229,8 +225,8 @@ class MaxPooling(_AbstractPoolingBase):
     """
     Apply max pooling to images.
 
-    This pools images with kernel sizes ``H x W`` by taking the maximum
-    pixel value over windows. For e.g. ``2 x 2`` this halves the image
+    This augmenter pools images with kernel sizes ``H x W`` by taking the
+    maximum pixel value over windows. For e.g. ``2 x 2`` this halves the image
     size. Optionally, the augmenter will automatically re-upscale the image
     to the input size (by default this is activated).
 
@@ -290,34 +286,30 @@ class MaxPooling(_AbstractPoolingBase):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = MaxPooling(2)
+    >>> aug = iaa.MaxPooling(2)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``.
+    Create an augmenter that always pools with a kernel size of ``2 x 2``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MaxPooling(2, keep_size=False)
+    >>> aug = iaa.MaxPooling(2, keep_size=False)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``
+    Create an augmenter that always pools with a kernel size of ``2 x 2``
     and does *not* resize back to the input image size, i.e. the resulting
     images have half the resolution.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MaxPooling([2, 8])
+    >>> aug = iaa.MaxPooling([2, 8])
 
-    Creates an augmenter that always pools either with a kernel size
+    Create an augmenter that always pools either with a kernel size
     of ``2 x 2`` or ``8 x 8``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MaxPooling((1, 7))
+    >>> aug = iaa.MaxPooling((1, 7))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``1 x 1`` (does nothing) to ``7 x 7``. The kernel sizes are always
     symmetric.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MaxPooling(((1, 7), (1, 7)))
+    >>> aug = iaa.MaxPooling(((1, 7), (1, 7)))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``H x W`` where ``H`` and ``W`` are both sampled independently from the
     range ``[1..7]``. E.g. resulting kernel sizes could be ``3 x 7``
     or ``5 x 1``.
@@ -345,8 +337,8 @@ class MinPooling(_AbstractPoolingBase):
     """
     Apply minimum pooling to images.
 
-    This pools images with kernel sizes ``H x W`` by taking the minimum
-    pixel value over windows. For e.g. ``2 x 2`` this halves the image
+    This augmenter pools images with kernel sizes ``H x W`` by taking the
+    minimum pixel value over windows. For e.g. ``2 x 2`` this halves the image
     size. Optionally, the augmenter will automatically re-upscale the image
     to the input size (by default this is activated).
 
@@ -406,34 +398,30 @@ class MinPooling(_AbstractPoolingBase):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = MinPooling(2)
+    >>> aug = iaa.MinPooling(2)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``.
+    Create an augmenter that always pools with a kernel size of ``2 x 2``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MinPooling(2, keep_size=False)
+    >>> aug = iaa.MinPooling(2, keep_size=False)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``
+    Create an augmenter that always pools with a kernel size of ``2 x 2``
     and does *not* resize back to the input image size, i.e. the resulting
     images have half the resolution.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MinPooling([2, 8])
+    >>> aug = iaa.MinPooling([2, 8])
 
-    Creates an augmenter that always pools either with a kernel size
+    Create an augmenter that always pools either with a kernel size
     of ``2 x 2`` or ``8 x 8``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MinPooling((1, 7))
+    >>> aug = iaa.MinPooling((1, 7))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``1 x 1`` (does nothing) to ``7 x 7``. The kernel sizes are always
     symmetric.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MinPooling(((1, 7), (1, 7)))
+    >>> aug = iaa.MinPooling(((1, 7), (1, 7)))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``H x W`` where ``H`` and ``W`` are both sampled independently from the
     range ``[1..7]``. E.g. resulting kernel sizes could be ``3 x 7``
     or ``5 x 1``.
@@ -461,8 +449,8 @@ class MedianPooling(_AbstractPoolingBase):
     """
     Apply median pooling to images.
 
-    This pools images with kernel sizes ``H x W`` by taking the median
-    pixel value over windows. For e.g. ``2 x 2`` this halves the image
+    This augmenter pools images with kernel sizes ``H x W`` by taking the
+    median pixel value over windows. For e.g. ``2 x 2`` this halves the image
     size. Optionally, the augmenter will automatically re-upscale the image
     to the input size (by default this is activated).
 
@@ -522,34 +510,30 @@ class MedianPooling(_AbstractPoolingBase):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = MedianPooling(2)
+    >>> aug = iaa.MedianPooling(2)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``.
+    Create an augmenter that always pools with a kernel size of ``2 x 2``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MedianPooling(2, keep_size=False)
+    >>> aug = iaa.MedianPooling(2, keep_size=False)
 
-    Creates an augmenter that always pools with a kernel size of ``2 x 2``
+    Create an augmenter that always pools with a kernel size of ``2 x 2``
     and does *not* resize back to the input image size, i.e. the resulting
     images have half the resolution.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MedianPooling([2, 8])
+    >>> aug = iaa.MedianPooling([2, 8])
 
-    Creates an augmenter that always pools either with a kernel size
+    Create an augmenter that always pools either with a kernel size
     of ``2 x 2`` or ``8 x 8``.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MedianPooling((1, 7))
+    >>> aug = iaa.MedianPooling((1, 7))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``1 x 1`` (does nothing) to ``7 x 7``. The kernel sizes are always
     symmetric.
 
-    >>> import imgaug.augmenters as iaa
-    >>> aug = MedianPooling(((1, 7), (1, 7)))
+    >>> aug = iaa.MedianPooling(((1, 7), (1, 7)))
 
-    Creates an augmenter that always pools with a kernel size of
+    Create an augmenter that always pools with a kernel size of
     ``H x W`` where ``H`` and ``W`` are both sampled independently from the
     range ``[1..7]``. E.g. resulting kernel sizes could be ``3 x 7``
     or ``5 x 1``.

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -80,6 +80,10 @@ class Superpixels(meta.Augmenter):
 
     This implementation uses skimage's version of the SLIC algorithm.
 
+    .. note::
+
+        This augmenter is fairly slow. See :ref:`performance`.
+
     dtype support::
 
         if (image size <= max_size)::
@@ -543,30 +547,29 @@ class Voronoi(meta.Augmenter):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> points_sampler = iaa.RegularGridPointsSampler(n_cols=10, n_rows=20)
+    >>> points_sampler = iaa.RegularGridPointsSampler(n_cols=20, n_rows=40)
     >>> aug = iaa.Voronoi(points_sampler)
 
-    Creates an augmenter that places a ``10x20`` (``HxW``) grid of cells on
+    Create an augmenter that places a ``20x40`` (``HxW``) grid of cells on
     the image and replaces all pixels within each cell by the cell's average
     color. The process is performed at an image size not exceeding 128px on
     any side. If necessary, the downscaling is performed using linear
     interpolation.
 
-    >>> import imgaug.augmenters as iaa
     >>> points_sampler = iaa.DropoutPointsSampler(
     >>>     iaa.RelativeRegularGridPointsSampler(
-    >>>         n_cols_frac=(0.01, 0.1),
+    >>>         n_cols_frac=(0.05, 0.2),
     >>>         n_rows_frac=0.1),
     >>>     0.2)
     >>> aug = iaa.Voronoi(points_sampler, p_replace=0.9, max_size=None)
 
-    Creates a voronoi augmenter that generates a grid of cells dynamically
+    Create a voronoi augmenter that generates a grid of cells dynamically
     adapted to the image size. Larger images get more cells. On the x-axis,
     the distance between two cells is ``w * W`` pixels, where ``W`` is the
     width of the image and ``w`` is always ``0.1``. On the y-axis,
     the distance between two cells is ``h * H`` pixels, where ``H`` is the
     height of the image and ``h`` is sampled uniformly from the interval
-    ``[0.01, 0.1]``. To make the voronoi pattern less regular, about ``20``
+    ``[0.05, 0.2]``. To make the voronoi pattern less regular, about ``20``
     percent of the cell coordinates are randomly dropped (i.e. the remaining
     cells grow in size). In contrast to the first example, the image is not
     resized (if it was, the sampling would happen *after* the resizing,
@@ -723,16 +726,15 @@ class UniformVoronoi(Voronoi):
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.UniformVoronoi((100, 500))
 
-    Samples for each image uniformly the number of voronoi cells ``N`` from the
-    interval ``[100, 500]``. Then generates ``N`` coordinates by sampling
+    Sample for each image uniformly the number of voronoi cells ``N`` from the
+    interval ``[100, 500]``. Then generate ``N`` coordinates by sampling
     uniformly the x-coordinates from ``[0, W]`` and the y-coordinates from
     ``[0, H]``, where ``H`` is the image height and ``W`` the image width.
-    Then uses these coordinates to group the image pixels into voronoi
-    cells and averages the colors within them. The process is performed at an
+    Then use these coordinates to group the image pixels into voronoi
+    cells and average the colors within them. The process is performed at an
     image size not exceeding 128px on any side. If necessary, the downscaling
     is performed using linear interpolation.
 
-    >>> import imgaug.augmenters as iaa
     >>> aug = iaa.UniformVoronoi(250, p_replace=0.9, max_size=None)
 
     Same as above, but always samples ``N=250`` cells, replaces only
@@ -876,15 +878,14 @@ class RegularGridVoronoi(Voronoi):
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.RegularGridVoronoi(10, 20)
 
-    Places a regular grid of ``10x20`` (``height x width``) coordinates on
-    each image. Randomly drops on average ``20`` percent of these points
-    to create a less regular pattern. Then uses the remaining coordinates
-    to group the image pixels into voronoi cells and averages the colors
+    Place a regular grid of ``10x20`` (``height x width``) coordinates on
+    each image. Randomly drop on average ``20`` percent of these points
+    to create a less regular pattern. Then use the remaining coordinates
+    to group the image pixels into voronoi cells and average the colors
     within them. The process is performed at an image size not exceeding
     128px on any side. If necessary, the downscaling is performed using
     linear interpolation.
 
-    >>> import imgaug.augmenters as iaa
     >>> aug = iaa.RegularGridVoronoi(
     >>>     (10, 30), 20, p_drop_points=0.0, p_replace=0.9, max_size=None)
 
@@ -922,11 +923,12 @@ class RelativeRegularGridVoronoi(Voronoi):
     to randomize the grid. Each image pixel then belongs to the voronoi
     cell with the closest coordinate.
 
-    **Note**: In contrast to the other Voronoi augmenters, this one uses
-    ``None`` as the default value for `max_size`, i.e. the color averaging
-    is always performed at full resolution. This enables the augmenter to
-    make most use of the added points for larger images. It does however slow
-    down the augmentation process.
+    .. note::
+        In contrast to the other Voronoi augmenters, this one uses
+        ``None`` as the default value for `max_size`, i.e. the color averaging
+        is always performed at full resolution. This enables the augmenter to
+        make most use of the added points for larger images. It does however
+        slow down the augmentation process.
 
     dtype support::
 
@@ -1039,24 +1041,23 @@ class RelativeRegularGridVoronoi(Voronoi):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.RelativeRegularGridVoronoi(0.01, 0.1)
+    >>> aug = iaa.RelativeRegularGridVoronoi(0.1, 0.25)
 
-    Places a regular grid of ``R x C`` coordinates on each image, where
-    ``R`` is the number of rows and computed as ``R=0.01*H`` with ``H`` being
+    Place a regular grid of ``R x C`` coordinates on each image, where
+    ``R`` is the number of rows and computed as ``R=0.1*H`` with ``H`` being
     the height of the input image. ``C`` is the number of columns and
-    analogously estimated from the image width ``W`` as ``C=0.1*W``.
+    analogously estimated from the image width ``W`` as ``C=0.25*W``.
     Larger images will lead to larger ``R`` and ``C`` values.
     On average, ``20`` percent of these grid coordinates are randomly
     dropped to create a less regular pattern. Then, the remaining coordinates
     are used to group the image pixels into voronoi cells and the colors
     within them are averaged.
 
-    >>> import imgaug.augmenters as iaa
     >>> aug = iaa.RelativeRegularGridVoronoi(
-    >>>     (0.01, 0.1), 0.1, p_drop_points=0.0, p_replace=0.9, max_size=512)
+    >>>     (0.03, 0.1), 0.1, p_drop_points=0.0, p_replace=0.9, max_size=512)
 
     Same as above, generates a grid with randomly ``R=r*H`` rows, where
-    ``r`` is sampled uniformly from the interval ``[0.01, 0.1]`` and
+    ``r`` is sampled uniformly from the interval ``[0.03, 0.1]`` and
     ``C=0.1*W`` rows. No points are dropped. The augmenter replaces only
     ``90`` percent of the voronoi cells with their average color (the pixels
     of the remaining ``10`` percent are not changed). Images larger than

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -429,7 +429,7 @@ class Resize(meta.Augmenter):
         for i in sm.xrange(nb_segmaps):
             segmaps_i = segmaps[i]
             sample_h, sample_w = samples_h[i], samples_w[i]
-            h_img, w_img = self._compute_height_width(segmaps_i.shape, sample_h, sample_w)
+            h_img, w_img = self._compute_height_width(segmaps_i.shape, sample_h, sample_w, self.size_order)
             h = int(np.round(h_img * (segmaps_i.arr.shape[0] / segmaps_i.shape[0])))
             w = int(np.round(w_img * (segmaps_i.arr.shape[1] / segmaps_i.shape[1])))
             h = max(h, 1)

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -415,8 +415,27 @@ class Resize(meta.Augmenter):
             w = int(np.round(w_img * (heatmaps_i.arr_0to1.shape[1] / heatmaps_i.shape[1])))
             h = max(h, 1)
             w = max(w, 1)
+            # TODO change this to always have cubic or automatic interpolation?
             heatmaps_i_resized = heatmaps_i.resize((h, w), interpolation=sample_ip)
             heatmaps_i_resized.shape = (h_img, w_img) + heatmaps_i.shape[2:]
+            result.append(heatmaps_i_resized)
+
+        return result
+
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        result = []
+        nb_segmaps = len(segmaps)
+        samples_h, samples_w, _ = self._draw_samples(nb_segmaps, random_state, do_sample_ip=False)
+        for i in sm.xrange(nb_segmaps):
+            segmaps_i = segmaps[i]
+            sample_h, sample_w = samples_h[i], samples_w[i]
+            h_img, w_img = self._compute_height_width(segmaps_i.shape, sample_h, sample_w)
+            h = int(np.round(h_img * (segmaps_i.arr.shape[0] / segmaps_i.shape[0])))
+            w = int(np.round(w_img * (segmaps_i.arr.shape[1] / segmaps_i.shape[1])))
+            h = max(h, 1)
+            w = max(w, 1)
+            heatmaps_i_resized = segmaps_i.resize((h, w))
+            heatmaps_i_resized.shape = (h_img, w_img) + segmaps_i.shape[2:]
             result.append(heatmaps_i_resized)
 
         return result
@@ -442,6 +461,7 @@ class Resize(meta.Augmenter):
             polygons_on_images, random_state, parents, hooks)
 
     def _draw_samples(self, nb_images, random_state, do_sample_ip=True):
+        # TODO use SEED_MAX
         seed = random_state.randint(0, 10**6, 1)[0]
         if isinstance(self.size, tuple):
             samples_h = self.size[0].draw_samples(nb_images, random_state=ia.new_random_state(seed + 0))
@@ -845,6 +865,7 @@ class CropAndPad(meta.Augmenter):
     def _augment_heatmaps(self, heatmaps, random_state, parents, hooks):
         result = []
         nb_heatmaps = len(heatmaps)
+        # TODO use SEED_MAX
         seeds = random_state.randint(0, 10**6, (nb_heatmaps,))
         for i in sm.xrange(nb_heatmaps):
             seed = seeds[i]
@@ -883,6 +904,7 @@ class CropAndPad(meta.Augmenter):
 
             arr_cr = heatmaps[i].arr_0to1[crop_top:height_heatmaps-crop_bottom, crop_left:width_heatmaps-crop_right, :]
 
+            # TODO switch to ia.pad()
             if any([pad_top > 0, pad_right > 0, pad_bottom > 0, pad_left > 0]):
                 if arr_cr.ndim == 2:
                     pad_vals = ((pad_top, pad_bottom), (pad_left, pad_right))
@@ -904,6 +926,73 @@ class CropAndPad(meta.Augmenter):
                 ) + heatmaps[i].shape[2:]
 
             result.append(heatmaps[i])
+
+        return result
+
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        result = []
+        nb_segmaps = len(segmaps)
+        # TODO use SEED_MAX
+        seeds = random_state.randint(0, 10**6, (nb_segmaps,))
+        for i in sm.xrange(nb_segmaps):
+            seed = seeds[i]
+            height_image, width_image = segmaps[i].shape[0:2]
+            height_segmaps, width_segmaps = segmaps[i].arr.shape[0:2]
+
+            vals = self._draw_samples_image(seed, height_image, width_image)
+            crop_image_top, crop_image_right, crop_image_bottom, crop_image_left, \
+                pad_image_top, pad_image_right, pad_image_bottom, pad_image_left, \
+                _pad_mode, _pad_cval = vals
+
+            if (height_image, width_image) != (height_segmaps, width_segmaps):
+                crop_top = int(np.round(height_segmaps * (crop_image_top/height_image)))
+                crop_right = int(np.round(width_segmaps * (crop_image_right/width_image)))
+                crop_bottom = int(np.round(height_segmaps * (crop_image_bottom/height_image)))
+                crop_left = int(np.round(width_segmaps * (crop_image_left/width_image)))
+
+                crop_top, crop_right, crop_bottom, crop_left = \
+                    _crop_prevent_zero_size(height_segmaps, width_segmaps,
+                                            crop_top, crop_right, crop_bottom, crop_left)
+
+                pad_top = int(np.round(height_segmaps * (pad_image_top/height_image)))
+                pad_right = int(np.round(width_segmaps * (pad_image_right/width_image)))
+                pad_bottom = int(np.round(height_segmaps * (pad_image_bottom/height_image)))
+                pad_left = int(np.round(width_segmaps * (pad_image_left/width_image)))
+            else:
+                crop_top = crop_image_top
+                crop_right = crop_image_right
+                crop_bottom = crop_image_bottom
+                crop_left = crop_image_left
+
+                pad_top = pad_image_top
+                pad_right = pad_image_right
+                pad_bottom = pad_image_bottom
+                pad_left = pad_image_left
+
+            arr_cr = segmaps[i].arr[crop_top:height_segmaps - crop_bottom, crop_left:width_segmaps - crop_right, :]
+
+            # TODO switch to ia.pad()
+            if any([pad_top > 0, pad_right > 0, pad_bottom > 0, pad_left > 0]):
+                if arr_cr.ndim == 2:
+                    pad_vals = ((pad_top, pad_bottom), (pad_left, pad_right))
+                else:
+                    pad_vals = ((pad_top, pad_bottom), (pad_left, pad_right), (0, 0))
+
+                arr_cr_pa = np.pad(arr_cr, pad_vals, mode="constant", constant_values=0)
+            else:
+                arr_cr_pa = arr_cr
+
+            segmaps[i].arr = arr_cr_pa
+
+            if self.keep_size:
+                segmaps[i] = segmaps[i].resize((height_segmaps, width_segmaps))
+            else:
+                segmaps[i].shape = (
+                   segmaps[i].shape[0] - crop_image_top - crop_image_bottom + pad_image_top + pad_image_bottom,
+                   segmaps[i].shape[1] - crop_image_left - crop_image_right + pad_image_left + pad_image_right
+                ) + segmaps[i].shape[2:]
+
+            result.append(segmaps[i])
 
         return result
 
@@ -1527,6 +1616,43 @@ class PadToFixedSize(meta.Augmenter):
 
         return heatmaps
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        nb_images = len(segmaps)
+        w, h = self.size
+        pad_xs, pad_ys, _pad_modes, _pad_cvals = self._draw_samples(nb_images, random_state)
+        for i in sm.xrange(nb_images):
+            height_image, width_image = segmaps[i].shape[:2]
+            pad_image_left, pad_image_right, pad_image_top, pad_image_bottom = \
+                self._calculate_paddings(h, w, height_image, width_image, pad_xs[i], pad_ys[i])
+            height_segmaps, width_segmaps = segmaps[i].arr.shape[0:2]
+
+            # TODO for 30x30 padded to 32x32 with 15x15 heatmaps this results in paddings of 1 on
+            # each side (assuming position=(0.5, 0.5)) giving 17x17 heatmaps when they should be
+            # 16x16. Error is due to each side getting projected 0.5 padding which is rounded to 1.
+            # This doesn't seem right.
+            if (height_image, width_image) != (height_segmaps, width_segmaps):
+                pad_top = int(np.round(height_segmaps * (pad_image_top/height_image)))
+                pad_right = int(np.round(width_segmaps * (pad_image_right/width_image)))
+                pad_bottom = int(np.round(height_segmaps * (pad_image_bottom/height_image)))
+                pad_left = int(np.round(width_segmaps * (pad_image_left/width_image)))
+            else:
+                pad_top = pad_image_top
+                pad_right = pad_image_right
+                pad_bottom = pad_image_bottom
+                pad_left = pad_image_left
+
+            segmaps[i].arr = ia.pad(
+                segmaps[i].arr,
+                top=pad_top, right=pad_right, bottom=pad_bottom, left=pad_left,
+                mode="constant", cval=0
+            )
+            segmaps[i].shape = (
+                height_image + pad_image_top + pad_image_bottom,
+                width_image + pad_image_left + pad_image_right
+            ) + segmaps[i].shape[2:]
+
+        return segmaps
+
     def _augment_polygons(self, polygons_on_images, random_state, parents,
                           hooks):
         return self._augment_polygons_as_keypoints(
@@ -1791,6 +1917,51 @@ class CropToFixedSize(meta.Augmenter):
 
         return heatmaps
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        nb_images = len(segmaps)
+        w, h = self.size
+        offset_xs, offset_ys = self._draw_samples(nb_images, random_state)
+        for i in sm.xrange(nb_images):
+            height_image, width_image = segmaps[i].shape[0:2]
+            height_segmaps, width_segmaps = segmaps[i].arr.shape[0:2]
+
+            crop_image_top, crop_image_bottom = 0, 0
+            crop_image_left, crop_image_right = 0, 0
+
+            if height_image > h:
+                crop_image_top = int(offset_ys[i] * (height_image - h))
+                crop_image_bottom = height_image - h - crop_image_top
+
+            if width_image > w:
+                crop_image_left = int(offset_xs[i] * (width_image - w))
+                crop_image_right = width_image - w - crop_image_left
+
+            if (height_image, width_image) != (height_segmaps, width_segmaps):
+                crop_top = int(np.round(height_segmaps * (crop_image_top/height_image)))
+                crop_right = int(np.round(width_segmaps * (crop_image_right/width_image)))
+                crop_bottom = int(np.round(height_segmaps * (crop_image_bottom/height_image)))
+                crop_left = int(np.round(width_segmaps * (crop_image_left/width_image)))
+
+                # TODO add test for zero-size prevention
+                crop_top, crop_right, crop_bottom, crop_left = _crop_prevent_zero_size(
+                    height_segmaps, width_segmaps, crop_top, crop_right, crop_bottom, crop_left)
+            else:
+                crop_top = crop_image_top
+                crop_right = crop_image_right
+                crop_bottom = crop_image_bottom
+                crop_left = crop_image_left
+
+            segmaps[i].arr = segmaps[i].arr[crop_top:height_segmaps - crop_bottom,
+                                            crop_left:width_segmaps-crop_right,
+                                            :]
+
+            segmaps[i].shape = (
+                segmaps[i].shape[0] - crop_image_top - crop_image_bottom,
+                segmaps[i].shape[1] - crop_image_left - crop_image_right
+            ) + segmaps[i].shape[2:]
+
+        return segmaps
+
     def _draw_samples(self, nb_images, random_state):
         seed = random_state.randint(0, 10**6, 1)[0]
 
@@ -1853,6 +2024,15 @@ class KeepSizeByResize(meta.Augmenter):
         corresponding images. The value may also be returned on a per-image basis if `interpolation_heatmaps` is
         provided as a StochasticParameter or may be one possible value if it is provided as a list of strings.
 
+    interpolation_segmaps : KeepSizeByResize.SAME_AS_IMAGES or KeepSizeByResize.NO_RESIZE or\
+                            {'nearest', 'linear', 'area', 'cubic'} or\
+                            {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or\
+                            list of str or list of int or StochasticParameter, optional
+        The interpolation mode to use when resizing segmentation maps.
+        Similar to `interpolation_heatmaps`.
+        NOTE: Only ``NO_RESIZE`` or nearest neighbour interpolation make sense
+        in the vast majority of all cases.
+
     name : None or str, optional
         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
 
@@ -1867,7 +2047,10 @@ class KeepSizeByResize(meta.Augmenter):
     NO_RESIZE = "NO_RESIZE"
     SAME_AS_IMAGES = "SAME_AS_IMAGES"
 
-    def __init__(self, children, interpolation="cubic", interpolation_heatmaps=SAME_AS_IMAGES,
+    def __init__(self, children,
+                 interpolation="cubic",
+                 interpolation_heatmaps=SAME_AS_IMAGES,
+                 interpolation_segmaps="nearest",
                  name=None, deterministic=False, random_state=None):
         super(KeepSizeByResize, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
         self.children = children
@@ -1899,12 +2082,12 @@ class KeepSizeByResize(meta.Augmenter):
         self.children = meta.handle_children_list(children, self.name, "then")
         self.interpolation = _validate_param(interpolation, False)
         self.interpolation_heatmaps = _validate_param(interpolation_heatmaps, True)
+        self.interpolation_segmaps = _validate_param(interpolation_segmaps, True)
 
-    def _draw_samples(self, nb_images, random_state, return_heatmaps):
+    def _draw_samples(self, nb_images, random_state):
+        # TODO use SEED_MAX
         seed = random_state.randint(0, 10 ** 6, 1)[0]
         interpolations = self.interpolation.draw_samples((nb_images,), random_state=ia.new_random_state(seed + 0))
-        if not return_heatmaps:
-            return interpolations
 
         if self.interpolation_heatmaps == KeepSizeByResize.SAME_AS_IMAGES:
             interpolations_heatmaps = np.copy(interpolations)
@@ -1913,19 +2096,39 @@ class KeepSizeByResize(meta.Augmenter):
                 (nb_images,), random_state=ia.new_random_state(seed + 10)
             )
 
-            # Note that `interpolations_heatmaps == self.SAME_AS_IMAGES` works here only if the datatype of the array
-            # is such that it may contain strings. It does not work properly for e.g. integer arrays and will produce
-            # a single bool output, even for arrays with more than one entry.
-            same_as_imgs_idx = [ip == self.SAME_AS_IMAGES for ip in interpolations_heatmaps]
+            # Note that `interpolations_heatmaps == self.SAME_AS_IMAGES`
+            # works here only if the datatype of the array is such that it
+            # may contain strings. It does not work properly for e.g.
+            # integer arrays and will produce a single bool output, even
+            # for arrays with more than one entry.
+            same_as_imgs_idx = [ip == self.SAME_AS_IMAGES
+                                for ip in interpolations_heatmaps]
 
             interpolations_heatmaps[same_as_imgs_idx] = interpolations[same_as_imgs_idx]
 
-        return interpolations, interpolations_heatmaps
+        if self.interpolation_segmaps == KeepSizeByResize.SAME_AS_IMAGES:
+            interpolations_segmaps = np.copy(interpolations)
+        else:
+            interpolations_segmaps = self.interpolation_segmaps.draw_samples(
+                (nb_images,), random_state=ia.new_random_state(seed + 10)
+            )
+
+            # Note that `interpolations_heatmaps == self.SAME_AS_IMAGES`
+            # works here only if the datatype of the array is such that it
+            # may contain strings. It does not work properly for e.g.
+            # integer arrays and will produce a single bool output, even
+            # for arrays with more than one entry.
+            same_as_imgs_idx = [ip == self.SAME_AS_IMAGES
+                                for ip in interpolations_segmaps]
+
+            interpolations_segmaps[same_as_imgs_idx] = interpolations[same_as_imgs_idx]
+
+        return interpolations, interpolations_heatmaps, interpolations_segmaps
 
     def _augment_images(self, images, random_state, parents, hooks):
         input_was_array = ia.is_np_array(images)
         if hooks is None or hooks.is_propagating(images, augmenter=self, parents=parents, default=True):
-            interpolations = self._draw_samples(len(images), random_state, return_heatmaps=False)
+            interpolations, _, _ = self._draw_samples(len(images), random_state)
             input_shapes = [image.shape[0:2] for image in images]
 
             images_aug = self.children.augment_images(
@@ -1954,7 +2157,7 @@ class KeepSizeByResize(meta.Augmenter):
     def _augment_heatmaps(self, heatmaps, random_state, parents, hooks):
         if hooks is None or hooks.is_propagating(heatmaps, augmenter=self, parents=parents, default=True):
             nb_heatmaps = len(heatmaps)
-            _, interpolations_heatmaps = self._draw_samples(nb_heatmaps, random_state, return_heatmaps=True)
+            _, interpolations_heatmaps, _ = self._draw_samples(nb_heatmaps, random_state)
             input_arr_shapes = [heatmaps_i.arr_0to1.shape for heatmaps_i in heatmaps]
 
             # augment according to if and else list
@@ -1978,9 +2181,36 @@ class KeepSizeByResize(meta.Augmenter):
 
         return result
 
+    def _augment_segmentation_maps(self, segmaps, random_state, parents, hooks):
+        if hooks is None or hooks.is_propagating(segmaps, augmenter=self, parents=parents, default=True):
+            nb_segmaps = len(segmaps)
+            _, _, interpolations_segmaps = self._draw_samples(nb_segmaps, random_state)
+            input_arr_shapes = [segmaps_i.arr.shape for segmaps_i in segmaps]
+
+            # augment according to if and else list
+            segmaps_aug = self.children.augment_segmentation_maps(
+                segmaps,
+                parents=parents + [self],
+                hooks=hooks
+            )
+
+            result = []
+            gen = zip(segmaps, segmaps_aug, interpolations_segmaps, input_arr_shapes)
+            for segmaps, segmaps_aug, interpolation, input_arr_shape in gen:
+                if interpolation == "NO_RESIZE":
+                    result.append(segmaps_aug)
+                else:
+                    segmaps_aug = segmaps_aug.resize(input_arr_shape[0:2], interpolation=interpolation)
+                    segmaps_aug.shape = segmaps.shape
+                    result.append(segmaps_aug)
+        else:
+            result = segmaps
+
+        return result
+
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         if hooks is None or hooks.is_propagating(keypoints_on_images, augmenter=self, parents=parents, default=True):
-            interpolations = self._draw_samples(len(keypoints_on_images), random_state, return_heatmaps=False)
+            interpolations, _, _ = self._draw_samples(len(keypoints_on_images), random_state)
             input_shapes = [kpsoi_i.shape for kpsoi_i in keypoints_on_images]
 
             # augment according to if and else list

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -108,8 +108,7 @@ class FastSnowyLandscape(meta.Augmenter):
 
     Search for all pixels in the image with a lightness value in HLS
     colorspace of less than ``140`` and increase their lightness by a factor
-    of ``2.5``. This is the configuration proposed in the original
-    article (see link above).
+    of ``2.5``.
 
     >>> aug = iaa.FastSnowyLandscape(
     >>>     lightness_threshold=[128, 200],
@@ -127,7 +126,7 @@ class FastSnowyLandscape(meta.Augmenter):
     >>>     lightness_multiplier=(1.0, 4.0)
     >>> )
 
-    Similar to above, but the lightness threshold is sampled
+    Similar to the previous example, but the lightness threshold is sampled
     from ``uniform(100, 255)`` (per image) and the multiplier
     from ``uniform(1.0, 4.0)`` (per image). This seems to produce good and
     varied results.
@@ -245,7 +244,7 @@ def Clouds(name=None, deterministic=False, random_state=None):
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.Clouds()
 
-    Creates an augmenter that adds clouds to images.
+    Create an augmenter that adds clouds to images.
 
     """
     if name is None:
@@ -334,7 +333,7 @@ def Fog(name=None, deterministic=False, random_state=None):
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.Fog()
 
-    Creates an augmenter that adds fog to images.
+    Create an augmenter that adds fog to images.
 
     """
     if name is None:
@@ -356,6 +355,7 @@ def Fog(name=None, deterministic=False, random_state=None):
     )
 
 
+# TODO add examples and add these to the overview docs
 # TODO add perspective transform to each cloud layer to make them look more distant?
 # TODO alpha_mean and density overlap - remove one of them
 class CloudLayer(meta.Augmenter):
@@ -801,15 +801,15 @@ def Snowflakes(density=(0.005, 0.075), density_uniformity=(0.3, 0.9),
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.Snowflakes(flake_size=(0.1, 0.4), speed=(0.01, 0.05))
 
-    Adds snowflakes to small images (around ``96x128``).
+    Add snowflakes to small images (around ``96x128``).
 
     >>> aug = iaa.Snowflakes(flake_size=(0.2, 0.7), speed=(0.007, 0.03))
 
-    Adds snowflakes to medium-sized images (around ``192x256``).
+    Add snowflakes to medium-sized images (around ``192x256``).
 
     >>> aug = iaa.Snowflakes(flake_size=(0.7, 0.95), speed=(0.001, 0.03))
 
-    Adds snowflakes to large images (around ``960x1280``).
+    Add snowflakes to large images (around ``960x1280``).
 
     """
     if name is None:
@@ -835,6 +835,7 @@ def Snowflakes(density=(0.005, 0.075), density_uniformity=(0.3, 0.9),
     )
 
 
+# TODO add examples and add these to the overview docs
 # TODO snowflakes are all almost 100% white, add some grayish tones and
 #      maybe color to them
 class SnowflakesLayer(meta.Augmenter):

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -739,12 +739,12 @@ def quokka_segmentation_map(size=None, extract=None):
 
     Returns
     -------
-    result : imgaug.SegmentationMapOnImage
+    result : imgaug.SegmentationMapsOnImage
         Segmentation map object.
 
     """
     # TODO get rid of this deferred import
-    from imgaug.augmentables.segmaps import SegmentationMapOnImage
+    from imgaug.augmentables.segmaps import SegmentationMapsOnImage
 
     with open(QUOKKA_ANNOTATIONS_FP, "r") as f:
         json_dict = json.load(f)
@@ -757,15 +757,16 @@ def quokka_segmentation_map(size=None, extract=None):
         xx.append(x)
         yy.append(y)
 
-    img_seg = np.zeros((643, 960, 1), dtype=np.float32)
-    rr, cc = skimage.draw.polygon(np.array(yy), np.array(xx), shape=img_seg.shape)
-    img_seg[rr, cc] = 1.0
+    img_seg = np.zeros((643, 960, 1), dtype=np.int32)
+    rr, cc = skimage.draw.polygon(
+        np.array(yy), np.array(xx), shape=img_seg.shape)
+    img_seg[rr, cc, 0] = 1
 
     if extract is not None:
         bb = _quokka_normalize_extract(extract)
         img_seg = bb.extract_from_image(img_seg)
 
-    segmap = SegmentationMapOnImage(img_seg, shape=img_seg.shape[0:2] + (3,))
+    segmap = SegmentationMapsOnImage(img_seg, shape=img_seg.shape[0:2] + (3,))
 
     if size is not None:
         shape_resized = _compute_resized_shape(img_seg.shape, size)
@@ -2559,7 +2560,7 @@ MOVED = [
     ("MultiPolygon", "imgaug.augmentables.polys", None),
     ("_ConcavePolygonRecoverer", "imgaug.augmentables.polys", None),
     ("HeatmapsOnImage", "imgaug.augmentables.heatmaps", None),
-    ("SegmentationMapOnImage", "imgaug.augmentables.segmaps", None),
+    ("SegmentationMapsOnImage", "imgaug.augmentables.segmaps", None),
     ("Batch", "imgaug.augmentables.batches", None),
     ("BatchLoader", "imgaug.multicore", None),
     ("BackgroundAugmenter", "imgaug.multicore", None),

--- a/test/augmentables/test_batches.py
+++ b/test/augmentables/test_batches.py
@@ -89,8 +89,9 @@ class TestBatch(unittest.TestCase):
         heatmaps = [ia.HeatmapsOnImage(np.zeros((1, 1, 1), dtype=np.float32),
                                        shape=(4, 4, 3))]
         segmentation_maps = [
-            ia.SegmentationMapOnImage(np.zeros((1, 1), dtype=np.int32),
-                                      shape=(5, 5, 3), nb_classes=20)]
+            ia.SegmentationMapsOnImage(np.zeros((1, 1), dtype=np.int32),
+                                       shape=(5, 5, 3),
+                                       nb_classes=20)]
         keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=2)],
                                          shape=(6, 6, 3))]
         bounding_boxes = [
@@ -147,7 +148,7 @@ class TestBatch(unittest.TestCase):
         assert observed.images_unaug.shape == (1, 1, 1, 3)
         assert isinstance(observed.heatmaps_unaug[0], ia.HeatmapsOnImage)
         assert isinstance(observed.segmentation_maps_unaug[0],
-                          ia.SegmentationMapOnImage)
+                          ia.SegmentationMapsOnImage)
         assert isinstance(observed.keypoints_unaug[0], ia.KeypointsOnImage)
         assert isinstance(observed.bounding_boxes_unaug[0],
                           ia.BoundingBoxesOnImage)

--- a/test/augmentables/test_batches.py
+++ b/test/augmentables/test_batches.py
@@ -90,8 +90,7 @@ class TestBatch(unittest.TestCase):
                                        shape=(4, 4, 3))]
         segmentation_maps = [
             ia.SegmentationMapsOnImage(np.zeros((1, 1), dtype=np.int32),
-                                       shape=(5, 5, 3),
-                                       nb_classes=20)]
+                                       shape=(5, 5, 3))]
         keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=2)],
                                          shape=(6, 6, 3))]
         bounding_boxes = [
@@ -164,7 +163,7 @@ class TestBatch(unittest.TestCase):
         assert observed.line_strings_unaug[0].shape == (101, 101, 3)
 
         assert observed.heatmaps_unaug[0].arr_0to1.shape == (1, 1, 1)
-        assert observed.segmentation_maps_unaug[0].arr.shape == (1, 1, 20)
+        assert observed.segmentation_maps_unaug[0].arr.shape == (1, 1, 1)
         assert observed.keypoints_unaug[0].keypoints[0].x == 1
         assert observed.keypoints_unaug[0].keypoints[0].y == 2
         assert observed.bounding_boxes_unaug[0].bounding_boxes[0].x1 == 1

--- a/test/augmentables/test_lines.py
+++ b/test/augmentables/test_lines.py
@@ -1498,10 +1498,10 @@ class TestLineString(unittest.TestCase):
     # TODO change this after the segmap PR was merged
 
     def test_segmentation_map(self):
-        from imgaug.augmentables.segmaps import SegmentationMapOnImage
+        from imgaug.augmentables.segmaps import SegmentationMapsOnImage
         ls = LineString([(0, 5), (5, 5)])
         observed = ls.to_segmentation_map((10, 10))
-        assert isinstance(observed, SegmentationMapOnImage)
+        assert isinstance(observed, SegmentationMapsOnImage)
         assert observed.shape == (10, 10)
         assert observed.arr.shape == (10, 10, 1)
         assert np.all(observed.arr[0:5, :, :] == 0)

--- a/test/augmentables/test_normalization.py
+++ b/test/augmentables/test_normalization.py
@@ -171,25 +171,24 @@ class TestNormalization(unittest.TestCase):
         # ----
         # array
         # ----
-        for dt in [np.dtype("int32"), np.dtype("uint32"), np.dtype(bool)]:
+        for dt in [np.dtype("int32"), np.dtype("uint16"), np.dtype(bool)]:
             for images in [[np.zeros((1, 1, 3), dtype=np.uint8)],
-                           np.zeros((1, 1, 1, 3), dtype=np.uint8)]:
-                before = np.ones((1, 1, 1), dtype=dt)
+                           np.zeros((1, 1, 3), dtype=np.uint8)]:
+                before = np.ones((1, 1, 1, 1), dtype=dt)
                 after = _norm_and_invert(before, images=images)
                 assert ia.is_np_array(after)
-                assert after.shape == (1, 1, 1)
+                assert after.shape == (1, 1, 1, 1)
                 assert after.dtype.name == dt.name
                 assert np.array_equal(after, before)
 
         # ----
-        # single SegmentationMapOnImage
+        # single SegmentationMapsOnImage
         # ----
-        before = ia.SegmentationMapOnImage(
-                     np.zeros((1, 1), dtype=np.int32) + 1,
-                     shape=(1, 1, 3),
-                     nb_classes=2)
+        before = ia.SegmentationMapsOnImage(
+                     np.zeros((1, 1, 1), dtype=np.int32) + 1,
+                     shape=(1, 1, 3))
         after = _norm_and_invert(before, images=None)
-        assert isinstance(after, ia.SegmentationMapOnImage)
+        assert isinstance(after, ia.SegmentationMapsOnImage)
         assert after.shape == before.shape
         assert np.array_equal(after.arr, before.arr)
 
@@ -204,27 +203,26 @@ class TestNormalization(unittest.TestCase):
         # ----
         # iterable of arrays
         # ----
-        for dt in [np.dtype("int32"), np.dtype("uint32"), np.dtype(bool)]:
+        for dt in [np.dtype("int32"), np.dtype("uint16"), np.dtype(bool)]:
             for images in [[np.zeros((1, 1, 3), dtype=np.uint8)],
                            np.zeros((1, 1, 1, 3), dtype=np.uint8)]:
-                before = [np.ones((1, 1), dtype=dt)]
+                before = [np.ones((1, 1, 1), dtype=dt)]
                 after = _norm_and_invert(before, images=images)
                 assert isinstance(after, list)
                 assert len(after) == 1
-                assert after[0].shape == (1, 1)
+                assert after[0].shape == (1, 1, 1)
                 assert after[0].dtype.name == dt.name
                 assert np.array_equal(after[0], before[0])
 
         # ----
-        # iterable of SegmentationMapOnImage
+        # iterable of SegmentationMapsOnImage
         # ----
-        before = [ia.SegmentationMapOnImage(
-                    np.zeros((1, 1), dtype=np.int32) + 1,
-                    shape=(1, 1, 3),
-                    nb_classes=2)]
+        before = [ia.SegmentationMapsOnImage(
+                    np.zeros((1, 1, 1), dtype=np.int32) + 1,
+                    shape=(1, 1, 3))]
         after = _norm_and_invert(before, images=None)
         assert isinstance(after, list)
-        assert isinstance(after[0], ia.SegmentationMapOnImage)
+        assert isinstance(after[0], ia.SegmentationMapsOnImage)
         assert after[0].shape == before[0].shape
         assert np.allclose(after[0].arr, before[0].arr)
 
@@ -1199,22 +1197,22 @@ class TestNormalization(unittest.TestCase):
         # ----
         # array
         # ----
-        for dt in [np.dtype("int32"), np.dtype("uint32"), np.dtype(bool)]:
+        for dt in [np.dtype("int32"), np.dtype("uint16"), np.dtype(bool)]:
             segmaps_norm = normalization.normalize_segmentation_maps(
-                np.zeros((1, 1, 1), dtype=dt) + 1,
+                np.zeros((1, 1, 1, 1), dtype=dt) + 1,
                 shapes=[np.zeros((1, 1, 3), dtype=np.uint8)]
             )
             assert isinstance(segmaps_norm, list)
-            assert isinstance(segmaps_norm[0], ia.SegmentationMapOnImage)
-            assert np.allclose(segmaps_norm[0].arr[..., 1], 1)
+            assert isinstance(segmaps_norm[0], ia.SegmentationMapsOnImage)
+            assert np.allclose(segmaps_norm[0].arr[..., 0], 1)
 
             segmaps_norm = normalization.normalize_segmentation_maps(
-                np.zeros((1, 1, 1), dtype=dt) + 1,
+                np.zeros((1, 1, 1, 1), dtype=dt) + 1,
                 shapes=np.zeros((1, 1, 1, 3), dtype=np.uint8)
             )
             assert isinstance(segmaps_norm, list)
-            assert isinstance(segmaps_norm[0], ia.SegmentationMapOnImage)
-            assert np.allclose(segmaps_norm[0].arr[..., 1], 1)
+            assert isinstance(segmaps_norm[0], ia.SegmentationMapsOnImage)
+            assert np.allclose(segmaps_norm[0].arr[..., 0], 1)
 
             # --> segmaps for too many images
             with self.assertRaises(ValueError):
@@ -1238,18 +1236,17 @@ class TestNormalization(unittest.TestCase):
                 )
 
         # ----
-        # single SegmentationMapOnImage
+        # single SegmentationMapsOnImage
         # ----
         segmaps_norm = normalization.normalize_segmentation_maps(
-            ia.SegmentationMapOnImage(
-                np.zeros((1, 1), dtype=np.int32) + 1,
-                shape=(1, 1, 3),
-                nb_classes=2),
+            ia.SegmentationMapsOnImage(
+                np.zeros((1, 1, 1), dtype=np.int32) + 1,
+                shape=(1, 1, 3)),
             shapes=None
         )
         assert isinstance(segmaps_norm, list)
-        assert isinstance(segmaps_norm[0], ia.SegmentationMapOnImage)
-        assert np.allclose(segmaps_norm[0].arr[..., 1], 0 + 1)
+        assert isinstance(segmaps_norm[0], ia.SegmentationMapsOnImage)
+        assert np.allclose(segmaps_norm[0].arr[..., 0], 0 + 1)
 
         # ----
         # empty iterable
@@ -1262,29 +1259,29 @@ class TestNormalization(unittest.TestCase):
         # ----
         # iterable of arrays
         # ----
-        for dt in [np.dtype("int32"), np.dtype("uint32"), np.dtype(bool)]:
+        for dt in [np.dtype("int32"), np.dtype("uint16"), np.dtype(bool)]:
             segmaps_norm = normalization.normalize_segmentation_maps(
-                [np.zeros((1, 1), dtype=dt) + 1],
+                [np.zeros((1, 1, 1), dtype=dt) + 1],
                 shapes=[np.zeros((1, 1, 3), dtype=np.uint8)]
             )
             assert isinstance(segmaps_norm, list)
-            assert isinstance(segmaps_norm[0], ia.SegmentationMapOnImage)
-            assert np.allclose(segmaps_norm[0].arr[..., 1], 1)
+            assert isinstance(segmaps_norm[0], ia.SegmentationMapsOnImage)
+            assert np.allclose(segmaps_norm[0].arr[..., 0], 1)
 
             segmaps_norm = normalization.normalize_segmentation_maps(
-                [np.zeros((1, 1), dtype=dt) + 1],
+                [np.zeros((1, 1, 1), dtype=dt) + 1],
                 shapes=np.zeros((1, 1, 1, 3), dtype=np.uint8)
             )
             assert isinstance(segmaps_norm, list)
-            assert isinstance(segmaps_norm[0], ia.SegmentationMapOnImage)
-            assert np.allclose(segmaps_norm[0].arr[..., 1], 1)
+            assert isinstance(segmaps_norm[0], ia.SegmentationMapsOnImage)
+            assert np.allclose(segmaps_norm[0].arr[..., 0], 1)
 
-            # --> heatmaps for too many images
+            # --> segmaps for too many images
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
                     [
-                        np.zeros((1, 1), dtype=np.int32) + 1,
-                        np.zeros((1, 1), dtype=np.int32) + 1
+                        np.zeros((1, 1, 1), dtype=np.int32) + 1,
+                        np.zeros((1, 1, 1), dtype=np.int32) + 1
                     ],
                     shapes=[np.zeros((1, 1, 3), dtype=np.uint8)]
                 )
@@ -1292,37 +1289,36 @@ class TestNormalization(unittest.TestCase):
             # --> too few segmaps
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    [np.zeros((1, 1), dtype=np.int32) + 1],
+                    [np.zeros((1, 1, 1), dtype=np.int32) + 1],
                     shapes=np.zeros((2, 1, 1, 3), dtype=np.uint8)
                 )
 
             # --> images None
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    [np.zeros((1, 1), dtype=np.int32) + 1],
+                    [np.zeros((1, 1, 1), dtype=np.int32) + 1],
                     shapes=None
                 )
 
             # --> wrong number of dimensions
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    [np.zeros((1, 1, 1), dtype=np.int32) + 1],
+                    [np.zeros((1, 1, 1, 1), dtype=np.int32) + 1],
                     shapes=np.zeros((1, 1, 1, 3), dtype=np.uint8)
                 )
 
         # ----
-        # iterable of SegmentationMapOnImage
+        # iterable of SegmentationMapsOnImage
         # ----
         segmaps_norm = normalization.normalize_segmentation_maps(
-            [ia.SegmentationMapOnImage(
-                np.zeros((1, 1), dtype=np.int32) + 1,
-                shape=(1, 1, 3),
-                nb_classes=2)],
+            [ia.SegmentationMapsOnImage(
+                np.zeros((1, 1, 1), dtype=np.int32) + 1,
+                shape=(1, 1, 3))],
             shapes=None
         )
         assert isinstance(segmaps_norm, list)
-        assert isinstance(segmaps_norm[0], ia.SegmentationMapOnImage)
-        assert np.allclose(segmaps_norm[0].arr[..., 1], 1)
+        assert isinstance(segmaps_norm[0], ia.SegmentationMapsOnImage)
+        assert np.allclose(segmaps_norm[0].arr[..., 0], 1)
 
     def test_normalize_keypoints(self):
         def _assert_single_image_expected(inputs):
@@ -2872,7 +2868,7 @@ class TestNormalization(unittest.TestCase):
         cls_names = ["Keypoint", "KeypointsOnImage",
                      "BoundingBox", "BoundingBoxesOnImage",
                      "Polygon", "PolygonsOnImage",
-                     "HeatmapsOnImage", "SegmentationMapOnImage"]
+                     "HeatmapsOnImage", "SegmentationMapsOnImage"]
         clss = [
             ia.Keypoint(x=1, y=1),
             ia.KeypointsOnImage([], shape=(1, 1, 3)),
@@ -2882,8 +2878,8 @@ class TestNormalization(unittest.TestCase):
             ia.PolygonsOnImage([], shape=(1,)),
             ia.HeatmapsOnImage(np.zeros((1, 1, 1), dtype=np.float32),
                                shape=(1, 1, 3)),
-            ia.SegmentationMapOnImage(np.zeros((1, 1, 1), dtype=np.int32),
-                                      shape=(1, 1, 3), nb_classes=1)
+            ia.SegmentationMapsOnImage(np.zeros((1, 1, 1), dtype=np.int32),
+                                       shape=(1, 1, 3))
         ]
         for cls_name, cls in zip(cls_names, clss):
             ntype = normalization._nonempty_info_to_type_str(
@@ -2969,13 +2965,12 @@ class TestNormalization(unittest.TestCase):
             assert ntype == "array[%s]" % (name,)
 
         ntype = normalization.estimate_segmaps_norm_type(
-            ia.SegmentationMapOnImage(
+            ia.SegmentationMapsOnImage(
                 np.zeros((1, 1, 1), dtype=np.int32),
-                shape=(1, 1, 1),
-                nb_classes=1
+                shape=(1, 1, 1)
             )
         )
-        assert ntype == "SegmentationMapOnImage"
+        assert ntype == "SegmentationMapsOnImage"
 
         ntype = normalization.estimate_segmaps_norm_type([])
         assert ntype == "iterable[empty]"
@@ -2985,11 +2980,10 @@ class TestNormalization(unittest.TestCase):
         assert ntype == "iterable-array[int]"
 
         ntype = normalization.estimate_segmaps_norm_type([
-            ia.SegmentationMapOnImage(np.zeros((1, 1, 1), dtype=np.int32),
-                                      shape=(1, 1, 1),
-                                      nb_classes=1)
+            ia.SegmentationMapsOnImage(np.zeros((1, 1, 1), dtype=np.int32),
+                                       shape=(1, 1, 1))
         ])
-        assert ntype == "iterable-SegmentationMapOnImage"
+        assert ntype == "iterable-SegmentationMapsOnImage"
 
         # --
         # error cases
@@ -3014,10 +3008,9 @@ class TestNormalization(unittest.TestCase):
         # list of list of SegMap, only list of SegMap is max
         with self.assertRaises(AssertionError):
             _ntype = normalization.estimate_segmaps_norm_type([
-                [ia.SegmentationMapOnImage(
-                    np.zeros((1, 1, 1), dtype=np.int32),
-                    shape=(1, 1, 1),
-                    nb_classes=1)]
+                [ia.SegmentationMapsOnImage(
+                    np.zeros((1, 1, 1, 1), dtype=np.int32),
+                    shape=(1, 1, 1))]
             ])
 
     def test_estimate_keypoints_norm_type(self):

--- a/test/augmentables/test_normalization.py
+++ b/test/augmentables/test_normalization.py
@@ -1198,8 +1198,11 @@ class TestNormalization(unittest.TestCase):
         # array
         # ----
         for dt in [np.dtype("int32"), np.dtype("uint16"), np.dtype(bool)]:
+            # NOTE: use np.full(shape, 1, dtype=dt) here and below instead of
+            # np.zeros(shape, dtype=dt) + 1, because the latter one converts
+            # dtype bool_ to int64.
             segmaps_norm = normalization.normalize_segmentation_maps(
-                np.zeros((1, 1, 1, 1), dtype=dt) + 1,
+                np.full((1, 1, 1, 1), 1, dtype=dt),
                 shapes=[np.zeros((1, 1, 3), dtype=np.uint8)]
             )
             assert isinstance(segmaps_norm, list)
@@ -1207,7 +1210,7 @@ class TestNormalization(unittest.TestCase):
             assert np.allclose(segmaps_norm[0].arr[..., 0], 1)
 
             segmaps_norm = normalization.normalize_segmentation_maps(
-                np.zeros((1, 1, 1, 1), dtype=dt) + 1,
+                np.full((1, 1, 1, 1), 1, dtype=dt),
                 shapes=np.zeros((1, 1, 1, 3), dtype=np.uint8)
             )
             assert isinstance(segmaps_norm, list)
@@ -1217,21 +1220,21 @@ class TestNormalization(unittest.TestCase):
             # --> segmaps for too many images
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    np.zeros((2, 1, 1), dtype=dt) + 1,
+                    np.full((2, 1, 1), 1, dtype=dt),
                     shapes=[np.zeros((1, 1, 3), dtype=np.uint8)]
                 )
 
             # --> too few segmaps
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    np.zeros((1, 1, 1), dtype=dt) + 1,
+                    np.full((1, 1, 1), 1, dtype=dt),
                     shapes=np.zeros((2, 1, 1, 3), dtype=np.uint8)
                 )
 
             # --> images None
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    np.zeros((1, 1, 1), dtype=dt) + 1,
+                    np.full((1, 1, 1), 1, dtype=dt),
                     shapes=None
                 )
 
@@ -1240,7 +1243,7 @@ class TestNormalization(unittest.TestCase):
         # ----
         segmaps_norm = normalization.normalize_segmentation_maps(
             ia.SegmentationMapsOnImage(
-                np.zeros((1, 1, 1), dtype=np.int32) + 1,
+                np.full((1, 1, 1), 1, dtype=np.int32),
                 shape=(1, 1, 3)),
             shapes=None
         )
@@ -1261,7 +1264,7 @@ class TestNormalization(unittest.TestCase):
         # ----
         for dt in [np.dtype("int32"), np.dtype("uint16"), np.dtype(bool)]:
             segmaps_norm = normalization.normalize_segmentation_maps(
-                [np.zeros((1, 1, 1), dtype=dt) + 1],
+                [np.full((1, 1, 1), 1, dtype=dt)],
                 shapes=[np.zeros((1, 1, 3), dtype=np.uint8)]
             )
             assert isinstance(segmaps_norm, list)
@@ -1269,7 +1272,7 @@ class TestNormalization(unittest.TestCase):
             assert np.allclose(segmaps_norm[0].arr[..., 0], 1)
 
             segmaps_norm = normalization.normalize_segmentation_maps(
-                [np.zeros((1, 1, 1), dtype=dt) + 1],
+                [np.full((1, 1, 1), 1, dtype=dt)],
                 shapes=np.zeros((1, 1, 1, 3), dtype=np.uint8)
             )
             assert isinstance(segmaps_norm, list)
@@ -1280,8 +1283,8 @@ class TestNormalization(unittest.TestCase):
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
                     [
-                        np.zeros((1, 1, 1), dtype=np.int32) + 1,
-                        np.zeros((1, 1, 1), dtype=np.int32) + 1
+                        np.full((1, 1, 1), 1, dtype=np.int32),
+                        np.full((1, 1, 1), 1, dtype=np.int32)
                     ],
                     shapes=[np.zeros((1, 1, 3), dtype=np.uint8)]
                 )
@@ -1289,21 +1292,21 @@ class TestNormalization(unittest.TestCase):
             # --> too few segmaps
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    [np.zeros((1, 1, 1), dtype=np.int32) + 1],
+                    [np.full((1, 1, 1), 1, dtype=np.int32)],
                     shapes=np.zeros((2, 1, 1, 3), dtype=np.uint8)
                 )
 
             # --> images None
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    [np.zeros((1, 1, 1), dtype=np.int32) + 1],
+                    [np.full((1, 1, 1), 1, dtype=np.int32)],
                     shapes=None
                 )
 
             # --> wrong number of dimensions
             with self.assertRaises(ValueError):
                 _segmaps_norm = normalization.normalize_segmentation_maps(
-                    [np.zeros((1, 1, 1, 1), dtype=np.int32) + 1],
+                    [np.full((1, 1, 1, 1), 1, dtype=np.int32)],
                     shapes=np.zeros((1, 1, 1, 3), dtype=np.uint8)
                 )
 
@@ -1312,7 +1315,7 @@ class TestNormalization(unittest.TestCase):
         # ----
         segmaps_norm = normalization.normalize_segmentation_maps(
             [ia.SegmentationMapsOnImage(
-                np.zeros((1, 1, 1), dtype=np.int32) + 1,
+                np.full((1, 1, 1), 1, dtype=np.int32),
                 shape=(1, 1, 3))],
             shapes=None
         )

--- a/test/augmentables/test_segmaps.py
+++ b/test/augmentables/test_segmaps.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import itertools
 import time
 import warnings
 import sys
@@ -24,130 +25,185 @@ import imgaug as ia
 def main():
     time_start = time.time()
 
-    test_SegmentationMapOnImage_bool()
-    test_SegmentationMapOnImage_get_arr_int()
-    # test_SegmentationMapOnImage_get_arr_bool()
-    test_SegmentationMapOnImage_draw()
-    test_SegmentationMapOnImage_draw_on_image()
-    test_SegmentationMapOnImage_pad()
-    test_SegmentationMapOnImage_pad_to_aspect_ratio()
-    test_SegmentationMapOnImage_scale()
-    test_SegmentationMapOnImage_to_heatmaps()
-    test_SegmentationMapOnImage_from_heatmaps()
-    test_SegmentationMapOnImage_copy()
-    test_SegmentationMapOnImage_deepcopy()
+    test_SegmentationMapsOnImage___init__()
+    test_SegmentationMapsOnImage_bool()
+    test_SegmentationMapsOnImage_get_arr()
+    test_SegmentationMapsOnImage_draw()
+    test_SegmentationMapsOnImage_draw_on_image()
+    test_SegmentationMapsOnImage_pad()
+    test_SegmentationMapsOnImage_pad_to_aspect_ratio()
+    test_SegmentationMapsOnImage_resize()
+    test_SegmentationMapsOnImage_copy()
+    test_SegmentationMapsOnImage_deepcopy()
 
     time_end = time.time()
     print("<%s> Finished without errors in %.4fs." % (__file__, time_end - time_start,))
 
 
-def test_SegmentationMapOnImage_bool():
-    # Test for #189 (boolean mask inputs into SegmentationMapOnImage not working)
-    arr = np.array([
-        [0, 0, 0],
-        [0, 1, 0],
-        [0, 0, 0]
-    ], dtype=bool)
-    assert arr.dtype.type == np.bool_
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3))
-    observed = segmap.get_arr_int()
-    assert observed.dtype.type == np.int32
-    assert np.array_equal(arr, observed)
+def test_SegmentationMapsOnImage___init__():
+    dtypes = ["int8", "int16", "int32", "uint8", "uint16"]
+    ndims = [2, 3]
+    img_shapes = [(3, 3), (3, 3, 3), (4, 5, 3)]
 
-    arr = np.array([
-        [0, 0, 0],
-        [0, 1, 0],
-        [0, 0, 0]
-    ], dtype=np.bool)
-    assert arr.dtype.type == np.bool_
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3))
-    observed = segmap.get_arr_int()
-    assert observed.dtype.type == np.int32
-    assert np.array_equal(arr, observed)
+    # int and uint dtypes
+    for dtype, ndim, img_shape in itertools.product(dtypes, ndims, img_shapes):
+        dtype = np.dtype(dtype)
+        shape = (3, 3) if ndim == 2 else (3, 3, 1)
+        arr = np.array([
+            [0, 0, 1],
+            [0, 2, 1],
+            [1, 3, 1]
+        ], dtype=dtype).reshape(shape)
+        segmap = ia.SegmentationMapsOnImage(arr, shape=img_shape)
+        assert segmap.shape == img_shape
+        assert segmap.arr.dtype.name == "int32"
+        assert segmap.arr.shape == (3, 3, 1)
+        assert np.array_equal(segmap.arr,
+                              arr.reshape((3, 3, 1)).astype(np.int32))
 
+        if ndim == 3:
+            arr = np.array([
+                [0, 0, 1],
+                [0, 2, 1],
+                [1, 3, 1]
+            ], dtype=dtype).reshape((3, 3, 1))
+            arr = np.tile(arr, (1, 1, 5))
+            segmap = ia.SegmentationMapsOnImage(arr, shape=img_shape)
+            assert segmap.shape == img_shape
+            assert segmap.arr.dtype.name == "int32"
+            assert segmap.arr.shape == (3, 3, 5)
+            assert np.array_equal(segmap.arr, arr.astype(np.int32))
 
-def test_SegmentationMapOnImage_get_arr_int():
-    arr = np.int32([
-        [0, 0, 1],
-        [0, 2, 1],
-        [1, 3, 1]
-    ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3), nb_classes=4)
-    observed = segmap.get_arr_int()
-    assert observed.dtype.type == np.int32
-    assert np.array_equal(arr, observed)
+    # bool dtypes
+    for ndim in ndims:
+        shape = (3, 3) if ndim == 2 else (3, 3, 1)
+        arr = np.array([
+            [0, 0, 1],
+            [0, 1, 1],
+            [1, 1, 1]
+        ], dtype=bool).reshape(shape)
+        segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
+        assert segmap.shape == (3, 3)
+        assert segmap.arr.dtype.name == "int32"
+        assert segmap.arr.shape == (3, 3, 1)
+        assert np.array_equal(segmap.arr,
+                              arr.reshape((3, 3, 1)).astype(np.int32))
 
-    arr_c0 = np.float32([
-        [0.1, 0.1, 0.1],
-        [0.1, 0.9, 0.1],
-        [0.0, 0.1, 0.0]
-    ])
-    arr_c1 = np.float32([
-        [0.2, 1.0, 0.2],
-        [0.2, 0.8, 0.2],
-        [0.0, 0.0, 0.0]
-    ])
-    arr_c2 = np.float32([
-        [0.0, 0.0, 0.0],
-        [0.3, 0.7, 0.3],
-        [0.1, 0.0, 0.0001]
-    ])
-    arr = np.concatenate([
-        arr_c0[..., np.newaxis],
-        arr_c1[..., np.newaxis],
-        arr_c2[..., np.newaxis]
-    ], axis=2)
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3))
-    observed = segmap.get_arr_int()
-    expected = np.int32([
-        [2, 2, 2],
-        [3, 1, 3],
-        [3, 1, 0]
-    ])
-    assert observed.dtype.type == np.int32
-    assert np.array_equal(observed, expected)
+        if ndim == 3:
+            arr = np.array([
+                [0, 0, 1],
+                [0, 1, 1],
+                [1, 1, 1]
+            ], dtype=bool).reshape((3, 3, 1))
+            arr = np.tile(arr, (1, 1, 5))
+            segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
+            assert segmap.shape == (3, 3)
+            assert segmap.arr.dtype.name == "int32"
+            assert segmap.arr.shape == (3, 3, 5)
+            assert np.array_equal(segmap.arr, arr.astype(np.int32))
 
+    # uint32 is not allowed
     got_exception = False
     try:
-        _ = segmap.get_arr_int(background_class_id=2)
+        arr = np.array([
+            [0, 0, 1],
+            [0, 2, 1],
+            [1, 3, 1]
+        ], dtype=np.uint32)
+        _segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3, 3))
     except Exception as exc:
-        assert "The background class id may only be changed if " in str(exc)
+        assert "only uint8 and uint16 " in str(exc)
         got_exception = True
     assert got_exception
 
-    observed = segmap.get_arr_int(background_threshold=0.21)
-    expected = np.int32([
-        [0, 2, 0],
-        [3, 1, 3],
-        [0, 0, 0]
-    ])
-    assert observed.dtype.type == np.int32
-    assert np.array_equal(observed, expected)
+
+def test_SegmentationMapsOnImage_bool():
+    # Test for #189 (boolean mask inputs into SegmentationMapsOnImage not working)
+    for dt in [bool, np.bool]:
+        arr = np.array([
+            [0, 0, 0],
+            [0, 1, 0],
+            [0, 0, 0]
+        ], dtype=dt)
+        assert arr.dtype.kind == "b"
+        segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
+        assert np.array_equal(
+            segmap.arr,
+            np.int32([
+                [0, 0, 0],
+                [0, 1, 0],
+                [0, 0, 0]
+            ])[:, :, np.newaxis]
+        )
+        assert segmap.get_arr().dtype.name == arr.dtype.name
+        assert np.array_equal(segmap.get_arr(), arr)
 
 
-def test_SegmentationMapOnImage_draw():
+def test_SegmentationMapsOnImage_get_arr():
+    dtypes = ["int8", "int16", "int32", "uint8", "uint16"]
+    ndims = [2, 3]
+
+    for dtype, ndim in itertools.product(dtypes, ndims):
+        dtype = np.dtype(dtype)
+        shape = (3, 3) if ndim == 2 else (3, 3, 1)
+        arr = np.array([
+            [0, 0, 1],
+            [0, 2, 1],
+            [1, 3, 1]
+        ], dtype=dtype).reshape(shape)
+        segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
+        observed = segmap.get_arr()
+        assert segmap.arr.dtype.name == "int32"
+        assert segmap.arr.ndim == 3
+        assert np.array_equal(observed, arr)
+        assert observed.dtype.name == dtype.name
+        assert observed.ndim == ndim
+        assert np.array_equal(observed, arr)
+
+    for ndim in ndims:
+        shape = (3, 3) if ndim == 2 else (3, 3, 1)
+        arr = np.array([
+            [0, 0, 1],
+            [0, 1, 1],
+            [1, 1, 1]
+        ], dtype=bool).reshape(shape)
+        segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
+        observed = segmap.get_arr()
+        assert segmap.arr.dtype.name == "int32"
+        assert segmap.arr.ndim == 3
+        assert np.array_equal(observed, arr)
+        assert observed.dtype.kind == "b"
+        assert observed.ndim == ndim
+        assert np.array_equal(observed, arr)
+
+
+def test_SegmentationMapsOnImage_draw():
     arr = np.int32([
         [0, 1, 1],
         [0, 1, 1],
         [0, 1, 1]
     ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3), nb_classes=2)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
 
     # simple example with 2 classes
     observed = segmap.draw()
-    col0 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[0]
-    col1 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[1]
+    col0 = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[0]
+    col1 = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[1]
     expected = np.uint8([
         [col0, col1, col1],
         [col0, col1, col1],
         [col0, col1, col1]
     ])
-    assert np.array_equal(observed, expected)
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert np.array_equal(observed[0], expected)
 
     # same example, with resizing to 2x the size
     observed = segmap.draw(size=(6, 6))
     expected = ia.imresize_single_image(expected, (6, 6), interpolation="nearest")
-    assert np.array_equal(observed, expected)
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert np.array_equal(observed[0], expected)
 
     # custom choice of colors
     col0 = (10, 10, 10)
@@ -158,69 +214,63 @@ def test_SegmentationMapOnImage_draw():
         [col0, col1, col1],
         [col0, col1, col1]
     ])
-    assert np.array_equal(observed, expected)
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert np.array_equal(observed[0], expected)
 
-    # background_threshold, background_class and foreground mask
-    arr_c0 = np.float32([
-        [0, 0, 0],
-        [1.0, 0, 0],
-        [0, 0, 0]
-    ])
-    arr_c1 = np.float32([
+    # test segmentation maps with multiple channels
+    arr_channel_1 = np.int32([
+        [0, 1, 5],
         [0, 1, 1],
-        [0, 1, 1],
-        [0.1, 1, 1]
+        [0, 4, 1]
     ])
-    arr = np.concatenate([
-        arr_c0[..., np.newaxis],
-        arr_c1[..., np.newaxis]
-    ], axis=2)
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3))
-
-    observed, observed_fg = segmap.draw(background_threshold=0.01, return_foreground_mask=True)
-    col0 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[0]
-    col1 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[1]
-    col2 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[2]
-    expected = np.uint8([
-        [col0, col2, col2],
-        [col1, col2, col2],
-        [col2, col2, col2]
+    arr_channel_2 = np.int32([
+        [1, 1, 0],
+        [2, 2, 0],
+        [1, 1, 0]
     ])
-    expected_fg = np.array([
-        [False, True, True],
-        [True, True, True],
-        [True, True, True]
-    ], dtype=np.bool)
-    assert np.array_equal(observed, expected)
-    assert np.array_equal(observed_fg, expected_fg)
-
-    # background_threshold, background_class and foreground mask
-    # here with higher threshold so that bottom left pixel switches to background
-    observed, observed_fg = segmap.draw(background_threshold=0.11, return_foreground_mask=True)
-    col0 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[0]
-    col1 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[1]
-    col2 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[2]
-    expected = np.uint8([
-        [col0, col2, col2],
-        [col1, col2, col2],
-        [col0, col2, col2]
+    arr_channel_3 = np.int32([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 3]
     ])
-    expected_fg = np.array([
-        [False, True, True],
-        [True, True, True],
-        [False, True, True]
-    ], dtype=np.bool)
-    assert np.array_equal(observed, expected)
-    assert np.array_equal(observed_fg, expected_fg)
+    arr_multi = np.stack(
+        [arr_channel_1, arr_channel_2, arr_channel_3],
+        axis=-1)
+
+    col = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS
+    expected_channel_1 = np.uint8([
+        [col[0], col[1], col[5]],
+        [col[0], col[1], col[1]],
+        [col[0], col[4], col[1]]
+    ])
+    expected_channel_2 = np.uint8([
+        [col[1], col[1], col[0]],
+        [col[2], col[2], col[0]],
+        [col[1], col[1], col[0]]
+    ])
+    expected_channel_3 = np.uint8([
+        [col[1], col[0], col[0]],
+        [col[0], col[1], col[0]],
+        [col[0], col[0], col[3]]
+    ])
+
+    segmap = ia.SegmentationMapsOnImage(arr_multi, shape=(3, 3, 3))
+    observed = segmap.draw()
+    assert isinstance(observed, list)
+    assert len(observed) == 3
+    assert np.array_equal(observed[0], expected_channel_1)
+    assert np.array_equal(observed[1], expected_channel_2)
+    assert np.array_equal(observed[2], expected_channel_3)
 
 
-def test_SegmentationMapOnImage_draw_on_image():
+def test_SegmentationMapsOnImage_draw_on_image():
     arr = np.int32([
         [0, 1, 1],
         [0, 1, 1],
         [0, 1, 1]
     ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3), nb_classes=2)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
 
     image = np.uint8([
         [0, 10, 20],
@@ -231,64 +281,119 @@ def test_SegmentationMapOnImage_draw_on_image():
 
     # only image visible
     observed = segmap.draw_on_image(image, alpha=0)
-    assert np.array_equal(observed, image)
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert np.array_equal(observed[0], image)
 
     # only segmap visible
     observed = segmap.draw_on_image(image, alpha=1.0, draw_background=True)
-    col0 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[0]
-    col1 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[1]
+    col0 = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[0]
+    col1 = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[1]
     expected = np.uint8([
         [col0, col1, col1],
         [col0, col1, col1],
         [col0, col1, col1]
     ])
-    assert np.array_equal(observed, expected)
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert np.array_equal(observed[0], expected)
 
     # only segmap visible - in foreground
     observed = segmap.draw_on_image(image, alpha=1.0, draw_background=False)
-    col1 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[1]
+    col1 = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[1]
     expected = np.uint8([
         [image[0, 0, :], col1, col1],
         [image[1, 0, :], col1, col1],
         [image[2, 0, :], col1, col1]
     ])
-    assert np.array_equal(observed, expected)
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert np.array_equal(observed[0], expected)
+
+    # only segmap visible in foreground + multiple channels in segmap
+    arr_channel_1 = np.int32([
+        [0, 1, 5],
+        [0, 1, 1],
+        [0, 4, 1]
+    ])
+    arr_channel_2 = np.int32([
+        [1, 1, 0],
+        [2, 2, 0],
+        [1, 1, 0]
+    ])
+    arr_channel_3 = np.int32([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 3]
+    ])
+    arr_multi = np.stack(
+        [arr_channel_1, arr_channel_2, arr_channel_3],
+        axis=-1)
+
+    col = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS
+    expected_channel_1 = np.uint8([
+        [image[0, 0, :], col[1], col[5]],
+        [image[1, 0, :], col[1], col[1]],
+        [image[2, 0, :], col[4], col[1]]
+    ])
+    expected_channel_2 = np.uint8([
+        [col[1], col[1], image[0, 2, :]],
+        [col[2], col[2], image[1, 2, :]],
+        [col[1], col[1], image[2, 2, :]]
+    ])
+    expected_channel_3 = np.uint8([
+        [col[1], image[0, 1, :], image[0, 2, :]],
+        [image[1, 0, :], col[1], image[1, 2, :]],
+        [image[2, 0, :], image[2, 1, :], col[3]]
+    ])
+
+    segmap_multi = ia.SegmentationMapsOnImage(arr_multi, shape=(3, 3, 3))
+    observed = segmap_multi.draw_on_image(image, alpha=1.0, draw_background=False)
+    assert isinstance(observed, list)
+    assert len(observed) == 3
+    assert np.array_equal(observed[0], expected_channel_1)
+    assert np.array_equal(observed[1], expected_channel_2)
+    assert np.array_equal(observed[2], expected_channel_3)
 
     # overlay without background drawn
     a1 = 0.7
     a0 = 1.0 - a1
     observed = segmap.draw_on_image(image, alpha=a1, draw_background=False)
-    col1 = np.uint8(ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[1])
+    col1 = np.uint8(ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[1])
     expected = np.float32([
         [image[0, 0, :], a0*image[0, 1, :] + a1*col1, a0*image[0, 2, :] + a1*col1],
         [image[1, 0, :], a0*image[1, 1, :] + a1*col1, a0*image[1, 2, :] + a1*col1],
         [image[2, 0, :], a0*image[2, 1, :] + a1*col1, a0*image[2, 2, :] + a1*col1]
     ])
-    d_max = np.max(np.abs(observed.astype(np.float32) - expected))
-    assert observed.shape == expected.shape
+    d_max = np.max(np.abs(observed[0].astype(np.float32) - expected))
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert observed[0].shape == expected.shape
     assert d_max <= 1.0 + 1e-4
 
     # overlay with background drawn
     a1 = 0.7
     a0 = 1.0 - a1
     observed = segmap.draw_on_image(image, alpha=a1, draw_background=True)
-    col0 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[0]
-    col1 = ia.SegmentationMapOnImage.DEFAULT_SEGMENT_COLORS[1]
+    col0 = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[0]
+    col1 = ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[1]
     expected = np.uint8([
         [col0, col1, col1],
         [col0, col1, col1],
         [col0, col1, col1]
     ])
     expected = a0 * image + a1 * expected
-    d_max = np.max(np.abs(observed.astype(np.float32) - expected.astype(np.float32)))
-    assert observed.shape == expected.shape
+    d_max = np.max(np.abs(observed[0].astype(np.float32) - expected.astype(np.float32)))
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert observed[0].shape == expected.shape
     assert d_max <= 1.0 + 1e-4
 
     # resizing of segmap to image
     arr = np.int32([
         [0, 1, 1]
     ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3), nb_classes=2)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
 
     image = np.uint8([
         [0, 10, 20],
@@ -306,8 +411,10 @@ def test_SegmentationMapOnImage_draw_on_image():
         [col0, col1, col1]
     ])
     expected = a0 * image + a1 * expected
-    d_max = np.max(np.abs(observed.astype(np.float32) - expected.astype(np.float32)))
-    assert observed.shape == expected.shape
+    d_max = np.max(np.abs(observed[0].astype(np.float32) - expected.astype(np.float32)))
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert observed[0].shape == expected.shape
     assert d_max <= 1.0 + 1e-4
 
     # resizing of image to segmap
@@ -316,7 +423,7 @@ def test_SegmentationMapOnImage_draw_on_image():
         [0, 1, 1],
         [0, 1, 1]
     ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(1, 3), nb_classes=2)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(1, 3))
 
     image = np.uint8([
         [0, 10, 20]
@@ -333,305 +440,141 @@ def test_SegmentationMapOnImage_draw_on_image():
         [col0, col1, col1]
     ])
     expected = a0 * image_rs + a1 * expected
-    d_max = np.max(np.abs(observed.astype(np.float32) - expected.astype(np.float32)))
-    assert observed.shape == expected.shape
+    d_max = np.max(np.abs(observed[0].astype(np.float32) - expected.astype(np.float32)))
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert observed[0].shape == expected.shape
     assert d_max <= 1.0 + 1e-4
 
 
-def test_SegmentationMapOnImage_pad():
+def test_SegmentationMapsOnImage_pad():
     arr = np.int32([
         [0, 1, 1],
         [0, 2, 1],
         [0, 1, 3]
     ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(3, 3), nb_classes=4)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
 
     segmap_padded = segmap.pad(top=1, right=2, bottom=3, left=4)
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((1, 3), (4, 2), (0, 0)), mode="constant", constant_values=0)
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
 
     segmap_padded = segmap.pad(top=1, right=2, bottom=3, left=4, cval=1.0)
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((1, 3), (4, 2), (0, 0)), mode="constant", constant_values=1.0)
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
 
     segmap_padded = segmap.pad(top=1, right=2, bottom=3, left=4, mode="edge")
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((1, 3), (4, 2), (0, 0)), mode="edge")
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
 
 
-def test_SegmentationMapOnImage_pad_to_aspect_ratio():
+def test_SegmentationMapsOnImage_pad_to_aspect_ratio():
     arr = np.int32([
         [0, 1, 1],
         [0, 2, 1]
     ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 3), nb_classes=3)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(2, 3))
 
     segmap_padded = segmap.pad_to_aspect_ratio(1.0)
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((0, 1), (0, 0), (0, 0)), mode="constant", constant_values=0)
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
 
     segmap_padded = segmap.pad_to_aspect_ratio(1.0, cval=1.0)
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((0, 1), (0, 0), (0, 0)), mode="constant", constant_values=1.0)
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
 
     segmap_padded = segmap.pad_to_aspect_ratio(1.0, mode="edge")
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((0, 1), (0, 0), (0, 0)), mode="edge")
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
 
     segmap_padded = segmap.pad_to_aspect_ratio(0.5)
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((2, 2), (0, 0), (0, 0)), mode="constant", constant_values=0)
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
 
     segmap_padded, pad_amounts = segmap.pad_to_aspect_ratio(0.5, return_pad_amounts=True)
     observed = segmap_padded.arr
     expected = np.pad(segmap.arr, ((2, 2), (0, 0), (0, 0)), mode="constant", constant_values=0)
-    assert np.allclose(observed, expected)
+    assert np.array_equal(observed, expected)
     assert pad_amounts == (2, 0, 2, 0)
 
 
-def test_SegmentationMapOnImage_scale():
+def test_SegmentationMapsOnImage_resize():
     arr = np.int32([
         [0, 1],
         [0, 2]
     ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2), nb_classes=3)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(2, 2))
 
-    segmap_scaled = segmap.resize((4, 4))
-    observed = segmap_scaled.arr
-    expected = np.clip(ia.imresize_single_image(segmap.arr, (4, 4), interpolation="cubic"), 0, 1.0)
-    assert np.allclose(observed, expected)
-    assert np.array_equal(segmap_scaled.get_arr_int(), np.int32([
-        [0, 0, 1, 1],
-        [0, 0, 1, 1],
-        [0, 0, 2, 2],
-        [0, 0, 2, 2],
-    ]))
-
-    segmap_scaled = segmap.resize((4, 4), interpolation="nearest")
-    observed = segmap_scaled.arr
-    expected = ia.imresize_single_image(segmap.arr, (4, 4), interpolation="nearest")
-    assert np.allclose(observed, expected)
-    assert np.array_equal(segmap_scaled.get_arr_int(), np.int32([
-        [0, 0, 1, 1],
-        [0, 0, 1, 1],
-        [0, 0, 2, 2],
-        [0, 0, 2, 2],
-    ]))
-
-    segmap_scaled = segmap.resize(2.0)
-    observed = segmap_scaled.arr
-    expected = np.clip(ia.imresize_single_image(segmap.arr, 2.0, interpolation="cubic"), 0, 1.0)
-    assert np.allclose(observed, expected)
-    assert np.array_equal(segmap_scaled.get_arr_int(), np.int32([
-        [0, 0, 1, 1],
-        [0, 0, 1, 1],
-        [0, 0, 2, 2],
-        [0, 0, 2, 2],
-    ]))
+    for factor in [(4, 4), 2.0]:
+        # TODO also test other interpolation modes
+        segmap_scaled = segmap.resize(factor)
+        observed = segmap_scaled.arr
+        expected = ia.imresize_single_image(segmap.arr, (4, 4), interpolation="nearest")
+        assert np.array_equal(observed, expected)
+        expected = np.int32([
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [0, 0, 2, 2],
+            [0, 0, 2, 2],
+        ]).reshape((4, 4, 1))
+        assert np.array_equal(segmap_scaled.arr, expected)
 
 
-def test_SegmentationMapOnImage_to_heatmaps():
-    arr = np.int32([
-        [0, 1],
-        [0, 2]
-    ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2), nb_classes=3)
-    heatmaps = segmap.to_heatmaps()
-    expected_c0 = np.float32([
-        [1.0, 0.0],
-        [1.0, 0.0]
-    ])
-    expected_c1 = np.float32([
-        [0.0, 1.0],
-        [0.0, 0.0]
-    ])
-    expected_c2 = np.float32([
-        [0.0, 0.0],
-        [0.0, 1.0]
-    ])
-    expected = np.concatenate([
-        expected_c0[..., np.newaxis],
-        expected_c1[..., np.newaxis],
-        expected_c2[..., np.newaxis]
-    ], axis=2)
-    assert np.allclose(heatmaps.arr_0to1, expected)
-
-    # only_nonempty when all are nonempty
-    heatmaps, class_indices = segmap.to_heatmaps(only_nonempty=True)
-    expected_c0 = np.float32([
-        [1.0, 0.0],
-        [1.0, 0.0]
-    ])
-    expected_c1 = np.float32([
-        [0.0, 1.0],
-        [0.0, 0.0]
-    ])
-    expected_c2 = np.float32([
-        [0.0, 0.0],
-        [0.0, 1.0]
-    ])
-    expected = np.concatenate([
-        expected_c0[..., np.newaxis],
-        expected_c1[..., np.newaxis],
-        expected_c2[..., np.newaxis]
-    ], axis=2)
-    assert np.allclose(heatmaps.arr_0to1, expected)
-    assert len(class_indices) == 3
-    assert [idx in class_indices for idx in [0, 1, 2]]
-
-    # only_nonempty when one is empty and two are nonempty
-    arr = np.int32([
-        [0, 2],
-        [0, 2]
-    ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2), nb_classes=3)
-    heatmaps, class_indices = segmap.to_heatmaps(only_nonempty=True)
-    expected_c0 = np.float32([
-        [1.0, 0.0],
-        [1.0, 0.0]
-    ])
-    expected_c2 = np.float32([
-        [0.0, 1.0],
-        [0.0, 1.0]
-    ])
-    expected = np.concatenate([
-        expected_c0[..., np.newaxis],
-        expected_c2[..., np.newaxis]
-    ], axis=2)
-    assert np.allclose(heatmaps.arr_0to1, expected)
-    assert len(class_indices) == 2
-    assert [idx in class_indices for idx in [0, 2]]
-
-    # only_nonempty when all are empty
-    arr_c0 = np.float32([
-        [0.0, 0.0],
-        [0.0, 0.0]
-    ])
-    arr = arr_c0[..., np.newaxis]
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2), nb_classes=3)
-    heatmaps, class_indices = segmap.to_heatmaps(only_nonempty=True)
-    assert heatmaps is None
-    assert len(class_indices) == 0
-
-    # only_nonempty when all are empty and not_none_if_no_nonempty is True
-    arr_c0 = np.float32([
-        [0.0, 0.0],
-        [0.0, 0.0]
-    ])
-    arr = arr_c0[..., np.newaxis]
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2), nb_classes=3)
-    heatmaps, class_indices = segmap.to_heatmaps(only_nonempty=True, not_none_if_no_nonempty=True)
-    assert np.allclose(heatmaps.arr_0to1, np.zeros((2, 2), dtype=np.float32))
-    assert len(class_indices) == 1
-    assert [idx in class_indices for idx in [0]]
-
-
-def test_SegmentationMapOnImage_from_heatmaps():
-    arr_c0 = np.float32([
-        [1.0, 0.0],
-        [1.0, 0.0]
-    ])
-    arr_c1 = np.float32([
-        [0.0, 1.0],
-        [0.0, 1.0]
-    ])
-    arr = np.concatenate([arr_c0[..., np.newaxis], arr_c1[..., np.newaxis]], axis=2)
-    heatmaps = ia.HeatmapsOnImage.from_0to1(arr, shape=(2, 2))
-
-    segmap = ia.SegmentationMapOnImage.from_heatmaps(heatmaps)
-    assert np.allclose(segmap.arr, arr)
-
-    # with class_indices
-    arr_c0 = np.float32([
-        [1.0, 0.0],
-        [1.0, 0.0]
-    ])
-    arr_c2 = np.float32([
-        [0.0, 1.0],
-        [0.0, 1.0]
-    ])
-    arr = np.concatenate([arr_c0[..., np.newaxis], arr_c2[..., np.newaxis]], axis=2)
-    heatmaps = ia.HeatmapsOnImage.from_0to1(arr, shape=(2, 2))
-
-    segmap = ia.SegmentationMapOnImage.from_heatmaps(heatmaps, class_indices=[0, 2], nb_classes=4)
-    expected_c0 = np.copy(arr_c0)
-    expected_c1 = np.zeros(arr_c0.shape)
-    expected_c2 = np.copy(arr_c2)
-    expected_c3 = np.zeros(arr_c0.shape)
-    expected = np.concatenate([
-        expected_c0[..., np.newaxis],
-        expected_c1[..., np.newaxis],
-        expected_c2[..., np.newaxis],
-        expected_c3[..., np.newaxis]
-    ], axis=2)
-    assert np.allclose(segmap.arr, expected)
-
-
-def test_SegmentationMapOnImage_copy():
-    arr_c0 = np.float32([
-        [1.0, 0.0],
-        [1.0, 0.0]
-    ])
-    arr_c1 = np.float32([
-        [0.0, 1.0],
-        [0.0, 1.0]
-    ])
-    arr = np.concatenate([arr_c0[..., np.newaxis], arr_c1[..., np.newaxis]], axis=2)
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2))
-    observed = segmap.copy()
-    assert np.allclose(observed.arr, segmap.arr)
-    assert observed.shape == (2, 2)
-    assert observed.nb_classes == segmap.nb_classes
-    assert observed.input_was == segmap.input_was
-
+def test_SegmentationMapsOnImage_copy():
     arr = np.int32([
         [0, 1],
         [2, 3]
-    ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2), nb_classes=10)
+    ]).reshape((2, 2, 1))
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(2, 2))
     observed = segmap.copy()
-    assert np.array_equal(observed.get_arr_int(), arr)
+    assert np.array_equal(observed.arr, segmap.arr)
     assert observed.shape == (2, 2)
-    assert observed.nb_classes == 10
+    assert observed.input_was == segmap.input_was
+
+    observed.arr[0, 0, 0] = 10
+    assert segmap.arr[0, 0, 0] == 10
+    assert arr[0, 0, 0] == 10
+
+    observed = segmap.copy(np.int32([[10]]).reshape((1, 1, 1)))
+    assert observed.arr.shape == (1, 1, 1)
+    assert observed.arr[0, 0, 0] == 10
+    assert observed.input_was == segmap.input_was
+
+    observed = segmap.copy(shape=(10, 11, 3))
+    assert observed.shape == (10, 11, 3)
+    assert segmap.shape != (10, 11, 3)
     assert observed.input_was == segmap.input_was
 
 
-def test_SegmentationMapOnImage_deepcopy():
-    arr_c0 = np.float32([
-        [1.0, 0.0],
-        [1.0, 0.0]
-    ])
-    arr_c1 = np.float32([
-        [0.0, 1.0],
-        [0.0, 1.0]
-    ])
-    arr = np.concatenate([arr_c0[..., np.newaxis], arr_c1[..., np.newaxis]], axis=2)
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2))
-    observed = segmap.deepcopy()
-    assert np.allclose(observed.arr, segmap.arr)
-    assert observed.shape == (2, 2)
-    assert observed.nb_classes == segmap.nb_classes
-    assert observed.input_was == segmap.input_was
-    segmap.arr[0, 0, 0] = 0.0
-    assert not np.allclose(observed.arr, segmap.arr)
-
+def test_SegmentationMapsOnImage_deepcopy():
     arr = np.int32([
         [0, 1],
         [2, 3]
-    ])
-    segmap = ia.SegmentationMapOnImage(arr, shape=(2, 2), nb_classes=10)
+    ]).reshape((2, 2, 1))
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(2, 2))
     observed = segmap.deepcopy()
-    assert np.array_equal(observed.get_arr_int(), segmap.get_arr_int())
+    assert np.array_equal(observed.arr, segmap.arr)
     assert observed.shape == (2, 2)
-    assert observed.nb_classes == 10
     assert observed.input_was == segmap.input_was
-    segmap.arr[0, 0, 0] = 0.0
-    segmap.arr[0, 0, 1] = 1.0
-    assert not np.array_equal(observed.get_arr_int(), segmap.get_arr_int())
+
+    observed.arr[0, 0, 0] = 10
+    assert segmap.arr[0, 0, 0] != 10
+    assert arr[0, 0, 0] != 10
+
+    observed = segmap.copy(np.int32([[10]]).reshape((1, 1, 1)))
+    assert observed.arr.shape == (1, 1, 1)
+    assert observed.arr[0, 0, 0] == 10
+    assert segmap.arr[0, 0, 0] != 10
+    assert observed.input_was == segmap.input_was
+
+    observed = segmap.copy(shape=(10, 11, 3))
+    assert observed.shape == (10, 11, 3)
+    assert segmap.shape != (10, 11, 3)
+    assert observed.input_was == segmap.input_was

--- a/test/augmentables/test_segmaps.py
+++ b/test/augmentables/test_segmaps.py
@@ -536,7 +536,7 @@ def test_SegmentationMapsOnImage_copy():
     observed = segmap.copy()
     assert np.array_equal(observed.arr, segmap.arr)
     assert observed.shape == (2, 2)
-    assert observed.input_was == segmap.input_was
+    assert observed._input_was == segmap._input_was
 
     observed.arr[0, 0, 0] = 10
     assert segmap.arr[0, 0, 0] == 10
@@ -545,12 +545,12 @@ def test_SegmentationMapsOnImage_copy():
     observed = segmap.copy(np.int32([[10]]).reshape((1, 1, 1)))
     assert observed.arr.shape == (1, 1, 1)
     assert observed.arr[0, 0, 0] == 10
-    assert observed.input_was == segmap.input_was
+    assert observed._input_was == segmap._input_was
 
     observed = segmap.copy(shape=(10, 11, 3))
     assert observed.shape == (10, 11, 3)
     assert segmap.shape != (10, 11, 3)
-    assert observed.input_was == segmap.input_was
+    assert observed._input_was == segmap._input_was
 
 
 def test_SegmentationMapsOnImage_deepcopy():
@@ -562,7 +562,7 @@ def test_SegmentationMapsOnImage_deepcopy():
     observed = segmap.deepcopy()
     assert np.array_equal(observed.arr, segmap.arr)
     assert observed.shape == (2, 2)
-    assert observed.input_was == segmap.input_was
+    assert observed._input_was == segmap._input_was
 
     observed.arr[0, 0, 0] = 10
     assert segmap.arr[0, 0, 0] != 10
@@ -572,9 +572,9 @@ def test_SegmentationMapsOnImage_deepcopy():
     assert observed.arr.shape == (1, 1, 1)
     assert observed.arr[0, 0, 0] == 10
     assert segmap.arr[0, 0, 0] != 10
-    assert observed.input_was == segmap.input_was
+    assert observed._input_was == segmap._input_was
 
     observed = segmap.copy(shape=(10, 11, 3))
     assert observed.shape == (10, 11, 3)
     assert segmap.shape != (10, 11, 3)
-    assert observed.input_was == segmap.input_was
+    assert observed._input_was == segmap._input_was

--- a/test/augmentables/test_segmaps.py
+++ b/test/augmentables/test_segmaps.py
@@ -134,6 +134,20 @@ def test_SegmentationMapsOnImage___init__():
         got_exception = True
     assert got_exception
 
+    # int64 is not allowed
+    got_exception = False
+    try:
+        arr = np.array([
+            [0, 0, 1],
+            [0, 2, 1],
+            [1, 3, 1]
+        ], dtype=np.int64)
+        _segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3, 3))
+    except Exception as exc:
+        assert "only int8, int16 and int32 " in str(exc)
+        got_exception = True
+    assert got_exception
+
 
 def test_SegmentationMapsOnImage___init___float32_2d():
     arr = np.array([0.4, 0.6], dtype=np.float32).reshape((1, 2))

--- a/test/augmentables/test_segmaps.py
+++ b/test/augmentables/test_segmaps.py
@@ -323,6 +323,37 @@ def test_SegmentationMapsOnImage_draw():
     assert np.array_equal(observed[2], expected_channel_3)
 
 
+def test_SegmentationMapsOnImage_draw_on_image_background_threshold_deprec():
+    arr = np.zeros((1, 1, 1), dtype=np.int32)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
+    image = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        _ = segmap.draw_on_image(image, background_threshold=0.01)
+
+    assert len(caught_warnings) == 1
+    assert (
+        "The argument `background_threshold` is deprecated"
+        in str(caught_warnings[0].message)
+    )
+
+
+def test_SegmentationMapsOnImage_draw_on_image_background_class_id_deprecated():
+    arr = np.zeros((1, 1, 1), dtype=np.int32)
+    segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
+    image = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        _ = segmap.draw_on_image(image, background_class_id=1)
+
+    assert len(caught_warnings) == 1
+    assert (
+        "The argument `background_class_id` is deprecated"
+        in str(caught_warnings[0].message)
+    )
+
 def test_SegmentationMapsOnImage_draw_on_image():
     arr = np.int32([
         [0, 1, 1],

--- a/test/augmentables/test_segmaps.py
+++ b/test/augmentables/test_segmaps.py
@@ -272,11 +272,38 @@ def test_SegmentationMapsOnImage_draw():
     assert np.array_equal(observed[0], expected)
 
     # same example, with resizing to 2x the size
-    observed = segmap.draw(size=(6, 6))
-    expected = ia.imresize_single_image(expected, (6, 6), interpolation="nearest")
-    assert isinstance(observed, list)
-    assert len(observed) == 1
-    assert np.array_equal(observed[0], expected)
+    double_size_args = [
+        (6, 6),
+        (2.0, 2.0),
+        6,
+        2.0
+    ]
+    expected = ia.imresize_single_image(expected,
+                                        (6, 6),
+                                        interpolation="nearest")
+    for double_size_arg in double_size_args:
+        observed = segmap.draw(size=double_size_arg)
+        assert isinstance(observed, list)
+        assert len(observed) == 1
+        assert np.array_equal(observed[0], expected)
+
+    # same example, keeps size at 3x3 via None and (int)3 or (float)1.0
+    size_args = [
+        None,
+        (None, None),
+        (3, None),
+        (None, 3),
+        (1.0, None),
+        (None, 1.0)
+    ]
+    expected = ia.imresize_single_image(expected,
+                                        (3, 3),
+                                        interpolation="nearest")
+    for size_arg in size_args:
+        observed = segmap.draw(size=size_arg)
+        assert isinstance(observed, list)
+        assert len(observed) == 1
+        assert np.array_equal(observed[0], expected)
 
     # custom choice of colors
     col0 = (10, 10, 10)

--- a/test/augmentables/test_segmaps.py
+++ b/test/augmentables/test_segmaps.py
@@ -338,22 +338,6 @@ def test_SegmentationMapsOnImage_draw_on_image_background_threshold_deprec():
         in str(caught_warnings[0].message)
     )
 
-
-def test_SegmentationMapsOnImage_draw_on_image_background_class_id_deprecated():
-    arr = np.zeros((1, 1, 1), dtype=np.int32)
-    segmap = ia.SegmentationMapsOnImage(arr, shape=(3, 3))
-    image = np.zeros((1, 1, 3), dtype=np.uint8)
-
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        warnings.simplefilter("always")
-        _ = segmap.draw_on_image(image, background_class_id=1)
-
-    assert len(caught_warnings) == 1
-    assert (
-        "The argument `background_class_id` is deprecated"
-        in str(caught_warnings[0].message)
-    )
-
 def test_SegmentationMapsOnImage_draw_on_image():
     arr = np.int32([
         [0, 1, 1],
@@ -454,6 +438,24 @@ def test_SegmentationMapsOnImage_draw_on_image():
         [image[0, 0, :], a0*image[0, 1, :] + a1*col1, a0*image[0, 2, :] + a1*col1],
         [image[1, 0, :], a0*image[1, 1, :] + a1*col1, a0*image[1, 2, :] + a1*col1],
         [image[2, 0, :], a0*image[2, 1, :] + a1*col1, a0*image[2, 2, :] + a1*col1]
+    ])
+    d_max = np.max(np.abs(observed[0].astype(np.float32) - expected))
+    assert isinstance(observed, list)
+    assert len(observed) == 1
+    assert observed[0].shape == expected.shape
+    assert d_max <= 1.0 + 1e-4
+
+    # overlay without background drawn
+    # different background class id
+    a1 = 0.7
+    a0 = 1.0 - a1
+    observed = segmap.draw_on_image(image, alpha=a1, draw_background=False,
+                                    background_class_id=1)
+    col0 = np.uint8(ia.SegmentationMapsOnImage.DEFAULT_SEGMENT_COLORS[0])
+    expected = np.float32([
+        [a0*image[0, 0, :] + a1*col0, image[0, 1, :], image[0, 2, :]],
+        [a0*image[1, 0, :] + a1*col0, image[1, 1, :], image[1, 2, :]],
+        [a0*image[2, 0, :] + a1*col0, image[2, 1, :], image[2, 2, :]]
     ])
     d_max = np.max(np.abs(observed[0].astype(np.float32) - expected))
     assert isinstance(observed, list)

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -1329,7 +1329,7 @@ class TestCoarseDropout(unittest.TestCase):
         assert np.allclose(hm.arr_0to1, hm_aug.arr_0to1)
 
 
-class TestMultiple(unittest.TestCase):
+class TestMultiply(unittest.TestCase):
     def setUp(self):
         reseed()
 
@@ -1543,6 +1543,7 @@ class TestMultiple(unittest.TestCase):
     def test_other_dtypes_uint_int(self):
         # uint, int
         for dtype in [np.uint8, np.uint16, np.int8, np.int16]:
+            dtype = np.dtype(dtype)
             min_value, center_value, max_value = iadt.get_value_range_of_dtype(dtype)
 
             image = np.full((3, 3), 10, dtype=dtype)
@@ -1607,11 +1608,13 @@ class TestMultiple(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == max_value)
 
-            image = np.full((3, 3), max_value, dtype=dtype)
-            aug = iaa.Multiply(10)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == max_value)
+            # non-uint8 currently don't increase the itemsize
+            if dtype.name == "uint8":
+                image = np.full((3, 3), max_value, dtype=dtype)
+                aug = iaa.Multiply(10)
+                image_aug = aug.augment_image(image)
+                assert image_aug.dtype.type == dtype
+                assert np.all(image_aug == max_value)
 
             image = np.full((3, 3), max_value, dtype=dtype)
             aug = iaa.Multiply(0)
@@ -1619,40 +1622,44 @@ class TestMultiple(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == 0)
 
-            image = np.full((3, 3), max_value, dtype=dtype)
-            aug = iaa.Multiply(-2)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == min_value)
-
-            for _ in sm.xrange(10):
-                image = np.full((1, 1, 3), 10, dtype=dtype)
-                aug = iaa.Multiply(iap.Uniform(0.5, 1.5))
+            # non-uint8 currently don't increase the itemsize
+            if dtype.name == "uint8":
+                image = np.full((3, 3), max_value, dtype=dtype)
+                aug = iaa.Multiply(-2)
                 image_aug = aug.augment_image(image)
                 assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
-                assert len(np.unique(image_aug)) == 1
+                assert np.all(image_aug == min_value)
 
-                image = np.full((1, 1, 100), 10, dtype=dtype)
-                aug = iaa.Multiply(iap.Uniform(0.5, 1.5), per_channel=True)
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
-                assert len(np.unique(image_aug)) > 1
+            # non-uint8 currently don't increase the itemsize
+            if dtype.name == "uint8":
+                for _ in sm.xrange(10):
+                    image = np.full((1, 1, 3), 10, dtype=dtype)
+                    aug = iaa.Multiply(iap.Uniform(0.5, 1.5))
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
+                    assert len(np.unique(image_aug)) == 1
 
-                image = np.full((1, 1, 3), 10, dtype=dtype)
-                aug = iaa.Multiply(iap.DiscreteUniform(1, 3))
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
-                assert len(np.unique(image_aug)) == 1
+                    image = np.full((1, 1, 100), 10, dtype=dtype)
+                    aug = iaa.Multiply(iap.Uniform(0.5, 1.5), per_channel=True)
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
+                    assert len(np.unique(image_aug)) > 1
 
-                image = np.full((1, 1, 100), 10, dtype=dtype)
-                aug = iaa.Multiply(iap.DiscreteUniform(1, 3), per_channel=True)
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
-                assert len(np.unique(image_aug)) > 1
+                    image = np.full((1, 1, 3), 10, dtype=dtype)
+                    aug = iaa.Multiply(iap.DiscreteUniform(1, 3))
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
+                    assert len(np.unique(image_aug)) == 1
+
+                    image = np.full((1, 1, 100), 10, dtype=dtype)
+                    aug = iaa.Multiply(iap.DiscreteUniform(1, 3), per_channel=True)
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
+                    assert len(np.unique(image_aug)) > 1
 
     def test_other_dtypes_float(self):
         # float
@@ -1677,11 +1684,12 @@ class TestMultiple(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert _allclose(image_aug, 20.0)
 
-            image = np.full((3, 3), max_value, dtype=dtype)
-            aug = iaa.Multiply(-10)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert _allclose(image_aug, min_value)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), max_value, dtype=dtype)
+            # aug = iaa.Multiply(-10)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert _allclose(image_aug, min_value)
 
             image = np.full((3, 3), max_value, dtype=dtype)
             aug = iaa.Multiply(0.0)
@@ -1695,11 +1703,12 @@ class TestMultiple(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert _allclose(image_aug, 0.5*max_value)
 
-            image = np.full((3, 3), min_value, dtype=dtype)
-            aug = iaa.Multiply(-2.0)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert _allclose(image_aug, max_value)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), min_value, dtype=dtype)
+            # aug = iaa.Multiply(-2.0)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert _allclose(image_aug, max_value)
 
             image = np.full((3, 3), min_value, dtype=dtype)
             aug = iaa.Multiply(0.0)
@@ -1708,6 +1717,8 @@ class TestMultiple(unittest.TestCase):
             assert _allclose(image_aug, 0.0)
 
             # using tolerances of -100 - 1e-2 and 100 + 1e-2 is not enough for float16, had to be increased to -/+ 1e-1
+            # deactivated, because itemsize increase was deactivated
+            """
             for _ in sm.xrange(10):
                 image = np.full((1, 1, 3), 10.0, dtype=dtype)
                 aug = iaa.Multiply(iap.Uniform(-10, 10))
@@ -1738,6 +1749,7 @@ class TestMultiple(unittest.TestCase):
                 assert image_aug.dtype.type == dtype
                 assert np.all(np.logical_and(-100 - 1e-1 < image_aug, image_aug < 100 + 1e-1))
                 assert not np.allclose(image_aug[:, :, 1:], image_aug[:, :, :-1])
+            """
 
 
 class TestMultiplyElementwise(unittest.TestCase):
@@ -1979,6 +1991,7 @@ class TestMultiplyElementwise(unittest.TestCase):
     def test_other_dtypes_uint_int(self):
         # uint, int
         for dtype in [np.uint8, np.uint16, np.int8, np.int16]:
+            dtype = np.dtype(dtype)
             min_value, center_value, max_value = iadt.get_value_range_of_dtype(dtype)
 
             image = np.full((3, 3), 10, dtype=dtype)
@@ -1987,11 +2000,12 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == 10)
 
-            image = np.full((3, 3), 10, dtype=dtype)
-            aug = iaa.MultiplyElementwise(10)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == 100)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), 10, dtype=dtype)
+            # aug = iaa.MultiplyElementwise(10)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert np.all(image_aug == 100)
 
             image = np.full((3, 3), 10, dtype=dtype)
             aug = iaa.MultiplyElementwise(0.5)
@@ -2005,18 +2019,20 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == 0)
 
-            if np.dtype(dtype).kind == "u":
-                image = np.full((3, 3), 10, dtype=dtype)
-                aug = iaa.MultiplyElementwise(-1)
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(image_aug == 0)
-            else:
-                image = np.full((3, 3), 10, dtype=dtype)
-                aug = iaa.MultiplyElementwise(-1)
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(image_aug == -10)
+            # partially deactivated, because itemsize increase was deactivated
+            if dtype.name == "uint8":
+                if dtype.kind == "u":
+                    image = np.full((3, 3), 10, dtype=dtype)
+                    aug = iaa.MultiplyElementwise(-1)
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(image_aug == 0)
+                else:
+                    image = np.full((3, 3), 10, dtype=dtype)
+                    aug = iaa.MultiplyElementwise(-1)
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(image_aug == -10)
 
             image = np.full((3, 3), int(center_value), dtype=dtype)
             aug = iaa.MultiplyElementwise(1)
@@ -2024,18 +2040,21 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == int(center_value))
 
-            image = np.full((3, 3), int(center_value), dtype=dtype)
-            aug = iaa.MultiplyElementwise(1.2)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == int(1.2 * int(center_value)))
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), int(center_value), dtype=dtype)
+            # aug = iaa.MultiplyElementwise(1.2)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert np.all(image_aug == int(1.2 * int(center_value)))
 
-            if np.dtype(dtype).kind == "u":
-                image = np.full((3, 3), int(center_value), dtype=dtype)
-                aug = iaa.MultiplyElementwise(100)
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(image_aug == max_value)
+            # deactivated, because itemsize increase was deactivated
+            if dtype.name == "uint8":
+                if dtype.kind == "u":
+                    image = np.full((3, 3), int(center_value), dtype=dtype)
+                    aug = iaa.MultiplyElementwise(100)
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(image_aug == max_value)
 
             image = np.full((3, 3), max_value, dtype=dtype)
             aug = iaa.MultiplyElementwise(1)
@@ -2043,11 +2062,12 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == max_value)
 
-            image = np.full((3, 3), max_value, dtype=dtype)
-            aug = iaa.MultiplyElementwise(10)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == max_value)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), max_value, dtype=dtype)
+            # aug = iaa.MultiplyElementwise(10)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert np.all(image_aug == max_value)
 
             image = np.full((3, 3), max_value, dtype=dtype)
             aug = iaa.MultiplyElementwise(0)
@@ -2055,46 +2075,50 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == 0)
 
-            image = np.full((3, 3), max_value, dtype=dtype)
-            aug = iaa.MultiplyElementwise(-2)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == min_value)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), max_value, dtype=dtype)
+            # aug = iaa.MultiplyElementwise(-2)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert np.all(image_aug == min_value)
 
-            for _ in sm.xrange(10):
-                image = np.full((5, 5, 3), 10, dtype=dtype)
-                aug = iaa.MultiplyElementwise(iap.Uniform(0.5, 1.5))
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
-                assert len(np.unique(image_aug)) > 1
-                assert np.all(image_aug[..., 0] == image_aug[..., 1])
+            # partially deactivated, because itemsize increase was deactivated
+            if dtype.name == "uint8":
+                for _ in sm.xrange(10):
+                    image = np.full((5, 5, 3), 10, dtype=dtype)
+                    aug = iaa.MultiplyElementwise(iap.Uniform(0.5, 1.5))
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
+                    assert len(np.unique(image_aug)) > 1
+                    assert np.all(image_aug[..., 0] == image_aug[..., 1])
 
-                image = np.full((1, 1, 100), 10, dtype=dtype)
-                aug = iaa.MultiplyElementwise(iap.Uniform(0.5, 1.5), per_channel=True)
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
-                assert len(np.unique(image_aug)) > 1
+                    image = np.full((1, 1, 100), 10, dtype=dtype)
+                    aug = iaa.MultiplyElementwise(iap.Uniform(0.5, 1.5), per_channel=True)
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(5 <= image_aug, image_aug <= 15))
+                    assert len(np.unique(image_aug)) > 1
 
-                image = np.full((5, 5, 3), 10, dtype=dtype)
-                aug = iaa.MultiplyElementwise(iap.DiscreteUniform(1, 3))
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
-                assert len(np.unique(image_aug)) > 1
-                assert np.all(image_aug[..., 0] == image_aug[..., 1])
+                    image = np.full((5, 5, 3), 10, dtype=dtype)
+                    aug = iaa.MultiplyElementwise(iap.DiscreteUniform(1, 3))
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
+                    assert len(np.unique(image_aug)) > 1
+                    assert np.all(image_aug[..., 0] == image_aug[..., 1])
 
-                image = np.full((1, 1, 100), 10, dtype=dtype)
-                aug = iaa.MultiplyElementwise(iap.DiscreteUniform(1, 3), per_channel=True)
-                image_aug = aug.augment_image(image)
-                assert image_aug.dtype.type == dtype
-                assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
-                assert len(np.unique(image_aug)) > 1
+                    image = np.full((1, 1, 100), 10, dtype=dtype)
+                    aug = iaa.MultiplyElementwise(iap.DiscreteUniform(1, 3), per_channel=True)
+                    image_aug = aug.augment_image(image)
+                    assert image_aug.dtype.type == dtype
+                    assert np.all(np.logical_and(10 <= image_aug, image_aug <= 30))
+                    assert len(np.unique(image_aug)) > 1
 
     def test_other_dtypes_float(self):
         # float
         for dtype in [np.float16, np.float32]:
+            dtype = np.dtype(dtype)
             min_value, center_value, max_value = iadt.get_value_range_of_dtype(dtype)
 
             if dtype == np.float16:
@@ -2109,17 +2133,19 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert _allclose(image_aug, 10.0)
 
-            image = np.full((3, 3), 10.0, dtype=dtype)
-            aug = iaa.MultiplyElementwise(2.0)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert _allclose(image_aug, 20.0)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), 10.0, dtype=dtype)
+            # aug = iaa.MultiplyElementwise(2.0)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert _allclose(image_aug, 20.0)
 
-            image = np.full((3, 3), max_value, dtype=dtype)
-            aug = iaa.MultiplyElementwise(-10)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert _allclose(image_aug, min_value)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), max_value, dtype=dtype)
+            # aug = iaa.MultiplyElementwise(-10)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert _allclose(image_aug, min_value)
 
             image = np.full((3, 3), max_value, dtype=dtype)
             aug = iaa.MultiplyElementwise(0.0)
@@ -2133,11 +2159,12 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert _allclose(image_aug, 0.5*max_value)
 
-            image = np.full((3, 3), min_value, dtype=dtype)
-            aug = iaa.MultiplyElementwise(-2.0)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert _allclose(image_aug, max_value)
+            # deactivated, because itemsize increase was deactivated
+            # image = np.full((3, 3), min_value, dtype=dtype)
+            # aug = iaa.MultiplyElementwise(-2.0)
+            # image_aug = aug.augment_image(image)
+            # assert image_aug.dtype.type == dtype
+            # assert _allclose(image_aug, max_value)
 
             image = np.full((3, 3), min_value, dtype=dtype)
             aug = iaa.MultiplyElementwise(0.0)
@@ -2146,6 +2173,8 @@ class TestMultiplyElementwise(unittest.TestCase):
             assert _allclose(image_aug, 0.0)
 
             # using tolerances of -100 - 1e-2 and 100 + 1e-2 is not enough for float16, had to be increased to -/+ 1e-1
+            # deactivated, because itemsize increase was deactivated
+            """
             for _ in sm.xrange(10):
                 image = np.full((50, 1, 3), 10.0, dtype=dtype)
                 aug = iaa.MultiplyElementwise(iap.Uniform(-10, 10))
@@ -2176,6 +2205,7 @@ class TestMultiplyElementwise(unittest.TestCase):
                 assert image_aug.dtype.type == dtype
                 assert np.all(np.logical_and(-100 - 1e-1 < image_aug, image_aug < 100 + 1e-1))
                 assert not np.allclose(image_aug[:, :, 1:], image_aug[:, :, :-1])
+            """
 
 
 class TestReplaceElementwise(unittest.TestCase):
@@ -2392,7 +2422,8 @@ class TestReplaceElementwise(unittest.TestCase):
 
     def test_other_dtypes_uint_int(self):
         # uint, int
-        for dtype in [np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int32, np.int64]:
+        for dtype in [np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int32]:
+            dtype = np.dtype(dtype)
             min_value, center_value, max_value = iadt.get_value_range_of_dtype(dtype)
 
             aug = iaa.ReplaceElementwise(mask=1, replacement=1)
@@ -2407,17 +2438,21 @@ class TestReplaceElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.all(image_aug == 2)
 
-            aug = iaa.ReplaceElementwise(mask=1, replacement=max_value)
-            image = np.full((3, 3), min_value, dtype=dtype)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == max_value)
+            # deterministic stochastic parameters are by default int32 for
+            # any integer value and hence cannot cover the full uint32 value
+            # range
+            if dtype.name != "uint32":
+                aug = iaa.ReplaceElementwise(mask=1, replacement=max_value)
+                image = np.full((3, 3), min_value, dtype=dtype)
+                image_aug = aug.augment_image(image)
+                assert image_aug.dtype.type == dtype
+                assert np.all(image_aug == max_value)
 
-            aug = iaa.ReplaceElementwise(mask=1, replacement=min_value)
-            image = np.full((3, 3), max_value, dtype=dtype)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert np.all(image_aug == min_value)
+                aug = iaa.ReplaceElementwise(mask=1, replacement=min_value)
+                image = np.full((3, 3), max_value, dtype=dtype)
+                image_aug = aug.augment_image(image)
+                assert image_aug.dtype.type == dtype
+                assert np.all(image_aug == min_value)
 
             aug = iaa.ReplaceElementwise(mask=1, replacement=iap.Uniform(1.0, 10.0))
             image = np.full((100, 1), 0, dtype=dtype)
@@ -2443,6 +2478,7 @@ class TestReplaceElementwise(unittest.TestCase):
     def test_other_dtypes_float(self):
         # float
         for dtype in [np.float16, np.float32, np.float64]:
+            dtype = np.dtype(dtype)
             min_value, center_value, max_value = iadt.get_value_range_of_dtype(dtype)
 
             atol = 1e-3*max_value if dtype == np.float16 else 1e-9 * max_value
@@ -2460,17 +2496,21 @@ class TestReplaceElementwise(unittest.TestCase):
             assert image_aug.dtype.type == dtype
             assert np.allclose(image_aug, 2.0)
 
-            aug = iaa.ReplaceElementwise(mask=1, replacement=max_value)
-            image = np.full((3, 3), min_value, dtype=dtype)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert _allclose(image_aug, max_value)
+            # deterministic stochastic parameters are by default float32 for
+            # any float value and hence cannot cover the full float64 value
+            # range
+            if dtype.name != "float64":
+                aug = iaa.ReplaceElementwise(mask=1, replacement=max_value)
+                image = np.full((3, 3), min_value, dtype=dtype)
+                image_aug = aug.augment_image(image)
+                assert image_aug.dtype.type == dtype
+                assert _allclose(image_aug, max_value)
 
-            aug = iaa.ReplaceElementwise(mask=1, replacement=min_value)
-            image = np.full((3, 3), max_value, dtype=dtype)
-            image_aug = aug.augment_image(image)
-            assert image_aug.dtype.type == dtype
-            assert _allclose(image_aug, min_value)
+                aug = iaa.ReplaceElementwise(mask=1, replacement=min_value)
+                image = np.full((3, 3), max_value, dtype=dtype)
+                image_aug = aug.augment_image(image)
+                assert image_aug.dtype.type == dtype
+                assert _allclose(image_aug, min_value)
 
             aug = iaa.ReplaceElementwise(mask=1, replacement=iap.Uniform(1.0, 10.0))
             image = np.full((100, 1), 0, dtype=dtype)

--- a/test/augmenters/test_contrast.py
+++ b/test/augmenters/test_contrast.py
@@ -78,7 +78,7 @@ def test_GammaContrast():
     # check that list to choice works
     aug = iaa.GammaContrast([1, 2])
     assert isinstance(aug.params1d[0], iap.Choice)
-    assert all([val in aug.params1d[0].a for val in [1, 2]])
+    assert np.all([val in aug.params1d[0].a for val in [1, 2]])
 
     # check that per_channel at 50% prob works
     aug = iaa.GammaContrast((0.5, 2.0), per_channel=0.5)
@@ -92,9 +92,9 @@ def test_GammaContrast():
             seen[0] = True
         else:
             seen[1] = True
-        if all(seen):
+        if np.all(seen):
             break
-    assert all(seen)
+    assert np.all(seen)
 
     # check that keypoints are not changed
     kpsoi = ia.KeypointsOnImage([ia.Keypoint(1, 1)], shape=(3, 3, 3))
@@ -227,9 +227,9 @@ def test_SigmoidContrast():
     # the order of skimage's function
     aug = iaa.SigmoidContrast(gain=[1, 2], cutoff=[0.25, 0.75])
     assert isinstance(aug.params1d[0], iap.Choice)
-    assert all([val in aug.params1d[0].a for val in [1, 2]])
+    assert np.all([val in aug.params1d[0].a for val in [1, 2]])
     assert isinstance(aug.params1d[1], iap.Choice)
-    assert all([np.allclose(val, val_choice) for val, val_choice in zip([0.25, 0.75], aug.params1d[1].a)])
+    assert np.all([np.allclose(val, val_choice) for val, val_choice in zip([0.25, 0.75], aug.params1d[1].a)])
 
     # check that per_channel at 50% prob works
     aug = iaa.SigmoidContrast(gain=(1, 10), cutoff=(0.25, 0.75), per_channel=0.5)
@@ -243,9 +243,9 @@ def test_SigmoidContrast():
             seen[0] = True
         else:
             seen[1] = True
-        if all(seen):
+        if np.all(seen):
             break
-    assert all(seen)
+    assert np.all(seen)
 
     # check that keypoints are not changed
     kpsoi = ia.KeypointsOnImage([ia.Keypoint(1, 1)], shape=(3, 3, 3))
@@ -345,7 +345,7 @@ def test_LogContrast():
     # check that list to choice works
     aug = iaa.LogContrast([1, 2])
     assert isinstance(aug.params1d[0], iap.Choice)
-    assert all([val in aug.params1d[0].a for val in [1, 2]])
+    assert np.all([val in aug.params1d[0].a for val in [1, 2]])
 
     # check that per_channel at 50% prob works
     aug = iaa.LogContrast((0.5, 2.0), per_channel=0.5)
@@ -359,9 +359,9 @@ def test_LogContrast():
             seen[0] = True
         else:
             seen[1] = True
-        if all(seen):
+        if np.all(seen):
             break
-    assert all(seen)
+    assert np.all(seen)
 
     # check that keypoints are not changed
     kpsoi = ia.KeypointsOnImage([ia.Keypoint(1, 1)], shape=(3, 3, 3))
@@ -376,8 +376,12 @@ def test_LogContrast():
     ###################
     # test other dtypes
     ###################
+    # support before 1.17:
+    #   [np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64]
+    # support beginning with 1.17:
+    #   [np.uint8, np.uint16, np.int8, np.int16]
     # uint, int
-    for dtype in [np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64]:
+    for dtype in [np.uint8, np.uint16, np.int8, np.int16]:
         min_value, center_value, max_value = iadt.get_value_range_of_dtype(dtype)
 
         gains = [0.5, 0.75, 1.0, 1.1]
@@ -402,7 +406,9 @@ def test_LogContrast():
     # float
     for dtype in [np.float16, np.float32, np.float64]:
         def _allclose(a, b):
-            atol = 1e-2 if dtype == np.float16 else 1e-8
+            # since numpy 1.17 this needs for some reason at least 1e-5 as the
+            # tolerance, previously 1e-8 worked
+            atol = 1e-2 if dtype == np.float16 else 1e-5
             return np.allclose(a, b, atol=atol, rtol=0)
 
         gains = [0.5, 0.75, 1.0, 1.1]
@@ -454,7 +460,7 @@ def test_LinearContrast():
     # check that list to choice works
     aug = iaa.LinearContrast([1, 2])
     assert isinstance(aug.params1d[0], iap.Choice)
-    assert all([val in aug.params1d[0].a for val in [1, 2]])
+    assert np.all([val in aug.params1d[0].a for val in [1, 2]])
 
     # check that per_channel at 50% prob works
     aug = iaa.LinearContrast((0.5, 2.0), per_channel=0.5)
@@ -470,9 +476,9 @@ def test_LinearContrast():
             seen[0] = True
         else:
             seen[1] = True
-        if all(seen):
+        if np.all(seen):
             break
-    assert all(seen)
+    assert np.all(seen)
 
     # check that keypoints are not changed
     kpsoi = ia.KeypointsOnImage([ia.Keypoint(1, 1)], shape=(3, 3, 3))
@@ -689,9 +695,9 @@ class TestAllChannelsCLAHE(unittest.TestCase):
                 seen[0] = True
             else:
                 seen[1] = True
-            if all(seen):
+            if np.all(seen):
                 break
-        assert all(seen)
+        assert np.all(seen)
 
     def test_unit_sized_kernels(self):
         img = np.zeros((1, 1), dtype=np.uint8)
@@ -801,7 +807,7 @@ class TestAllChannelsCLAHE(unittest.TestCase):
     def test_get_parameters(self):
         aug = iaa.AllChannelsCLAHE(clip_limit=1, tile_grid_size_px=3, tile_grid_size_px_min=2, per_channel=True)
         params = aug.get_parameters()
-        assert all([isinstance(params[i], iap.Deterministic) for i in [0, 3]])
+        assert np.all([isinstance(params[i], iap.Deterministic) for i in [0, 3]])
         assert params[0].value == 1
         assert params[1][0].value == 3
         assert params[1][1] is None

--- a/test/augmenters/test_flip.py
+++ b/test/augmenters/test_flip.py
@@ -12,6 +12,8 @@ from imgaug import augmenters as iaa
 from imgaug import parameters as iap
 from imgaug import dtypes as iadt
 from imgaug.testutils import keypoints_equal, reseed
+from imgaug.augmentables.heatmaps import HeatmapsOnImage
+from imgaug.augmentables.segmaps import SegmentationMapsOnImage
 
 
 def main():
@@ -102,7 +104,7 @@ def test_Fliplr():
 
     # 0% chance of flip, heatmaps
     aug = iaa.Fliplr(0)
-    heatmaps = ia.HeatmapsOnImage(
+    heatmaps = HeatmapsOnImage(
         np.float32([
             [0, 0.5, 0.75],
             [0, 0.5, 0.75],
@@ -115,6 +117,21 @@ def test_Fliplr():
     assert observed.shape == heatmaps.shape
     assert heatmaps.min_value - 1e-6 < observed.min_value < heatmaps.min_value + 1e-6
     assert heatmaps.max_value - 1e-6 < observed.max_value < heatmaps.max_value + 1e-6
+    assert np.array_equal(observed.get_arr(), expected)
+
+    # 0% chance of flip, segmaps
+    aug = iaa.Fliplr(0)
+    segmaps = SegmentationMapsOnImage(
+        np.int32([
+            [0, 1, 2],
+            [0, 1, 2],
+            [2, 2, 2],
+        ]),
+        shape=(3, 3, 3)
+    )
+    observed = aug.augment_segmentation_maps([segmaps])[0]
+    expected = segmaps.get_arr()
+    assert observed.shape == segmaps.shape
     assert np.array_equal(observed.get_arr(), expected)
 
     # 100% chance of flip
@@ -149,7 +166,7 @@ def test_Fliplr():
 
     # 100% chance of flip, heatmaps
     aug = iaa.Fliplr(1.0)
-    heatmaps = ia.HeatmapsOnImage(
+    heatmaps = HeatmapsOnImage(
         np.float32([
             [0, 0.5, 0.75],
             [0, 0.5, 0.75],
@@ -162,6 +179,21 @@ def test_Fliplr():
     assert observed.shape == heatmaps.shape
     assert heatmaps.min_value - 1e-6 < observed.min_value < heatmaps.min_value + 1e-6
     assert heatmaps.max_value - 1e-6 < observed.max_value < heatmaps.max_value + 1e-6
+    assert np.array_equal(observed.get_arr(), expected)
+
+    # 100% chance of flip, segmaps
+    aug = iaa.Fliplr(1.0)
+    segmaps = SegmentationMapsOnImage(
+        np.int32([
+            [0, 1, 2],
+            [0, 1, 2],
+            [2, 2, 2],
+        ]),
+        shape=(3, 3, 3)
+    )
+    observed = aug.augment_segmentation_maps([segmaps])[0]
+    expected = np.fliplr(segmaps.get_arr())
+    assert observed.shape == segmaps.shape
     assert np.array_equal(observed.get_arr(), expected)
 
     # 50% chance of flip
@@ -361,7 +393,7 @@ def test_Flipud():
 
     # 0% chance of flip, heatmaps
     aug = iaa.Flipud(0)
-    heatmaps = ia.HeatmapsOnImage(
+    heatmaps = HeatmapsOnImage(
         np.float32([
             [0, 0.5, 0.75],
             [0, 0.5, 0.75],
@@ -374,6 +406,21 @@ def test_Flipud():
     assert observed.shape == heatmaps.shape
     assert heatmaps.min_value - 1e-6 < observed.min_value < heatmaps.min_value + 1e-6
     assert heatmaps.max_value - 1e-6 < observed.max_value < heatmaps.max_value + 1e-6
+    assert np.array_equal(observed.get_arr(), expected)
+
+    # 0% chance of flip, segmaps
+    aug = iaa.Flipud(0)
+    segmaps = SegmentationMapsOnImage(
+        np.int32([
+            [0, 1, 2],
+            [0, 1, 2],
+            [2, 2, 2],
+        ]),
+        shape=(3, 3, 3)
+    )
+    observed = aug.augment_segmentation_maps([segmaps])[0]
+    expected = segmaps.get_arr()
+    assert observed.shape == segmaps.shape
     assert np.array_equal(observed.get_arr(), expected)
 
     # 100% chance of flip
@@ -421,6 +468,21 @@ def test_Flipud():
     assert observed.shape == heatmaps.shape
     assert heatmaps.min_value - 1e-6 < observed.min_value < heatmaps.min_value + 1e-6
     assert heatmaps.max_value - 1e-6 < observed.max_value < heatmaps.max_value + 1e-6
+    assert np.array_equal(observed.get_arr(), expected)
+
+    # 100% chance of flip, segmaps
+    aug = iaa.Flipud(1.0)
+    segmaps = SegmentationMapsOnImage(
+        np.int32([
+            [0, 1, 2],
+            [0, 1, 2],
+            [2, 2, 2],
+        ]),
+        shape=(3, 3, 3)
+    )
+    observed = aug.augment_segmentation_maps([segmaps])[0]
+    expected = np.flipud(segmaps.get_arr())
+    assert observed.shape == segmaps.shape
     assert np.array_equal(observed.get_arr(), expected)
 
     # 50% chance of flip

--- a/test/augmenters/test_meta.py
+++ b/test/augmenters/test_meta.py
@@ -3828,7 +3828,7 @@ def test_Sequential():
             seen[1] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
     assert np.all(seen)
 
@@ -3857,9 +3857,9 @@ def test_Sequential():
             seen[1] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
-    assert all(seen)
+    assert np.all(seen)
 
     # None as children
     aug = iaa.Sequential(children=None)
@@ -4150,7 +4150,7 @@ def test_SomeOf():
     observed1 = iaa.SomeOf(n=1, children=augs).augment_segmentation_maps([segmaps])[0]
     observed2 = iaa.SomeOf(n=2, children=augs).augment_segmentation_maps([segmaps])[0]
     observed3 = iaa.SomeOf(n=3, children=augs).augment_segmentation_maps([segmaps])[0]
-    assert all([obs.shape == (3, 3, 3) for obs in [observed0, observed1, observed2, observed3]])
+    assert np.all([obs.shape == (3, 3, 3) for obs in [observed0, observed1, observed2, observed3]])
     obs_lst = [observed0, observed1, observed2, observed3]
     segmaps_lst = [segmaps_arr0, segmaps_arr1, segmaps_arr2, segmaps_arr3]
     for obs, exp in zip(obs_lst, segmaps_lst):
@@ -4238,7 +4238,7 @@ def test_SomeOf():
             seen[3] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
     assert np.all(seen)
 
@@ -4282,7 +4282,7 @@ def test_SomeOf():
             seen[3] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
     assert np.all(seen)
 
@@ -5081,7 +5081,7 @@ def test_Sometimes():
             seen[1] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
     assert np.all(seen)
 
@@ -5103,7 +5103,7 @@ def test_Sometimes():
                 seen[1] = True
             else:
                 assert False
-            if all(seen):
+            if np.all(seen):
                 break
         assert np.all(seen)
 
@@ -5124,7 +5124,7 @@ def test_Sometimes():
                 seen[1] = True
             else:
                 assert False
-            if all(seen):
+            if np.all(seen):
                 break
         assert np.all(seen)
 
@@ -5415,7 +5415,7 @@ def test_ChannelShuffle():
             seen[1] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
     assert np.all(seen)
 
@@ -5442,7 +5442,7 @@ def test_ChannelShuffle():
             seen[1] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
     assert np.all(seen)
 
@@ -5511,7 +5511,7 @@ def test_ChannelShuffle():
             seen[1] = True
         else:
             assert False
-        if all(seen):
+        if np.all(seen):
             break
     assert np.all(seen)
 
@@ -5533,7 +5533,7 @@ def test_ChannelShuffle():
                 seen[1] = True
             else:
                 assert False
-            if all(seen):
+            if np.all(seen):
                 break
         assert np.all(seen)
 
@@ -5554,7 +5554,7 @@ def test_ChannelShuffle():
                 seen[1] = True
             else:
                 assert False
-            if all(seen):
+            if np.all(seen):
                 break
         assert np.all(seen)
 

--- a/test/augmenters/test_segmentation.py
+++ b/test/augmenters/test_segmentation.py
@@ -118,7 +118,7 @@ class TestSuperpixels(unittest.TestCase):
                 raise Exception(
                     "Generated superpixels image does not match any "
                     "expected image.")
-            if all(seen.values()):
+            if np.all(seen.values()):
                 break
         assert np.all(seen.values())
 
@@ -1285,11 +1285,11 @@ class TestUniformPointsSampler(unittest.TestCase):
         for i in sm.xrange(50):
             points = sampler.sample_points(images, i)[0]
             seen[len(points)] = True
-            if all(seen.values()):
+            if np.all(seen.values()):
                 break
 
         assert len(list(seen.keys())) == 2
-        assert all(seen.values())
+        assert np.all(seen.values())
 
     def test_n_points_can_vary_between_images(self):
         sampler = iaa.UniformPointsSampler(iap.Choice([1, 10]))

--- a/test/test_imgaug.py
+++ b/test/test_imgaug.py
@@ -1144,7 +1144,10 @@ def test_pad():
             assert np.all(arr_pad[0, 2, :] == v1)
             assert np.all(arr_pad[1, 0, :] == 0)
 
-        arr = np.zeros((1, 1), dtype=dtype) + 0
+        # TODO reactivate this block when np 1.17 pad with mode=linear_ramp
+        #      uint and end_value>edge_value is fixed
+        """
+        arr = np.zeros((1, 1), dtype=dtype) + 100
         arr_pad = ia.pad(arr, top=4, mode="linear_ramp", cval=100)
         assert arr_pad.shape == (5, 1)
         assert arr_pad.dtype == np.dtype(dtype)
@@ -1153,6 +1156,17 @@ def test_pad():
         assert arr_pad[2, 0] == 50
         assert arr_pad[3, 0] == 25
         assert arr_pad[4, 0] == 0
+        
+        arr = np.zeros((1, 1), dtype=dtype) + 100
+        arr_pad = ia.pad(arr, top=4, mode="linear_ramp", cval=0)
+        assert arr_pad.shape == (5, 1)
+        assert arr_pad.dtype == np.dtype(dtype)
+        assert arr_pad[0, 0] == 0
+        assert arr_pad[1, 0] == 25
+        assert arr_pad[2, 0] == 50
+        assert arr_pad[3, 0] == 75
+        assert arr_pad[4, 0] == 100
+        """
 
         # test other channel numbers
         value = int(center_value + 0.25 * max_value)

--- a/test/test_imgaug.py
+++ b/test/test_imgaug.py
@@ -506,17 +506,17 @@ def test_quokka_segmentation_map():
     segmap = ia.quokka_segmentation_map()
     assert segmap.shape == (643, 960, 3)
     assert segmap.arr.shape == (643, 960, 1)
-    assert np.allclose(np.average(segmap.arr), 0.3016427)
+    assert np.allclose(np.average(segmap.arr), 0.3016427, rtol=0, atol=1e-2)
 
     segmap = ia.quokka_segmentation_map(extract="square")
     assert segmap.shape == (643, 643, 3)
     assert segmap.arr.shape == (643, 643, 1)
-    assert np.allclose(np.average(segmap.arr), 0.450353)
+    assert np.allclose(np.average(segmap.arr), 0.450353, rtol=0, atol=1e-2)
 
     segmap = ia.quokka_segmentation_map(size=(642, 959))
     assert segmap.shape == (642, 959, 3)
     assert segmap.arr.shape == (642, 959, 1)
-    assert np.allclose(np.average(segmap.arr), 0.30160266)
+    assert np.allclose(np.average(segmap.arr), 0.30160266, rtol=0, atol=1e-2)
 
 
 def test_quokka_keypoints():

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -2592,10 +2592,10 @@ class TestMultiply(unittest.TestCase):
                 samples = p.draw_samples((2, 3))
 
                 assert p.draw_sample() == v1 * v2
-                assert samples.dtype == np.int64
+                assert samples.dtype.name == "int32"
                 assert np.array_equal(
                     samples,
-                    np.zeros((2, 3), dtype=np.int64) + v1 * v2
+                    np.zeros((2, 3), dtype=np.int32) + v1 * v2
                 )
 
     def test_multiply_example_float_values(self):
@@ -2607,11 +2607,11 @@ class TestMultiply(unittest.TestCase):
                 sample = p.draw_sample()
                 samples = p.draw_samples((2, 3))
 
-                assert v1 * v2 - _eps(sample) < sample < v1 * v2 + _eps(sample)
+                assert np.isclose(sample, v1 * v2, atol=1e-3, rtol=0)
                 assert samples.dtype.kind == "f"
                 assert np.allclose(
                     samples,
-                    np.zeros((2, 3), dtype=np.float64) + v1 * v2
+                    np.zeros((2, 3), dtype=np.float32) + v1 * v2
                 )
 
     def test_multiply_example_float_values_both_deterministic(self):
@@ -2623,11 +2623,11 @@ class TestMultiply(unittest.TestCase):
                 sample = p.draw_sample()
                 samples = p.draw_samples((2, 3))
 
-                assert v1 * v2 - _eps(sample) < sample < v1 * v2 + _eps(sample)
+                assert np.isclose(sample, v1 * v2, atol=1e-3, rtol=0)
                 assert samples.dtype.kind == "f"
                 assert np.allclose(
                     samples,
-                    np.zeros((2, 3), dtype=np.float64) + v1 * v2
+                    np.zeros((2, 3), dtype=np.float32) + v1 * v2
                 )
 
     def test_multiply_by_stochastic_parameter(self):
@@ -2910,7 +2910,7 @@ class TestAdd(unittest.TestCase):
                 assert samples.dtype.kind == "i"
                 assert np.array_equal(
                     samples,
-                    np.zeros((2, 3), dtype=np.int64) + v1 + v2
+                    np.zeros((2, 3), dtype=np.int32) + v1 + v2
                 )
 
     def test_add_integers_both_deterministic(self):
@@ -2927,7 +2927,7 @@ class TestAdd(unittest.TestCase):
                 assert samples.dtype.kind == "i"
                 assert np.array_equal(
                     samples,
-                    np.zeros((2, 3), dtype=np.int64) + v1 + v2
+                    np.zeros((2, 3), dtype=np.int32) + v1 + v2
                 )
 
     def test_add_floats(self):
@@ -2939,11 +2939,11 @@ class TestAdd(unittest.TestCase):
                 sample = p.draw_sample()
                 samples = p.draw_samples((2, 3))
 
-                assert v1 + v2 - _eps(sample) < sample < v1 + v2 + _eps(sample)
+                assert np.isclose(sample, v1 + v2, atol=1e-3, rtol=0)
                 assert samples.dtype.kind == "f"
                 assert np.allclose(
                     samples,
-                    np.zeros((2, 3), dtype=np.float64) + v1 + v2
+                    np.zeros((2, 3), dtype=np.float32) + v1 + v2
                 )
 
     def test_add_floats_both_deterministic(self):
@@ -2955,11 +2955,11 @@ class TestAdd(unittest.TestCase):
                 sample = p.draw_sample()
                 samples = p.draw_samples((2, 3))
 
-                assert v1 + v2 - _eps(sample) < sample < v1 + v2 + _eps(sample)
+                assert np.isclose(sample, v1 + v2, atol=1e-3, rtol=0)
                 assert samples.dtype.kind == "f"
                 assert np.allclose(
                     samples,
-                    np.zeros((2, 3), dtype=np.float64) + v1 + v2
+                    np.zeros((2, 3), dtype=np.float32) + v1 + v2
                 )
 
     def test_add_stochastic_parameter(self):


### PR DESCRIPTION
Adds dedicated segmentation map augmentation (previously: wrapped around heatmap augmentation).
Stays always within integer space, instead of switching to floats.
Should significantly improve performance and lower memory consumption during segmentation map augmentation.
Required memory now grows with the number of segmentation map array components instead of growing with the number of classes (and height/width of the array).

Several breaking changes, see changelog.