### PR TITLE
Fix FlipLR augmentation with floating keypoints

### DIFF
--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -116,8 +116,18 @@ class Fliplr(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
             elif samples[i] == 1:
                 width = keypoints_on_image.shape[1]
                 for keypoint in keypoints_on_image.keypoints:
-                    # TODO is this still correct with float keypoints? Seems like the -1 should be dropped
-                    keypoint.x = (width - 1) - keypoint.x
+                    if isinstance(keypoint.x, int):
+                        # Note: an integer keypoint is equivalent floating
+                        # point keypoint is actually shifted by 0.5 to the
+                        # bottom/right.  This is because integer keypoints
+                        # point to the middle of a pixel / grid cell.
+                        keypoint.x = (width - 1) - keypoint.x
+                        # This is why the int implementation contains a -1 term.
+                        # It is the same thing moving to floating point
+                        # coordinate, flipping and then transforming back:
+                        # keypoint.x = int((width - (keypoint.x + 0.5)) - 0.5)
+                    else:
+                        keypoint.x = width - keypoint.x
         return keypoints_on_images
 
     def _augment_polygons(self, polygons_on_images, random_state, parents,
@@ -209,8 +219,18 @@ class Flipud(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
             elif samples[i] == 1:
                 height = keypoints_on_image.shape[0]
                 for keypoint in keypoints_on_image.keypoints:
-                    # TODO is this still correct with float keypoints? seems like the -1 should be dropped
-                    keypoint.y = (height - 1) - keypoint.y
+                    if isinstance(keypoint.y, int):
+                        # Note: an integer keypoint is equivalent floating
+                        # point keypoint is actually shifted by 0.5 to the
+                        # bottom/right.  This is because integer keypoints
+                        # point to the middle of a pixel / grid cell.
+                        keypoint.y = (height - 1) - keypoint.y
+                        # This is why the int implementation contains a -1 term.
+                        # It is the same thing moving to floating point
+                        # coordinate, flipping and then transforming back:
+                        # keypoint.x = int((width - (keypoint.x + 0.5)) - 0.5)
+                    else:
+                        keypoint.y = height - keypoint.y
         return keypoints_on_images
 
     def _augment_polygons(self, polygons_on_images, random_state, parents,

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -116,18 +116,7 @@ class Fliplr(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
             elif samples[i] == 1:
                 width = keypoints_on_image.shape[1]
                 for keypoint in keypoints_on_image.keypoints:
-                    if isinstance(keypoint.x, int):
-                        # Note: an integer keypoint is equivalent floating
-                        # point keypoint is actually shifted by 0.5 to the
-                        # bottom/right.  This is because integer keypoints
-                        # point to the middle of a pixel / grid cell.
-                        keypoint.x = (width - 1) - keypoint.x
-                        # This is why the int implementation contains a -1 term.
-                        # It is the same thing moving to floating point
-                        # coordinate, flipping and then transforming back:
-                        # keypoint.x = int((width - (keypoint.x + 0.5)) - 0.5)
-                    else:
-                        keypoint.x = width - keypoint.x
+                    keypoint.x = width - float(keypoint.x)
         return keypoints_on_images
 
     def _augment_polygons(self, polygons_on_images, random_state, parents,
@@ -219,18 +208,7 @@ class Flipud(meta.Augmenter):  # pylint: disable=locally-disabled, unused-variab
             elif samples[i] == 1:
                 height = keypoints_on_image.shape[0]
                 for keypoint in keypoints_on_image.keypoints:
-                    if isinstance(keypoint.y, int):
-                        # Note: an integer keypoint is equivalent floating
-                        # point keypoint is actually shifted by 0.5 to the
-                        # bottom/right.  This is because integer keypoints
-                        # point to the middle of a pixel / grid cell.
-                        keypoint.y = (height - 1) - keypoint.y
-                        # This is why the int implementation contains a -1 term.
-                        # It is the same thing moving to floating point
-                        # coordinate, flipping and then transforming back:
-                        # keypoint.x = int((width - (keypoint.x + 0.5)) - 0.5)
-                    else:
-                        keypoint.y = height - keypoint.y
+                    keypoint.y = height - float(keypoint.y)
         return keypoints_on_images
 
     def _augment_polygons(self, polygons_on_images, random_state, parents,

--- a/test/augmenters/test_flip.py
+++ b/test/augmenters/test_flip.py
@@ -54,16 +54,20 @@ def test_Fliplr():
     images = np.array([base_img])
     images_flipped = np.array([base_img_flipped])
 
-    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=0, y=0), ia.Keypoint(x=1, y=1),
-                                      ia.Keypoint(x=2, y=2)], shape=base_img.shape)]
-    keypoints_flipped = [ia.KeypointsOnImage([ia.Keypoint(x=2, y=0), ia.Keypoint(x=1, y=1),
-                                              ia.Keypoint(x=0, y=2)], shape=base_img.shape)]
+    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=0, y=0),
+                                      ia.Keypoint(x=1, y=1),
+                                      ia.Keypoint(x=2, y=2)],
+                                     shape=base_img.shape)]
+    keypoints_flipped = [ia.KeypointsOnImage([ia.Keypoint(x=3-0, y=0),
+                                              ia.Keypoint(x=3-1, y=1),
+                                              ia.Keypoint(x=3-2, y=2)],
+                                             shape=base_img.shape)]
 
     polygons = [ia.PolygonsOnImage(
         [ia.Polygon([(0, 0), (2, 0), (2, 2)])],
         shape=base_img.shape)]
     polygons_flipped = [ia.PolygonsOnImage(
-        [ia.Polygon([(2, 0), (0, 0), (0, 2)])],
+        [ia.Polygon([(3-0, 0), (3-2, 0), (3-2, 2)])],
         shape=base_img.shape)]
 
     # 0% chance of flip
@@ -309,16 +313,20 @@ def test_Flipud():
     images = np.array([base_img])
     images_flipped = np.array([base_img_flipped])
 
-    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=0, y=0), ia.Keypoint(x=1, y=1),
-                                      ia.Keypoint(x=2, y=2)], shape=base_img.shape)]
-    keypoints_flipped = [ia.KeypointsOnImage([ia.Keypoint(x=0, y=2), ia.Keypoint(x=1, y=1),
-                                              ia.Keypoint(x=2, y=0)], shape=base_img.shape)]
+    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=0, y=0),
+                                      ia.Keypoint(x=1, y=1),
+                                      ia.Keypoint(x=2, y=2)],
+                                     shape=base_img.shape)]
+    keypoints_flipped = [ia.KeypointsOnImage([ia.Keypoint(x=0, y=3-0),
+                                              ia.Keypoint(x=1, y=3-1),
+                                              ia.Keypoint(x=2, y=3-2)],
+                                             shape=base_img.shape)]
 
     polygons = [ia.PolygonsOnImage(
         [ia.Polygon([(0, 0), (2, 0), (2, 2)])],
         shape=base_img.shape)]
     polygons_flipped = [ia.PolygonsOnImage(
-        [ia.Polygon([(0, 2), (2, 2), (2, 0)])],
+        [ia.Polygon([(0, 3-0), (2, 3-0), (2, 3-2)])],
         shape=base_img.shape)]
 
     # 0% chance of flip

--- a/test/augmenters/test_meta.py
+++ b/test/augmenters/test_meta.py
@@ -1576,14 +1576,14 @@ def test_Augmenter():
 def test_Augmenter_augment_batches():
     reseed()
 
-    image = np.array([[0, 0, 1, 1],
-                      [0, 0, 1, 1],
-                      [0, 1, 1, 1]], dtype=np.uint8)
+    image = np.array([[0, 0, 1, 1, 1],
+                      [0, 0, 1, 1, 1],
+                      [0, 1, 1, 1, 1]], dtype=np.uint8)
     image_flipped = np.fliplr(image)
     keypoint = ia.Keypoint(x=2, y=1)
     keypoints = [ia.KeypointsOnImage([keypoint], shape=image.shape + (1,))]
     kp_flipped = ia.Keypoint(
-        x=image.shape[1]-1-keypoint.x,
+        x=image.shape[1]-keypoint.x,
         y=keypoint.y
     )
 
@@ -1650,9 +1650,9 @@ def test_Augmenter_augment_batches():
             if np.array_equal(image_aug, image_flipped):
                 nb_flipped_images += 1
 
-            assert (keypoint_aug.x == keypoint.x and keypoint_aug.y == keypoint.y) \
-                or (keypoint_aug.x == kp_flipped.x and keypoint_aug.y == kp_flipped.y)
-            if keypoint_aug.x == kp_flipped.x and keypoint_aug.y == kp_flipped.y:
+            assert np.isclose(keypoint_aug.x, keypoint.x) and np.isclose(keypoint_aug.y, keypoint.y) \
+                or np.isclose(keypoint_aug.x, kp_flipped.x) and np.isclose(keypoint_aug.y, kp_flipped.y)
+            if np.isclose(keypoint_aug.x, kp_flipped.x) and np.isclose(keypoint_aug.y, kp_flipped.y):
                 nb_flipped_keypoints += 1
         assert 0.4*nb_iterations <= nb_flipped_images <= 0.6*nb_iterations
         assert nb_flipped_images == nb_flipped_keypoints
@@ -3338,10 +3338,14 @@ def test_Sequential():
     images_lr_ud_list = [image_lr_ud]
     images_lr_ud = np.array([image_lr_ud])
 
-    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=0), ia.Keypoint(x=2, y=0),
-                                      ia.Keypoint(x=2, y=1)], shape=image.shape)]
-    keypoints_aug = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=2), ia.Keypoint(x=0, y=2),
-                                          ia.Keypoint(x=0, y=1)], shape=image.shape)]
+    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=0),
+                                      ia.Keypoint(x=2, y=0),
+                                      ia.Keypoint(x=2, y=1)],
+                                     shape=image.shape)]
+    keypoints_aug = [ia.KeypointsOnImage([ia.Keypoint(x=3-1, y=3-0),
+                                          ia.Keypoint(x=3-2, y=3-0),
+                                          ia.Keypoint(x=3-2, y=3-1)],
+                                         shape=image.shape)]
 
     polygons = [
         ia.PolygonsOnImage(
@@ -3350,7 +3354,7 @@ def test_Sequential():
     ]
     polygons_aug = [
         ia.PolygonsOnImage(
-            [ia.Polygon([(2, 2), (0, 2), (0, 0), (2, 0)])],
+            [ia.Polygon([(3-0, 3-0), (3-2, 3-0), (3-2, 3-2), (3-0, 3-2)])],
             shape=image.shape)
     ]
 
@@ -4360,21 +4364,27 @@ def test_Sometimes():
     images_ud_list = [image_ud]
     images_ud = np.array([image_ud])
 
-    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=0), ia.Keypoint(x=2, y=0),
-                                      ia.Keypoint(x=2, y=1)], shape=image.shape)]
-    keypoints_lr = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=0), ia.Keypoint(x=0, y=0),
-                                         ia.Keypoint(x=0, y=1)], shape=image.shape)]
-    keypoints_ud = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=2), ia.Keypoint(x=2, y=2),
-                                         ia.Keypoint(x=2, y=1)], shape=image.shape)]
+    keypoints = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=0),
+                                      ia.Keypoint(x=2, y=0),
+                                      ia.Keypoint(x=2, y=1)],
+                                     shape=image.shape)]
+    keypoints_lr = [ia.KeypointsOnImage([ia.Keypoint(x=3-1, y=0),
+                                         ia.Keypoint(x=3-2, y=0),
+                                         ia.Keypoint(x=3-2, y=1)],
+                                        shape=image.shape)]
+    keypoints_ud = [ia.KeypointsOnImage([ia.Keypoint(x=1, y=3-0),
+                                         ia.Keypoint(x=2, y=3-0),
+                                         ia.Keypoint(x=2, y=3-1)],
+                                        shape=image.shape)]
 
     polygons = [ia.PolygonsOnImage(
         [ia.Polygon([(0, 0), (2, 0), (2, 2)])],
         shape=image.shape)]
     polygons_lr = [ia.PolygonsOnImage(
-        [ia.Polygon([(2, 0), (0, 0), (0, 2)])],
+        [ia.Polygon([(3-0, 0), (3-2, 0), (3-2, 2)])],
         shape=image.shape)]
     polygons_ud = [ia.PolygonsOnImage(
-        [ia.Polygon([(0, 2), (2, 2), (2, 0)])],
+        [ia.Polygon([(0, 3-0), (2, 3-0), (2, 3-2)])],
         shape=image.shape)]
 
     heatmaps_arr = np.float32([[0.0, 0.0, 1.0],


### PR DESCRIPTION
The FlipLR implementation for keypoints has the current note: `TODO is this still correct with float keypoints? Seems like the -1 should be dropped`. 

The note is correct, the -1 term should be dropped when keypoints are floats. However, the -1 term is correct when keypoints are integers. To see why consider which point in the image a floating point / integer keypoint is pointing to. 

Consider the example of a 1D image with 5 pixels.

```
 ____ ____ ____ ____ ____
|    |    |    |    |    |
|____|____|____|____|____|
```

A floating point coordinate of 0.0 points all the way to the left

```
 ____ ____ ____ ____ ____
|    |    |    |    |    |
|____|____|____|____|____|
^
float(0.0)
```

However, an integer keypoint actually references **the center** of the 0-th pixel

```
 ____ ____ ____ ____ ____
|    |    |    |    |    |
|____|____|____|____|____|
   ^
   int(0)
```

This means an integer keypoint of (x,y) is actually equivalent to the floating point keypoint (x + 0.5, y + 0.5). If we just consider one dimension the the int-to-float transform is `f(x) = x + 0.5`, and the inverse float-to-int transform is `g(x) = round(x - .5)`.

```
 ____ ____ ____ ____ ____
|    |    |    |    |    |
|____|____|____|____|____|
   ^
   int(0)
   ^
   float(0.5)
```

The correct implementation of FlipLR for floating point keypoints is simply: `(x = width - x)`. 

We can derive the correct integer FlipLR formula by first converting to float, and then back to an integer. 

```
x = g(width - f(x))
```

which simplifies to 

```
x = (width - (x + .5) - .5)
```

which further simplifies to

```
x = (width - x - 1.0)
```

which is the same as the current implementation of FlipLR keypoints as of `0.2.9`. Hence this is why the current implementation works for integers, but fails for floats. 


In this PR I've simply checked to see if the x/y attribute is an integer and applied the old transform, and otherwise I apply the new transform. I haven't tested this, so I'm not sure if the keypoint x/y attributes get converted to floats (even if they were originally integers).

I've been monkey-patching around this issue, and hoping that it was going to be fixed in the newest version, but as `0.2.9` was released and this issue hasn't been fixed yet, I wanted to make sure it was getting some love. Hence the speedy and untested PR. 

Please advise on any issues this implementation may have and how best to address this issue. 