### PR TITLE
Fix Clouds repr

### DIFF
--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -435,7 +435,7 @@ class CloudLayer(meta.Augmenter):
 
     def get_parameters(self):
         return [self.intensity_mean, self.alpha_min, self.alpha_multiplier, self.alpha_size_px_max,
-                self.alpha_freq_exponent, self.intensity_freq_exponent, self.sparsity, self.density_min,
+                self.alpha_freq_exponent, self.intensity_freq_exponent, self.sparsity,
                 self.density_multiplier,
                 self.intensity_coarse_scale]
 


### PR DESCRIPTION
Previously if you printed the Clouds augmenter you got an attribute error:

```
~/code/imgaug/imgaug/augmenters/weather.py in get_parameters(self)
    436     def get_parameters(self):
    437         return [self.intensity_mean, self.alpha_min, self.alpha_multiplier, self.alpha_size_px_max,
--> 438                 self.alpha_freq_exponent, self.intensity_freq_exponent, self.sparsity, self.density_min,
    439                 self.density_multiplier,
    440                 self.intensity_coarse_scale]

AttributeError: 'CloudLayer' object has no attribute 'density_min'
```

This is because the `density_min` parameter does not exist. I simply removed it from `get_parameters` and now it works fine. 
