### PR TITLE
Change opencv-python to opencv-python-headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 * Added the library to ``conda-forge`` so it can now be installed via
   ``conda install imgaug`` (provided the conda-forge channel was added
   before that). #320 #339
+* Changed dependency `opencv-python` to `opencv-python-headless`.
+  This should improve support for some system without GUIs.
 
 ## Fixes
  

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ scipy
 Pillow
 matplotlib
 scikit-image
-opencv-python
+opencv-python-headless
 imageio
 Shapely

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/aleju/imgaug",
     download_url="https://github.com/aleju/imgaug/archive/0.2.9.tar.gz",
     install_requires=["scipy", "scikit-image>=0.11.0", "numpy>=1.15.0", "six", "imageio", "Pillow", "matplotlib",
-                      "Shapely", "opencv-python"],
+                      "Shapely", "opencv-python-headless"],
     packages=find_packages(),
     include_package_data=True,
     package_data={


### PR DESCRIPTION
This should improve support for some server systems.
Not entirely clear though if it plays well with a parallel installation of opencv-python. Remains to be seen.

See https://github.com/skvark/opencv-python/issues/44
Aligns downstream with https://github.com/albu/albumentations/pull/228