### PR TITLE
Add scaling of shorter/longer axis to Resize

### DIFF
--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -200,8 +200,9 @@ class Resize(meta.Augmenter):
               be queried once per image. The resulting value will be used
               for both height and width.
             * If this is a dictionary, it may contain the keys "height" and
-              "width". Each key may have the same datatypes as above and
-              describes the scaling on x and y-axis. Both axis are sampled
+              "width" or the keys "short" and "long". Each key may have the
+              same datatypes as above and describes the scaling on x and y-axis
+              or the shorter and longer-axis, respectively. Both axis are sampled
               independently. Additionally, one of the keys may have the value
               "keep-aspect-ratio", which means that the respective side of the
               image will be resized so that the original aspect ratio is kept.
@@ -274,6 +275,11 @@ class Resize(meta.Augmenter):
     resizes all images to a height of 32 pixels and resizes the x-axis
     (width) so that the aspect ratio is maintained.
 
+    >>> aug = iaa.Resize({"short": 224, "long": "keep-aspect-ratio"})
+
+    resizes all images to a height/width of 224 pixels depending on which axis is shorter
+    and resizes the other axis so that the aspect ratio is maintained.
+
     >>> aug = iaa.Resize({"height": (0.5, 0.75), "width": [16, 32, 64]})
 
     resizes all images to a height of ``H*v``, where ``H`` is the original height
@@ -302,7 +308,7 @@ class Resize(meta.Augmenter):
             elif allow_dict and isinstance(val, dict):
                 if len(val.keys()) == 0:
                     return iap.Deterministic("keep")
-                else:
+                elif any([key in ["height", "width"] for key in val.keys()]):
                     ia.do_assert(all([key in ["height", "width"] for key in val.keys()]))
                     if "height" in val and "width" in val:
                         ia.do_assert(val["height"] != "keep-aspect-ratio" or val["width"] != "keep-aspect-ratio")
@@ -318,6 +324,23 @@ class Resize(meta.Augmenter):
                             entry = iap.Deterministic("keep")
                         size_tuple.append(entry)
                     return tuple(size_tuple)
+                elif any([key in ["short", "long"] for key in val.keys()]):
+                    ia.do_assert(all([key in ["short", "long"] for key in val.keys()]))
+                    if "short" in val and "long" in val:
+                        ia.do_assert(val["short"] != "keep-aspect-ratio" or val["long"] != "keep-aspect-ratio")
+
+                    size_tuple = []
+                    for k in ["short", "long"]:
+                        if k in val:
+                            if val[k] == "keep-aspect-ratio" or val[k] == "keep":
+                                entry = iap.Deterministic(val[k])
+                            else:
+                                entry = handle(val[k], False)
+                        else:
+                            entry = iap.Deterministic("keep")
+                        size_tuple.append(entry)
+                    return tuple(size_tuple)
+
             elif isinstance(val, tuple):
                 ia.do_assert(len(val) == 2)
                 ia.do_assert(val[0] > 0 and val[1] > 0)
@@ -336,14 +359,16 @@ class Resize(meta.Augmenter):
                     return iap.Choice(val)
             elif isinstance(val, iap.StochasticParameter):
                 return val
-            else:
-                raise Exception(
-                    "Expected number, tuple of two numbers, list of numbers, dictionary of "
-                    "form {'height': number/tuple/list/'keep-aspect-ratio'/'keep', "
-                    "'width': <analogous>}, or StochasticParameter, got %s." % (type(val),)
-                )
+
+            raise Exception(
+                "Expected number, tuple of two numbers, list of numbers, dictionary of "
+                "form {'height': number/tuple/list/'keep-aspect-ratio'/'keep', "
+                "'width': <analogous>}, dictionary of form {'short': number/tuple/list/'keep-aspect-ratio'/'keep', "
+                "'long': <analogous>}, or StochasticParameter, got %s." % (type(val),)
+            )
 
         self.size = handle(size, True)
+        self.size_order = 'SL' if (isinstance(size, dict) and 'short' in size) else 'HW'
 
         if interpolation == ia.ALL:
             self.interpolation = iap.Choice(["nearest", "linear", "area", "cubic"])
@@ -362,11 +387,11 @@ class Resize(meta.Augmenter):
     def _augment_images(self, images, random_state, parents, hooks):
         result = []
         nb_images = len(images)
-        samples_h, samples_w, samples_ip = self._draw_samples(nb_images, random_state, do_sample_ip=True)
+        samples_a, samples_b, samples_ip = self._draw_samples(nb_images, random_state, do_sample_ip=True)
         for i in sm.xrange(nb_images):
             image = images[i]
-            sample_h, sample_w, sample_ip = samples_h[i], samples_w[i], samples_ip[i]
-            h, w = self._compute_height_width(image.shape, sample_h, sample_w)
+            sample_a, sample_b, sample_ip = samples_a[i], samples_b[i], samples_ip[i]
+            h, w = self._compute_height_width(image.shape, sample_a, sample_b, self.size_order)
             image_rs = ia.imresize_single_image(image, (h, w), interpolation=sample_ip)
             result.append(image_rs)
 
@@ -380,11 +405,11 @@ class Resize(meta.Augmenter):
     def _augment_heatmaps(self, heatmaps, random_state, parents, hooks):
         result = []
         nb_heatmaps = len(heatmaps)
-        samples_h, samples_w, samples_ip = self._draw_samples(nb_heatmaps, random_state, do_sample_ip=True)
+        samples_a, samples_b, samples_ip = self._draw_samples(nb_heatmaps, random_state, do_sample_ip=True)
         for i in sm.xrange(nb_heatmaps):
             heatmaps_i = heatmaps[i]
-            sample_h, sample_w, sample_ip = samples_h[i], samples_w[i], samples_ip[i]
-            h_img, w_img = self._compute_height_width(heatmaps_i.shape, sample_h, sample_w)
+            sample_a, sample_b, sample_ip = samples_a[i], samples_b[i], samples_ip[i]
+            h_img, w_img = self._compute_height_width(heatmaps_i.shape, sample_a, sample_b, self.size_order)
             h = int(np.round(h_img * (heatmaps_i.arr_0to1.shape[0] / heatmaps_i.shape[0])))
             w = int(np.round(w_img * (heatmaps_i.arr_0to1.shape[1] / heatmaps_i.shape[1])))
             h = max(h, 1)
@@ -398,11 +423,11 @@ class Resize(meta.Augmenter):
     def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
         result = []
         nb_images = len(keypoints_on_images)
-        samples_h, samples_w, _samples_ip = self._draw_samples(nb_images, random_state, do_sample_ip=False)
+        samples_a, samples_b, _samples_ip = self._draw_samples(nb_images, random_state, do_sample_ip=False)
         for i in sm.xrange(nb_images):
             keypoints_on_image = keypoints_on_images[i]
-            sample_h, sample_w = samples_h[i], samples_w[i]
-            h, w = self._compute_height_width(keypoints_on_image.shape, sample_h, sample_w)
+            sample_a, sample_b = samples_a[i], samples_b[i]
+            h, w = self._compute_height_width(keypoints_on_image.shape, sample_a, sample_b, self.size_order)
             new_shape = (h, w) + keypoints_on_image.shape[2:]
             keypoints_on_image_rs = keypoints_on_image.on(new_shape)
 
@@ -430,9 +455,19 @@ class Resize(meta.Augmenter):
         return samples_h, samples_w, samples_ip
 
     @classmethod
-    def _compute_height_width(cls, image_shape, sample_h, sample_w):
+    def _compute_height_width(cls, image_shape, sample_a, sample_b, size_order):
         imh, imw = image_shape[0:2]
-        h, w = sample_h, sample_w
+
+        if size_order == 'SL':
+            # size order: short, long
+            if imh < imw:
+                h, w = sample_a, sample_b
+            else:
+                w, h = sample_a, sample_b
+
+        else:
+            # size order: height, width
+            h, w = sample_a, sample_b
 
         if ia.is_single_float(h):
             ia.do_assert(0 < h)
@@ -460,7 +495,7 @@ class Resize(meta.Augmenter):
         return h, w
 
     def get_parameters(self):
-        return [self.size, self.interpolation]
+        return [self.size, self.interpolation, self.size_order]
 
 
 class CropAndPad(meta.Augmenter):

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -200,7 +200,7 @@ class Resize(meta.Augmenter):
               be queried once per image. The resulting value will be used
               for both height and width.
             * If this is a dictionary, it may contain the keys "height" and
-              "width" or the keys "short" and "long". Each key may have the
+              "width" or the keys "shorter-side" and "longer-side". Each key may have the
               same datatypes as above and describes the scaling on x and y-axis
               or the shorter and longer-axis, respectively. Both axis are sampled
               independently. Additionally, one of the keys may have the value
@@ -275,7 +275,7 @@ class Resize(meta.Augmenter):
     resizes all images to a height of 32 pixels and resizes the x-axis
     (width) so that the aspect ratio is maintained.
 
-    >>> aug = iaa.Resize({"short": 224, "long": "keep-aspect-ratio"})
+    >>> aug = iaa.Resize({"shorter-side": 224, "longer-side": "keep-aspect-ratio"})
 
     resizes all images to a height/width of 224 pixels depending on which axis is shorter
     and resizes the other axis so that the aspect ratio is maintained.
@@ -324,13 +324,13 @@ class Resize(meta.Augmenter):
                             entry = iap.Deterministic("keep")
                         size_tuple.append(entry)
                     return tuple(size_tuple)
-                elif any([key in ["short", "long"] for key in val.keys()]):
-                    ia.do_assert(all([key in ["short", "long"] for key in val.keys()]))
-                    if "short" in val and "long" in val:
-                        ia.do_assert(val["short"] != "keep-aspect-ratio" or val["long"] != "keep-aspect-ratio")
+                elif any([key in ["shorter-side", "longer-side"] for key in val.keys()]):
+                    ia.do_assert(all([key in ["shorter-side", "longer-side"] for key in val.keys()]))
+                    if "shorter-side" in val and "longer-side" in val:
+                        ia.do_assert(val["shorter-side"] != "keep-aspect-ratio" or val["longer-side"] != "keep-aspect-ratio")
 
                     size_tuple = []
-                    for k in ["short", "long"]:
+                    for k in ["shorter-side", "longer-side"]:
                         if k in val:
                             if val[k] == "keep-aspect-ratio" or val[k] == "keep":
                                 entry = iap.Deterministic(val[k])
@@ -363,12 +363,13 @@ class Resize(meta.Augmenter):
             raise Exception(
                 "Expected number, tuple of two numbers, list of numbers, dictionary of "
                 "form {'height': number/tuple/list/'keep-aspect-ratio'/'keep', "
-                "'width': <analogous>}, dictionary of form {'short': number/tuple/list/'keep-aspect-ratio'/'keep', "
-                "'long': <analogous>}, or StochasticParameter, got %s." % (type(val),)
+                "'width': <analogous>}, dictionary of form {'shorter-side': number/tuple/list"
+                "/'keep-aspect-ratio'/'keep', 'longer-side': <analogous>},"
+                " or StochasticParameter, got %s." % (type(val),)
             )
 
         self.size = handle(size, True)
-        self.size_order = 'SL' if (isinstance(size, dict) and 'short' in size) else 'HW'
+        self.size_order = 'SL' if (isinstance(size, dict) and 'shorter-side' in size) else 'HW'
 
         if interpolation == ia.ALL:
             self.interpolation = iap.Choice(["nearest", "linear", "area", "cubic"])

--- a/test/augmenters/test_size.py
+++ b/test/augmenters/test_size.py
@@ -366,6 +366,20 @@ def test_Resize():
     assert observed2d.shape == (int(12 * (1/aspect_ratio2d)), 12)
     assert observed3d.shape == (int(12 * (1/aspect_ratio3d)), 12, 3)
 
+    # change short axis, keep long axis at same aspect ration
+    aug = iaa.Resize({"short": 6, "long": "keep-aspect-ratio"})
+    observed2d = aug.augment_image(base_img2d)
+    observed3d = aug.augment_image(base_img3d)
+    assert observed2d.shape == (6, int(6 * aspect_ratio2d))
+    assert observed3d.shape == (6, int(6 * aspect_ratio3d), 3)
+
+    # change long axis, keep short axis at same aspect ration
+    aug = iaa.Resize({"long": 6, "short": "keep-aspect-ratio"})
+    observed2d = aug.augment_image(base_img2d)
+    observed3d = aug.augment_image(base_img3d)
+    assert observed2d.shape == (int(6 * (1/aspect_ratio2d)), 6)
+    assert observed3d.shape == (int(6 * (1/aspect_ratio3d)), 6, 3)
+
     # change height randomly, width deterministically
     aug = iaa.Resize({"height": [12, 14], "width": 12})
     seen2d = [False, False]

--- a/test/augmenters/test_size.py
+++ b/test/augmenters/test_size.py
@@ -367,14 +367,14 @@ def test_Resize():
     assert observed3d.shape == (int(12 * (1/aspect_ratio3d)), 12, 3)
 
     # change short axis, keep long axis at same aspect ration
-    aug = iaa.Resize({"short": 6, "long": "keep-aspect-ratio"})
+    aug = iaa.Resize({"shorter-side": 6, "longer-side": "keep-aspect-ratio"})
     observed2d = aug.augment_image(base_img2d)
     observed3d = aug.augment_image(base_img3d)
     assert observed2d.shape == (6, int(6 * aspect_ratio2d))
     assert observed3d.shape == (6, int(6 * aspect_ratio3d), 3)
 
     # change long axis, keep short axis at same aspect ration
-    aug = iaa.Resize({"long": 6, "short": "keep-aspect-ratio"})
+    aug = iaa.Resize({"longer-side": 6, "shorter-side": "keep-aspect-ratio"})
     observed2d = aug.augment_image(base_img2d)
     observed3d = aug.augment_image(base_img3d)
     assert observed2d.shape == (int(6 * (1/aspect_ratio2d)), 6)


### PR DESCRIPTION
Adding a new feature to Resize that allows resizing of the shorter / larger image axis. Before Resize was only able to scale width and/or height but not conditionally depending on the image size.

Example:
`
iaa.Resize({'short': (256, 460), 'long': "keep-aspect-ratio"})
`

Fixes issue #138.