### PR TITLE
Require fixed scikit-image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email="kontakt@ajung.name",
     url="https://github.com/aleju/imgaug",
     download_url="https://github.com/aleju/imgaug/archive/0.2.9.tar.gz",
-    install_requires=["scipy", "scikit-image>=0.11.0", "numpy>=1.15.0", "six", "imageio", "Pillow", "matplotlib",
+    install_requires=["scipy", "scikit-image>=0.14.2", "numpy>=1.15.0", "six", "imageio", "Pillow", "matplotlib",
                       "Shapely", "opencv-python-headless"],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This PR fixes the `ImportError: cannot import name '_validate_lengths'` exception from older versions of scikit-image.

To reproduce in a fresh Python installation:

```
pip install scikit-image==0.14.1 imgaug
python -c "import imgaug"
```

But the issue was fixed on their end in [0.14.2](https://github.com/scikit-image/scikit-image/issues/3649#issuecomment-454154866).

This should close #235.

It's not going to fail in your `requirements.txt` because the latest version of scikit-image works correctly. But you could require that to be >= 0.14.2 too.