### PR TITLE
Change docstrings from multiline datatypes to singleline datatypes

### DIFF
--- a/imgaug/augmentables/batches.py
+++ b/imgaug/augmentables/batches.py
@@ -19,44 +19,23 @@ class UnnormalizedBatch(object):
 
     Parameters
     ----------
-    images : None \
-             or (N,H,W,C) ndarray \
-             or (N,H,W) ndarray \
-             or iterable of (H,W,C) ndarray \
-             or iterable of (H,W) ndarray
+    images : None or (N,H,W,C) ndarray or (N,H,W) ndarray or iterable of (H,W,C) ndarray or iterable of (H,W) ndarray
         The images to augment.
 
-    heatmaps : None \
-               or (N,H,W,C) ndarray \
-               or imgaug.augmentables.heatmaps.HeatmapsOnImage \
-               or iterable of (H,W,C) ndarray \
-               or iterable of imgaug.augmentables.heatmaps.HeatmapsOnImage
+    heatmaps : None or (N,H,W,C) ndarray or imgaug.augmentables.heatmaps.HeatmapsOnImage or iterable of (H,W,C) ndarray or iterable of imgaug.augmentables.heatmaps.HeatmapsOnImage
         The heatmaps to augment.
         If anything else than ``HeatmapsOnImage``, then the number of heatmaps
         must match the number of images provided via parameter `images`.
         The number is contained either in ``N`` or the first iterable's size.
 
-    segmentation_maps : None \
-            or (N,H,W) ndarray \
-            or imgaug.augmentables.segmaps.SegmentationMapsOnImage \
-            or iterable of (H,W) ndarray \
-            or iterable of imgaug.augmentables.segmaps.SegmentationMapsOnImage
+    segmentation_maps : None or (N,H,W) ndarray or imgaug.augmentables.segmaps.SegmentationMapsOnImage or iterable of (H,W) ndarray or iterable of imgaug.augmentables.segmaps.SegmentationMapsOnImage
         The segmentation maps to augment.
         If anything else than ``SegmentationMapsOnImage``, then the number of
         segmaps must match the number of images provided via parameter
         `images`. The number is contained either in ``N`` or the first
         iterable's size.
 
-    keypoints : None \
-                or list of (N,K,2) ndarray \
-                or tuple of number \
-                or imgaug.augmentables.kps.Keypoint \
-                or iterable of (K,2) ndarray \
-                or iterable of tuple of number \
-                or iterable of imgaug.augmentables.kps.Keypoint \
-                or iterable of imgaug.augmentables.kps.KeypointOnImage \
-                or iterable of iterable of tuple of number \
-                or iterable of iterable of imgaug.augmentables.kps.Keypoint
+    keypoints : None or list of (N,K,2) ndarray or tuple of number or imgaug.augmentables.kps.Keypoint or iterable of (K,2) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.kps.Keypoint or iterable of imgaug.augmentables.kps.KeypointOnImage or iterable of iterable of tuple of number or iterable of iterable of imgaug.augmentables.kps.Keypoint
         The keypoints to augment.
         If a tuple (or iterable(s) of tuple), then iterpreted as (x,y)
         coordinates and must hence contain two numbers.
@@ -72,38 +51,13 @@ class UnnormalizedBatch(object):
         in case of "iterable of iterable of tuples" in the first iterable's
         size.
 
-    bounding_boxes : None \
-                or (N,B,4) ndarray \
-                or tuple of number \
-                or imgaug.augmentables.bbs.BoundingBox \
-                or imgaug.augmentables.bbs.BoundingBoxesOnImage \
-                or iterable of (B,4) ndarray \
-                or iterable of tuple of number \
-                or iterable of imgaug.augmentables.bbs.BoundingBox \
-                or iterable of imgaug.augmentables.bbs.BoundingBoxesOnImage \
-                or iterable of iterable of tuple of number \
-                or iterable of iterable imgaug.augmentables.bbs.BoundingBox
+    bounding_boxes : None or (N,B,4) ndarray or tuple of number or imgaug.augmentables.bbs.BoundingBox or imgaug.augmentables.bbs.BoundingBoxesOnImage or iterable of (B,4) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.bbs.BoundingBox or iterable of imgaug.augmentables.bbs.BoundingBoxesOnImage or iterable of iterable of tuple of number or iterable of iterable imgaug.augmentables.bbs.BoundingBox
         The bounding boxes to augment.
         This is analogous to the `keypoints` parameter. However, each
         tuple -- and also the last index in case of arrays -- has size 4,
         denoting the bounding box coordinates ``x1``, ``y1``, ``x2`` and ``y2``.
 
-    polygons : None  \
-               or (N,#polys,#points,2) ndarray \
-               or imgaug.augmentables.polys.Polygon \
-               or imgaug.augmentables.polys.PolygonsOnImage \
-               or iterable of (#polys,#points,2) ndarray \
-               or iterable of tuple of number \
-               or iterable of imgaug.augmentables.kps.Keypoint \
-               or iterable of imgaug.augmentables.polys.Polygon \
-               or iterable of imgaug.augmentables.polys.PolygonsOnImage \
-               or iterable of iterable of (#points,2) ndarray \
-               or iterable of iterable of tuple of number \
-               or iterable of iterable of imgaug.augmentables.kps.Keypoint \
-               or iterable of iterable of imgaug.augmentables.polys.Polygon \
-               or iterable of iterable of iterable of tuple of number \
-               or iterable of iterable of iterable of tuple of \
-               imgaug.augmentables.kps.Keypoint
+    polygons : None  or (N,#polys,#points,2) ndarray or imgaug.augmentables.polys.Polygon or imgaug.augmentables.polys.PolygonsOnImage or iterable of (#polys,#points,2) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.kps.Keypoint or iterable of imgaug.augmentables.polys.Polygon or iterable of imgaug.augmentables.polys.PolygonsOnImage or iterable of iterable of (#points,2) ndarray or iterable of iterable of tuple of number or iterable of iterable of imgaug.augmentables.kps.Keypoint or iterable of iterable of imgaug.augmentables.polys.Polygon or iterable of iterable of iterable of tuple of number or iterable of iterable of iterable of tuple of imgaug.augmentables.kps.Keypoint
         The polygons to augment.
         This is similar to the `keypoints` parameter. However, each polygon
         may be made up of several ``(x,y)`` coordinates (three or more are
@@ -133,22 +87,7 @@ class UnnormalizedBatch(object):
           * ``iterable of iterable of iterable of tuple of number``
           * ``iterable of iterable of iterable of tuple of imgaug.augmentables.kps.Keypoint``
 
-    line_strings : None  \
-               or (N,#lines,#points,2) ndarray \
-               or imgaug.augmentables.lines.LineString \
-               or imgaug.augmentables.lines.LineStringOnImage \
-               or iterable of (#lines,#points,2) ndarray \
-               or iterable of tuple of number \
-               or iterable of imgaug.augmentables.kps.Keypoint \
-               or iterable of imgaug.augmentables.lines.LineString \
-               or iterable of imgaug.augmentables.lines.LineStringOnImage \
-               or iterable of iterable of (#points,2) ndarray \
-               or iterable of iterable of tuple of number \
-               or iterable of iterable of imgaug.augmentables.kps.Keypoint \
-               or iterable of iterable of imgaug.augmentables.polys.LineString \
-               or iterable of iterable of iterable of tuple of number \
-               or iterable of iterable of iterable of tuple of \
-               imgaug.augmentables.kps.Keypoint
+    line_strings : None or (N,#lines,#points,2) ndarray or imgaug.augmentables.lines.LineString or imgaug.augmentables.lines.LineStringOnImage or iterable of (#lines,#points,2) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.kps.Keypoint or iterable of imgaug.augmentables.lines.LineString or iterable of imgaug.augmentables.lines.LineStringOnImage or iterable of iterable of (#points,2) ndarray or iterable of iterable of tuple of number or iterable of iterable of imgaug.augmentables.kps.Keypoint or iterable of iterable of imgaug.augmentables.polys.LineString or iterable of iterable of iterable of tuple of number or iterable of iterable of iterable of tuple of imgaug.augmentables.kps.Keypoint
         The line strings to augment.
         See `polygons` for more details as polygons follow a similar
         structure to line strings.
@@ -292,15 +231,13 @@ class Batch(object):
     heatmaps : None or list of imgaug.augmentables.heatmaps.HeatmapsOnImage
         The heatmaps to augment.
 
-    segmentation_maps : None or list of \
-                        imgaug.augmentables.segmaps.SegmentationMapsOnImage
+    segmentation_maps : None or list of imgaug.augmentables.segmaps.SegmentationMapsOnImage
         The segmentation maps to augment.
 
     keypoints : None or list of imgaug.augmentables.kps.KeypointOnImage
         The keypoints to augment.
 
-    bounding_boxes : None \
-                     or list of imgaug.augmentables.bbs.BoundingBoxesOnImage
+    bounding_boxes : None or list of imgaug.augmentables.bbs.BoundingBoxesOnImage
         The bounding boxes to augment.
 
     polygons : None or list of imgaug.augmentables.polys.PolygonsOnImage

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -163,9 +163,7 @@ class LineString(object):
 
         Parameters
         ----------
-        other : tuple of number \
-                or imgaug.augmentables.kps.Keypoint \
-                or imgaug.augmentables.LineString
+        other : tuple of number or imgaug.augmentables.kps.Keypoint or imgaug.augmentables.LineString
             Other object to which to compute the distances.
 
         default
@@ -206,9 +204,7 @@ class LineString(object):
 
         Parameters
         ----------
-        other : tuple of number \
-                or imgaug.augmentables.kps.Keypoint \
-                or imgaug.augmentables.LineString
+        other : tuple of number or imgaug.augmentables.kps.Keypoint or imgaug.augmentables.LineString
             Other object to which to compute the distance.
 
         default
@@ -494,8 +490,7 @@ class LineString(object):
 
         Parameters
         ----------
-        other : tuple of number or list of tuple of number or \
-                list of LineString or LineString
+        other : tuple of number or list of tuple of number or list of LineString or LineString
             The other geometry to use during intersection tests.
 
         Returns
@@ -1143,8 +1138,7 @@ class LineString(object):
 
         Parameters
         ----------
-        other : imgaug.augmentables.lines.LineString or ndarray \
-                or iterable of tuple of number
+        other : imgaug.augmentables.lines.LineString or ndarray or iterable of tuple of number
             The points to add to this line string.
 
         Returns
@@ -1333,11 +1327,7 @@ class LineString(object):
 
         Parameters
         ----------
-        other : imgaug.augmentables.lines.LineString \
-                or tuple of number \
-                or ndarray \
-                or list of ndarray \
-                or list of tuple of number
+        other : imgaug.augmentables.lines.LineString or tuple of number or ndarray or list of ndarray or list of tuple of number
             The other line string or its coordinates.
 
         max_distance : float, optional
@@ -1767,8 +1757,7 @@ class LineStringsOnImage(object):
 
         Parameters
         ----------
-        line_strings : None \
-                       or list of imgaug.augmentables.lines.LineString, optional
+        line_strings : None or list of imgaug.augmentables.lines.LineString, optional
             List of line strings on the image.
             If not ``None``, then the ``line_strings`` attribute of the copied
             object will be set to this value.
@@ -1796,8 +1785,7 @@ class LineStringsOnImage(object):
 
         Parameters
         ----------
-        line_strings : None \
-                       or list of imgaug.augmentables.lines.LineString, optional
+        line_strings : None or list of imgaug.augmentables.lines.LineString, optional
             List of line strings on the image.
             If not ``None``, then the ``line_strings`` attribute of the copied
             object will be set to this value.

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -1842,8 +1842,7 @@ class MultiPolygon(object):
 
         Parameters
         ----------
-        geometry : shapely.geometry.MultiPolygon or shapely.geometry.Polygon\
-                   or shapely.geometry.collection.GeometryCollection
+        geometry : shapely.geometry.MultiPolygon or shapely.geometry.Polygon or shapely.geometry.collection.GeometryCollection
             The object to convert to a MultiPolygon.
 
         label : None or str, optional

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -357,8 +357,7 @@ class AverageBlur(meta.Augmenter):  # pylint: disable=locally-disabled, unused-v
 
     Parameters
     ----------
-    k : int or tuple of int or tuple of tuple of int or imgaug.parameters.StochasticParameter\
-        or tuple of StochasticParameter, optional
+    k : int or tuple of int or tuple of tuple of int or imgaug.parameters.StochasticParameter or tuple of StochasticParameter, optional
         Kernel size to use.
 
             * If a single int, then that value will be used for the height

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -775,9 +775,7 @@ class AllChannelsCLAHE(meta.Augmenter):
     clip_limit : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See ``imgaug.augmenters.contrast.CLAHE``.
 
-    tile_grid_size_px : int or tuple of int or list of int or imgaug.parameters.StochasticParameter \
-                        or tuple of tuple of int or tuple of list of int \
-                        or tuple of imgaug.parameters.StochasticParameter, optional
+    tile_grid_size_px : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or tuple of tuple of int or tuple of list of int or tuple of imgaug.parameters.StochasticParameter, optional
         See ``imgaug.augmenters.contrast.CLAHE``.
 
     tile_grid_size_px_min : int, optional
@@ -943,9 +941,7 @@ class CLAHE(meta.Augmenter):
             * If a list, then a random value will be sampled from that list per image.
             * If a StochasticParameter, then a value will be sampled per image from that parameter.
 
-    tile_grid_size_px : int or tuple of int or list of int or imgaug.parameters.StochasticParameter \
-                        or tuple of tuple of int or tuple of list of int \
-                        or tuple of imgaug.parameters.StochasticParameter, optional
+    tile_grid_size_px : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or tuple of tuple of int or tuple of list of int or tuple of imgaug.parameters.StochasticParameter, optional
         Kernel size, i.e. size of each local neighbourhood in pixels.
 
             * If an int, then that value will be used for all images for both kernel height and width.

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -195,9 +195,7 @@ class Affine(meta.Augmenter):
 
     Parameters
     ----------
-    scale : number or tuple of number or list of number or imgaug.parameters.StochasticParameter\
-            or dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter},\
-            optional
+    scale : number or tuple of number or list of number or imgaug.parameters.StochasticParameter or dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter}, optional
         Scaling factor to use,
         where 1.0 represents no change and 0.5 is zoomed out to 50 percent of the original size.
 
@@ -215,9 +213,7 @@ class Affine(meta.Augmenter):
               set different values for the axis. If they are set to the same
               ranges, different values may still be sampled per axis.
 
-    translate_percent : None or number or tuple of number or list of number or imgaug.parameters.StochasticParameter or\
-                        dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter},\
-                        optional
+    translate_percent : None or number or tuple of number or list of number or imgaug.parameters.StochasticParameter or dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter}, optional
         Translation in percent relative to the image height/width (x-translation, y-translation) to use,
         where 0 represents no change and 0.5 is half of the image height/width.
 
@@ -237,9 +233,7 @@ class Affine(meta.Augmenter):
               If they are set to the same ranges, different values may still
               be sampled per axis.
 
-    translate_px : None or int or tuple of int or list of int or imgaug.parameters.StochasticParameter or\
-                   dict {"x": int/tuple/list/StochasticParameter, "y": int/tuple/list/StochasticParameter},\
-                   optional
+    translate_px : None or int or tuple of int or list of int or imgaug.parameters.StochasticParameter or dict {"x": int/tuple/list/StochasticParameter, "y": int/tuple/list/StochasticParameter}, optional
         Translation in pixels.
 
             * If None then equivalent to 0.0 unless translate_percent has a non-None value.
@@ -1046,9 +1040,7 @@ class AffineCv2(meta.Augmenter):
 
     Parameters
     ----------
-    scale : number or tuple of number or list of number or imgaug.parameters.StochasticParameter or\
-            dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter},\
-            optional
+    scale : number or tuple of number or list of number or imgaug.parameters.StochasticParameter or dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter}, optional
         Scaling factor to use,
         where 1.0 represents no change and 0.5 is zoomed out to 50 percent of the original size.
 
@@ -1066,9 +1058,7 @@ class AffineCv2(meta.Augmenter):
               set different values for the axis. If they are set to the same
               ranges, different values may still be sampled per axis.
 
-    translate_percent : number or tuple of number or list of number or imgaug.parameters.StochasticParameter or\
-                        dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter},\
-                        optional
+    translate_percent : number or tuple of number or list of number or imgaug.parameters.StochasticParameter or dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter}, optional
         Translation in percent relative to the image
         height/width (x-translation, y-translation) to use,
         where 0 represents no change and 0.5 is half of the image
@@ -1089,9 +1079,7 @@ class AffineCv2(meta.Augmenter):
               If they are set to the same ranges, different values may still
               be sampled per axis.
 
-    translate_px : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or\
-                   dict {"x": int/tuple/list/StochasticParameter, "y": int/tuple/list/StochasticParameter},\
-                   optional
+    translate_px : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or dict {"x": int/tuple/list/StochasticParameter, "y": int/tuple/list/StochasticParameter}, optional
         Translation in pixels.
 
             * If a single int, then that value will be used for all images.

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -231,10 +231,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        batches : imgaug.augmentables.batches.Batch \
-                  or imgaug.augmentables.batches.UnnormalizedBatch \
-                  or iterable of imgaug.augmentables.batches.Batch \
-                  or iterable of imgaug.augmentables.batches.UnnormalizedBatch
+        batches : imgaug.augmentables.batches.Batch or imgaug.augmentables.batches.UnnormalizedBatch or iterable of imgaug.augmentables.batches.Batch or iterable of imgaug.augmentables.batches.UnnormalizedBatch
             A single batch or a list of batches to augment.
 
         hooks : None or imgaug.HooksImages, optional
@@ -254,10 +251,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Yields
         -------
-        imgaug.augmentables.batches.Batch \
-                  or imgaug.augmentables.batches.UnnormalizedBatch \
-                  or iterable of imgaug.augmentables.batches.Batch \
-                  or iterable of imgaug.augmentables.batches.UnnormalizedBatch
+        imgaug.augmentables.batches.Batch or imgaug.augmentables.batches.UnnormalizedBatch or iterable of imgaug.augmentables.batches.Batch or iterable of imgaug.augmentables.batches.UnnormalizedBatch
             Augmented batches.
 
         """
@@ -421,8 +415,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        batch : imgaug.augmentables.batches.Batch \
-                or imgaug.augmentables.batches.UnnormalizedBatch
+        batch : imgaug.augmentables.batches.Batch or imgaug.augmentables.batches.UnnormalizedBatch
             A single batch to augment.
 
         hooks : None or imgaug.HooksImages, optional
@@ -431,8 +424,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Returns
         -------
-        imgaug.augmentables.batches.Batch \
-                or imgaug.augmentables.batches.UnnormalizedBatch
+        imgaug.augmentables.batches.Batch or imgaug.augmentables.batches.UnnormalizedBatch
             Augmented batch.
 
         """
@@ -839,8 +831,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        segmaps : imgaug.SegmentationMapsOnImage or \
-                  list of imgaug.SegmentationMapsOnImage
+        segmaps : imgaug.SegmentationMapsOnImage or list of imgaug.SegmentationMapsOnImage
             Segmentation map(s) to augment. Either a single heatmap or a list
             of segmentation maps.
 
@@ -855,8 +846,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Returns
         -------
-        segmaps_aug : imgaug.SegmentationMapsOnImage or \
-                      list of imgaug.SegmentationMapsOnImage
+        segmaps_aug : imgaug.SegmentationMapsOnImage or list of imgaug.SegmentationMapsOnImage
             Corresponding augmented segmentation map(s).
 
         """
@@ -982,8 +972,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        keypoints_on_images : imgaug.KeypointsOnImage or \
-                              list of imgaug.KeypointsOnImage
+        keypoints_on_images : imgaug.KeypointsOnImage or list of imgaug.KeypointsOnImage
             The keypoints/landmarks to augment.
             Expected is an instance of imgaug.KeypointsOnImage or a list of
             imgaug.KeypointsOnImage objects, with each such object containing
@@ -1000,8 +989,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Returns
         -------
-        keypoints_on_images_result : imgaug.KeypointsOnImage or \
-                                     list of imgaug.KeypointsOnImage
+        keypoints_on_images_result : imgaug.KeypointsOnImage or list of imgaug.KeypointsOnImage
             Augmented keypoints.
 
         """
@@ -1123,8 +1111,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        bounding_boxes_on_images : imgaug.BoundingBoxesOnImage or \
-                                   list of imgaug.BoundingBoxesOnImage
+        bounding_boxes_on_images : imgaug.BoundingBoxesOnImage or list of imgaug.BoundingBoxesOnImage
             The bounding boxes to augment.
             Expected is an instance of imgaug.BoundingBoxesOnImage or a list of
             imgaug.BoundingBoxesOnImage objects, with each such object
@@ -1136,8 +1123,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Returns
         -------
-        result : imgaug.BoundingBoxesOnImage or \
-                 list of imgaug.BoundingBoxesOnImage
+        result : imgaug.BoundingBoxesOnImage or list of imgaug.BoundingBoxesOnImage
             Augmented bounding boxes.
 
         """
@@ -1218,8 +1204,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        polygons_on_images : imgaug.PolygonsOnImage or \
-                             list of imgaug.PolygonsOnImage
+        polygons_on_images : imgaug.PolygonsOnImage or list of imgaug.PolygonsOnImage
             The polygons to augment.
             Expected is an instance of imgaug.PolygonsOnImage or a list of
             imgaug.PolygonsOnImage objects, with each such object
@@ -1296,8 +1281,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        line_strings_on_images : imgaug.augmentables.lines.LineStringsOnImage \
-                                 or list of imgaug.augmentables.lines.LineStringsOnImage
+        line_strings_on_images : imgaug.augmentables.lines.LineStringsOnImage or list of imgaug.augmentables.lines.LineStringsOnImage
             The line strings to augment.
             Expected is an instance of LineStringsOnImage or a list of
             LineStringsOnImage objects, with each such object containing the
@@ -1314,8 +1298,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Returns
         -------
-        imgaug.augmentables.lines.LineStringsOnImage \
-        or list of imgaug.augmentables.lines.LineStringsOnImage
+        imgaug.augmentables.lines.LineStringsOnImage or list of imgaug.augmentables.lines.LineStringsOnImage
             Augmented line strings.
 
         """
@@ -1356,10 +1339,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
         subaugment_func : callable
             Function that will be called to actually augment the data.
 
-        augables_ois : imgaug.augmentables.polys.PolygonsOnImage \
-                       or imgaug.augmentables.lines.LineStringsOnImage \
-                       or list of imgaug.augmentables.lines.LineStringsOnImage \
-                       or list of imgaug.augmentables.polys.PolygonsOnImage
+        augables_ois : imgaug.augmentables.polys.PolygonsOnImage or imgaug.augmentables.lines.LineStringsOnImage or list of imgaug.augmentables.lines.LineStringsOnImage or list of imgaug.augmentables.polys.PolygonsOnImage
             The augmentables to augment. `augables_ois` is the abbreviation for
             "augmentables_on_images". Expected are the augmentables on a
             single image (single instance) or 1+ images (list of instances).
@@ -1375,10 +1355,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Returns
         -------
-        imgaug.augmentables.polys.PolygonsOnImage \
-        or imgaug.augmentables.lines.LineStringsOnImage \
-        or list of imgaug.augmentables.polys.PolygonsOnImage \
-        or list of imgaug.augmentables.lines.LineStringsOnImage
+        imgaug.augmentables.polys.PolygonsOnImage or imgaug.augmentables.lines.LineStringsOnImage or list of imgaug.augmentables.polys.PolygonsOnImage or list of imgaug.augmentables.lines.LineStringsOnImage
             Augmented augmentables.
 
         """
@@ -1651,59 +1628,31 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        image : None
-            or (H,W,C) ndarray \
-            or (H,W) ndarray, \
-            optional
+        image : None or (H,W,C) ndarray or (H,W) ndarray, optional
             The image to augment. Only this or `images` can be set, not both.
             If `return_batch` is ``False`` and the python version is below 3.6,
             either this or `images` **must** be provided.
 
-        images : None \
-            or (N,H,W,C) ndarray \
-            or (N,H,W) ndarray \
-            or iterable of (H,W,C) ndarray \
-            or iterable of (H,W) ndarray, \
-            optional
+        images : None or (N,H,W,C) ndarray or (N,H,W) ndarray or iterable of (H,W,C) ndarray or iterable of (H,W) ndarray, optional
             The images to augment. Only this or `image` can be set, not both.
             If `return_batch` is ``False`` and the python version is below 3.6,
             either this or `image` **must** be provided.
 
-        heatmaps : None \
-            or (N,H,W,C) ndarray \
-            or imgaug.augmentables.heatmaps.HeatmapsOnImage \
-            or iterable of (H,W,C) ndarray \
-            or iterable of imgaug.augmentables.heatmaps.HeatmapsOnImage, \
-            optional
+        heatmaps : None or (N,H,W,C) ndarray or imgaug.augmentables.heatmaps.HeatmapsOnImage or iterable of (H,W,C) ndarray or iterable of imgaug.augmentables.heatmaps.HeatmapsOnImage, optional
             The heatmaps to augment.
             If anything else than ``HeatmapsOnImage``, then the number of
             heatmaps must match the number of images provided via parameter
             `images`. The number is contained either in ``N`` or the first
             iterable's size.
 
-        segmentation_maps : None \
-            or (N,H,W) ndarray \
-            or imgaug.augmentables.segmaps.SegmentationMapsOnImage \
-            or iterable of (H,W) ndarray \
-            or iterable of imgaug.augmentables.segmaps.SegmentationMapsOnImage, \
-            optional
+        segmentation_maps : None or (N,H,W) ndarray or imgaug.augmentables.segmaps.SegmentationMapsOnImage or iterable of (H,W) ndarray or iterable of imgaug.augmentables.segmaps.SegmentationMapsOnImage, optional
             The segmentation maps to augment.
             If anything else than ``SegmentationMapsOnImage``, then the number
             of segmaps must match the number of images provided via parameter
             `images`. The number is contained either in ``N`` or the first
             iterable's size.
 
-        keypoints : None \
-            or list of (N,K,2) ndarray \
-            or tuple of number \
-            or imgaug.augmentables.kps.Keypoint \
-            or iterable of (K,2) ndarray \
-            or iterable of tuple of number \
-            or iterable of imgaug.augmentables.kps.Keypoint \
-            or iterable of imgaug.augmentables.kps.KeypointOnImage \
-            or iterable of iterable of tuple of number \
-            or iterable of iterable of imgaug.augmentables.kps.Keypoint, \
-            optional
+        keypoints : None or list of (N,K,2) ndarray or tuple of number or imgaug.augmentables.kps.Keypoint or iterable of (K,2) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.kps.Keypoint or iterable of imgaug.augmentables.kps.KeypointOnImage or iterable of iterable of tuple of number or iterable of iterable of imgaug.augmentables.kps.Keypoint, optional
             The keypoints to augment.
             If a tuple (or iterable(s) of tuple), then iterpreted as (x,y)
             coordinates and must hence contain two numbers.
@@ -1719,41 +1668,14 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
             in case of "iterable of iterable of tuples" in the first iterable's
             size.
 
-        bounding_boxes : None \
-            or (N,B,4) ndarray \
-            or tuple of number \
-            or imgaug.augmentables.bbs.BoundingBox \
-            or imgaug.augmentables.bbs.BoundingBoxesOnImage \
-            or iterable of (B,4) ndarray \
-            or iterable of tuple of number \
-            or iterable of imgaug.augmentables.bbs.BoundingBox \
-            or iterable of imgaug.augmentables.bbs.BoundingBoxesOnImage \
-            or iterable of iterable of tuple of number \
-            or iterable of iterable imgaug.augmentables.bbs.BoundingBox, \
-            optional
+        bounding_boxes : None or (N,B,4) ndarray or tuple of number or imgaug.augmentables.bbs.BoundingBox or imgaug.augmentables.bbs.BoundingBoxesOnImage or iterable of (B,4) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.bbs.BoundingBox or iterable of imgaug.augmentables.bbs.BoundingBoxesOnImage or iterable of iterable of tuple of number or iterable of iterable imgaug.augmentables.bbs.BoundingBox, optional
             The bounding boxes to augment.
             This is analogous to the `keypoints` parameter. However, each
             tuple -- and also the last index in case of arrays -- has size 4,
             denoting the bounding box coordinates ``x1``, ``y1``, ``x2`` and
             ``y2``.
 
-        polygons : None  \
-            or (N,#polys,#points,2) ndarray \
-            or imgaug.augmentables.polys.Polygon \
-            or imgaug.augmentables.polys.PolygonsOnImage \
-            or iterable of (#polys,#points,2) ndarray \
-            or iterable of tuple of number \
-            or iterable of imgaug.augmentables.kps.Keypoint \
-            or iterable of imgaug.augmentables.polys.Polygon \
-            or iterable of imgaug.augmentables.polys.PolygonsOnImage \
-            or iterable of iterable of (#points,2) ndarray \
-            or iterable of iterable of tuple of number \
-            or iterable of iterable of imgaug.augmentables.kps.Keypoint \
-            or iterable of iterable of imgaug.augmentables.polys.Polygon \
-            or iterable of iterable of iterable of tuple of number \
-            or iterable of iterable of iterable of tuple of \
-            imgaug.augmentables.kps.Keypoint, \
-            optional
+        polygons : None or (N,#polys,#points,2) ndarray or imgaug.augmentables.polys.Polygon or imgaug.augmentables.polys.PolygonsOnImage or iterable of (#polys,#points,2) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.kps.Keypoint or iterable of imgaug.augmentables.polys.Polygon or iterable of imgaug.augmentables.polys.PolygonsOnImage or iterable of iterable of (#points,2) ndarray or iterable of iterable of tuple of number or iterable of iterable of imgaug.augmentables.kps.Keypoint or iterable of iterable of imgaug.augmentables.polys.Polygon or iterable of iterable of iterable of tuple of number or iterable of iterable of iterable of tuple of imgaug.augmentables.kps.Keypoint, optional
             The polygons to augment.
             This is similar to the `keypoints` parameter. However, each polygon
             may be made up of several (x,y) coordinates (three or more are
@@ -1783,23 +1705,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
               * ``iterable of iterable of iterable of tuple of number``
               * ``iterable of iterable of iterable of tuple of imgaug.augmentables.kps.Keypoint``
 
-        line_strings : None \
-            or (N,#lines,#points,2) ndarray \
-            or imgaug.augmentables.lines.LineString \
-            or imgaug.augmentables.lines.LineStringOnImage \
-            or iterable of (#polys,#points,2) ndarray \
-            or iterable of tuple of number \
-            or iterable of imgaug.augmentables.kps.Keypoint \
-            or iterable of imgaug.augmentables.lines.LineString \
-            or iterable of imgaug.augmentables.lines.LineStringOnImage \
-            or iterable of iterable of (#points,2) ndarray \
-            or iterable of iterable of tuple of number \
-            or iterable of iterable of imgaug.augmentables.kps.Keypoint \
-            or iterable of iterable of imgaug.augmentables.lines.LineString \
-            or iterable of iterable of iterable of tuple of number \
-            or iterable of iterable of iterable of tuple of \
-            imgaug.augmentables.kps.Keypoint, \
-            optional
+        line_strings : None or (N,#lines,#points,2) ndarray or imgaug.augmentables.lines.LineString or imgaug.augmentables.lines.LineStringOnImage or iterable of (#polys,#points,2) ndarray or iterable of tuple of number or iterable of imgaug.augmentables.kps.Keypoint or iterable of imgaug.augmentables.lines.LineString or iterable of imgaug.augmentables.lines.LineStringOnImage or iterable of iterable of (#points,2) ndarray or iterable of iterable of tuple of number or iterable of iterable of imgaug.augmentables.kps.Keypoint or iterable of iterable of imgaug.augmentables.lines.LineString or iterable of iterable of iterable of tuple of number or iterable of iterable of iterable of tuple of imgaug.augmentables.kps.Keypoint, optional
             The line strings to augment.
             See `polygons`, which behaves similarly.
 
@@ -2078,8 +1984,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         -------
-        images : (N,H,W,3) ndarray or (H,W,3) ndarray or (H,W) ndarray or list of (H,W,3) ndarray\
-                 or list of (H,W) ndarray
+        images : (N,H,W,3) ndarray or (H,W,3) ndarray or (H,W) ndarray or list of (H,W,3) ndarray or list of (H,W) ndarray
             List of images of which to show the augmented versions.
             If a list, then each element is expected to have shape ``(H, W)`` or
             ``(H, W, 3)``. If a single array, then it is expected to have
@@ -2168,8 +2073,7 @@ class Augmenter(object):  # pylint: disable=locally-disabled, unused-variable, l
 
         Parameters
         ----------
-        images : (N,H,W,3) ndarray or (H,W,3) ndarray or (H,W) ndarray or list of (H,W,3) ndarray\
-                 or list of (H,W) ndarray
+        images : (N,H,W,3) ndarray or (H,W,3) ndarray or (H,W) ndarray or list of (H,W,3) ndarray or list of (H,W) ndarray
             List of images of which to show the augmented versions.
             If a list, then each element is expected to have shape ``(H, W)`` or ``(H, W, 3)``.
             If a single array, then it is expected to have shape ``(N, H, W, 3)``

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -130,10 +130,7 @@ class AveragePooling(_AbstractPoolingBase):
 
     Attributes
     ----------
-    kernel_size : int or tuple of int or list of int \
-                  or imgaug.parameters.StochasticParameter \
-                  or tuple of tuple of int or tuple of list of int \
-                  or tuple of imgaug.parameters.StochasticParameter, optional
+    kernel_size : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or tuple of tuple of int or tuple of list of int or tuple of imgaug.parameters.StochasticParameter, optional
         The kernel size of the pooling operation.
 
         * If an int, then that value will be used for all images for both
@@ -240,10 +237,7 @@ class MaxPooling(_AbstractPoolingBase):
 
     Attributes
     ----------
-    kernel_size : int or tuple of int or list of int \
-                  or imgaug.parameters.StochasticParameter \
-                  or tuple of tuple of int or tuple of list of int \
-                  or tuple of imgaug.parameters.StochasticParameter, optional
+    kernel_size : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or tuple of tuple of int or tuple of list of int or tuple of imgaug.parameters.StochasticParameter, optional
         The kernel size of the pooling operation.
 
         * If an int, then that value will be used for all images for both
@@ -352,10 +346,7 @@ class MinPooling(_AbstractPoolingBase):
 
     Attributes
     ----------
-    kernel_size : int or tuple of int or list of int \
-                  or imgaug.parameters.StochasticParameter \
-                  or tuple of tuple of int or tuple of list of int \
-                  or tuple of imgaug.parameters.StochasticParameter, optional
+    kernel_size : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or tuple of tuple of int or tuple of list of int or tuple of imgaug.parameters.StochasticParameter, optional
         The kernel size of the pooling operation.
 
         * If an int, then that value will be used for all images for both
@@ -464,10 +455,7 @@ class MedianPooling(_AbstractPoolingBase):
 
     Attributes
     ----------
-    kernel_size : int or tuple of int or list of int \
-                  or imgaug.parameters.StochasticParameter \
-                  or tuple of tuple of int or tuple of list of int \
-                  or tuple of imgaug.parameters.StochasticParameter, optional
+    kernel_size : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or tuple of tuple of int or tuple of list of int or tuple of imgaug.parameters.StochasticParameter, optional
         The kernel size of the pooling operation.
 
         * If an int, then that value will be used for all images for both

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -177,8 +177,7 @@ class Resize(meta.Augmenter):
 
     Parameters
     ----------
-    size : 'keep' or int or float or tuple of int or tuple of float or list of int or list of float or\
-           imgaug.parameters.StochasticParameter or dict
+    size : 'keep' or int or float or tuple of int or tuple of float or list of int or list of float or imgaug.parameters.StochasticParameter or dict
         The new size of the images.
 
             * If this has the string value "keep", the original height and
@@ -210,8 +209,7 @@ class Resize(meta.Augmenter):
               value (e.g. resize images to a height of 64 pixels and resize
               the width so that the overall aspect ratio is maintained).
 
-    interpolation : imgaug.ALL or int or str or list of int or list of str or imgaug.parameters.StochasticParameter,\
-                    optional
+    interpolation : imgaug.ALL or int or str or list of int or list of str or imgaug.parameters.StochasticParameter, optional
         Interpolation to use.
 
             * If imgaug.ALL, then a random interpolation from ``nearest``, ``linear``,
@@ -583,8 +581,7 @@ class CropAndPad(meta.Augmenter):
               StochasticParameter (sample the amount to crop/pad from that
               parameter).
 
-    percent : None or int or float or imgaug.parameters.StochasticParameter \
-              or tuple, optional
+    percent : None or int or float or imgaug.parameters.StochasticParameter or tuple, optional
         The number of pixels to crop (negative values) or pad (positive values)
         on each side of the image given *in percent* of the image height/width.
         E.g. if this is set to 0.1, the augmenter will always crop away 10
@@ -613,8 +610,7 @@ class CropAndPad(meta.Augmenter):
               a StochasticParameter (sample the percentage to crop/pad from
               that parameter).
 
-    pad_mode : imgaug.ALL or str or list of str or \
-               imgaug.parameters.StochasticParameter, optional
+    pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
         Padding mode to use. The available modes match the numpy padding modes,
         i.e. ``constant``, ``edge``, ``linear_ramp``, ``maximum``, ``median``,
         ``minimum``, ``reflect``, ``symmetric``, ``wrap``. The modes
@@ -630,8 +626,7 @@ class CropAndPad(meta.Augmenter):
             * If StochasticParameter, a random mode will be sampled from this
               parameter per image.
 
-    pad_cval : number or tuple of number list of number or \
-               imgaug.parameters.StochasticParameter, optional
+    pad_cval : number or tuple of number list of number or imgaug.parameters.StochasticParameter, optional
         The constant value to use if the pad mode is ``constant`` or the end
         value to use if the mode is ``linear_ramp``.
         See :func:`imgaug.imgaug.pad` for more details.
@@ -1108,8 +1103,7 @@ def Pad(px=None, percent=None, pad_mode="constant", pad_cval=0, keep_size=True, 
               that is contained in the list) or a StochasticParameter (sample
               the amount to pad from that parameter).
 
-    percent : None or int or float or imgaug.parameters.StochasticParameter \
-              or tuple, optional
+    percent : None or int or float or imgaug.parameters.StochasticParameter or tuple, optional
         The number of pixels to pad on each side of the image given
         *in percent* of the image height/width.
         E.g. if this is set to 0.1, the augmenter will always add 10 percent
@@ -1135,8 +1129,7 @@ def Pad(px=None, percent=None, pad_mode="constant", pad_cval=0, keep_size=True, 
               StochasticParameter (sample the percentage to pad from that
               parameter).
 
-    pad_mode : imgaug.ALL or str or list of str or \
-               imgaug.parameters.StochasticParameter, optional
+    pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
         Padding mode to use. The available modes match the numpy padding modes,
         i.e. ``constant``, ``edge``, ``linear_ramp``, ``maximum``, ``median``,
         ``minimum``, ``reflect``, ``symmetric``, ``wrap``. The modes
@@ -1152,8 +1145,7 @@ def Pad(px=None, percent=None, pad_mode="constant", pad_cval=0, keep_size=True, 
             * If StochasticParameter, a random mode will be sampled from this
               parameter per image.
 
-    pad_cval : number or tuple of number list of number or \
-               imgaug.parameters.StochasticParameter, optional
+    pad_cval : number or tuple of number list of number or imgaug.parameters.StochasticParameter, optional
         The constant value to use if the pad mode is ``constant`` or the end
         value to use if the mode is ``linear_ramp``.
         See :func:`imgaug.imgaug.pad` for more details.
@@ -1311,8 +1303,7 @@ def Crop(px=None, percent=None, keep_size=True, sample_independently=True,
               value that is contained in the list) or a StochasticParameter
               (sample the amount to crop from that parameter).
 
-    percent : None or int or float or imgaug.parameters.StochasticParameter \
-              or tuple, optional
+    percent : None or int or float or imgaug.parameters.StochasticParameter or tuple, optional
         The number of pixels to crop away (cut off) on each side of the image
         given *in percent* of the image height/width.
         E.g. if this is set to 0.1, the augmenter will always crop away
@@ -1463,9 +1454,7 @@ class PadToFixedSize(meta.Augmenter):
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :func:`imgaug.augmenters.size.CropAndPad.__init__`.
 
-    position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center',\
-            'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter\
-            or tuple of StochasticParameter, optional
+    position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         Sets the center point of the padding, which determines how the required padding amounts are distributed
         to each side. For a tuple ``(a, b)``, both ``a`` and ``b`` are expected to be in range ``[0.0, 1.0]``
         and describe the fraction of padding applied to the left/right (low/high values for ``a``) and the fraction
@@ -1749,9 +1738,7 @@ class CropToFixedSize(meta.Augmenter):
     height : int
         Fixed height of new images.
 
-    position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center',\
-                'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter\
-                or tuple of StochasticParameter, optional
+    position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
          Sets the center point of the cropping, which determines how the required cropping amounts are distributed
          to each side. For a tuple ``(a, b)``, both ``a`` and ``b`` are expected to be in range ``[0.0, 1.0]``
          and describe the fraction of cropping applied to the left/right (low/high values for ``a``) and the fraction
@@ -2020,9 +2007,7 @@ class KeepSizeByResize(meta.Augmenter):
     children : Augmenter or list of imgaug.augmenters.meta.Augmenter or None, optional
         One or more augmenters to apply to images. These augmenters may change the image size.
 
-    interpolation : KeepSizeByResize.NO_RESIZE or {'nearest', 'linear', 'area', 'cubic'} or\
-                    {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or\
-                    list of str or list of int or StochasticParameter, optional
+    interpolation : KeepSizeByResize.NO_RESIZE or {'nearest', 'linear', 'area', 'cubic'} or {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or list of str or list of int or StochasticParameter, optional
         The interpolation mode to use when resizing images.
         Can take any value that :func:`imgaug.imgaug.imresize_single_image` accepts, e.g. ``cubic``.
 
@@ -2036,20 +2021,14 @@ class KeepSizeByResize(meta.Augmenter):
             * If this is a StochasticParameter, it will be queried once per call to ``_augment_images()`` and must
               return ``N`` strings or ints (matching the above mentioned ones) for ``N`` images.
 
-    interpolation_heatmaps : KeepSizeByResize.SAME_AS_IMAGES or KeepSizeByResize.NO_RESIZE or\
-                             {'nearest', 'linear', 'area', 'cubic'} or\
-                             {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or\
-                             list of str or list of int or StochasticParameter, optional
+    interpolation_heatmaps : KeepSizeByResize.SAME_AS_IMAGES or KeepSizeByResize.NO_RESIZE or {'nearest', 'linear', 'area', 'cubic'} or {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or list of str or list of int or StochasticParameter, optional
         The interpolation mode to use when resizing heatmaps.
         Meaning and valid values are similar to `interpolation`. This parameter may also take the value
         ``KeepSizeByResize.SAME_AS_IMAGES``, which will lead to copying the interpolation modes used for the
         corresponding images. The value may also be returned on a per-image basis if `interpolation_heatmaps` is
         provided as a StochasticParameter or may be one possible value if it is provided as a list of strings.
 
-    interpolation_segmaps : KeepSizeByResize.SAME_AS_IMAGES or KeepSizeByResize.NO_RESIZE or\
-                            {'nearest', 'linear', 'area', 'cubic'} or\
-                            {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or\
-                            list of str or list of int or StochasticParameter, optional
+    interpolation_segmaps : KeepSizeByResize.SAME_AS_IMAGES or KeepSizeByResize.NO_RESIZE or {'nearest', 'linear', 'area', 'cubic'} or {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or list of str or list of int or StochasticParameter, optional
         The interpolation mode to use when resizing segmentation maps.
         Similar to `interpolation_heatmaps`.
         NOTE: Only ``NO_RESIZE`` or nearest neighbour interpolation make sense

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -1038,8 +1038,7 @@ def quokka_polygons(size=None, extract=None):
         original image are used). Floats lead to relative size changes, ints
         to absolute sizes in pixels.
 
-    extract : None or 'square' or tuple of number or imgaug.BoundingBox or \
-              imgaug.BoundingBoxesOnImage
+    extract : None or 'square' or tuple of number or imgaug.BoundingBox or imgaug.BoundingBoxesOnImage
         Subarea to extract from the image. See :func:`imgaug.quokka`.
 
     Returns

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -2039,8 +2039,7 @@ class IterativeNoiseAggregator(StochasticParameter):
         the number of iterations will be sampled once per call
         to :func:`imgaug.parameters.IterativeNoiseAggregator._draw_samples`.
 
-    aggregation_method : imgaug.ALL or {'min', 'avg', 'max'} or list of str or\
-                         imgaug.parameters.StochasticParameter, optional
+    aggregation_method : imgaug.ALL or {'min', 'avg', 'max'} or list of str or imgaug.parameters.StochasticParameter, optional
         The method to use to aggregate the results of multiple iterations.
         If a string, it must have the value ``min`` or ``max`` or ``avg``.
         If ``min`` is chosen, the elementwise minimum will be computed over
@@ -2209,8 +2208,7 @@ class Sigmoid(StochasticParameter):
         other_param : imgaug.parameters.StochasticParameter
             See :func:`imgaug.parameters.Sigmoid.__init__`.
 
-        threshold : number or tuple of number or iterable of number or imgaug.parameters.StochasticParameter,\
-                    optional
+        threshold : number or tuple of number or iterable of number or imgaug.parameters.StochasticParameter, optional
             See :func:`imgaug.parameters.Sigmoid.__init__`.
 
         activated : bool or number, optional


### PR DESCRIPTION
This patch changes how the datatypes of parameter are formatted
in docstrings.

For some datatype definitions of parameters in docstrings, the
different allowed datatypes were split over multiple lines to
make them easier to read and to avoid breaking the line length
limit. This is now changed so that these datatype definitions
always only consist of a single line, even if that severely
breaks the line length limit.

This is often horrendously ugly and very hard to read.
Unfortunately it seems to be the only format that is both
understood by Sphinx (when generating ReadTheDocs pages)
and PyCharm. Various ways seem to exist that make multiline
datatype definitions work in either of these cases, but
none that works in both cases. That is why it is now changed
to singleline definitions.