### PR TITLE
Add initial vectorized keypoint backend

### DIFF
--- a/imgaug/augmentables/kps.py
+++ b/imgaug/augmentables/kps.py
@@ -392,8 +392,8 @@ class Keypoints(object):
         return len(self._data)
 
     def __getitem__(self, index):
-        xy = self._data[index]
-        return Keypoint(*xy)
+        x, y = self._data[index].tolist()
+        return Keypoint(x, y)
 
     def deepcopy(self, data=None):
         if data is None:


### PR DESCRIPTION
The start of an incremental solution to the problem in #426

Minimize python overhead by using vectorized backends. 

EDIT: I've notice that this solution isn't quite a drop in replacement. Augmentors like FlipLR, which modify the Keypoint attribute inplace don't work because `Keypoints.__getitem__` returns a copy of the data and not the original. It might be possible to fix this by modifying the original `Keypoint` class to keep a pointer to the location in `Keypoints._data`, but maybe their is a better way. Not quite sure ATM. 

EDIT EDIT: Actually this isn't that hard to do. You can make a new class that inherits from `Keypoint` which just stores the row in `Keypoints` and return that instead. You can make setter/getter properties to simulate the x and y values of the parent `Keypoint` object. Doing this seems to make it work seemlessly. 