### PR TITLE
Add fit_output (False/True) option to PerspectiveTransform augmenter

### DIFF
--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -2844,7 +2844,7 @@ class PerspectiveTransform(meta.Augmenter):
         dst -= dst.min(axis=0, keepdims=True)
         dst = np.around(dst, decimals=0)
         M_expanded = cv2.getPerspectiveTransform(rect, dst)
-        maxWidth, maxHeight = dst.max(axis=0)
+        maxWidth, maxHeight = dst.max(axis=0) + 1
         return M_expanded, maxWidth, maxHeight
 
     def _create_matrices(self, shapes, random_state):


### PR DESCRIPTION
Recalculate the transformation matrix to cover all the input content after transformation. 

Sample
------
`fit_output=False`:
![image](https://user-images.githubusercontent.com/4105014/66451318-e5b65000-ea29-11e9-9589-4c5b77bd0835.png)
![image](https://user-images.githubusercontent.com/4105014/66451336-fc5ca700-ea29-11e9-9db8-a0ea61a4c1ac.png)
`fit_output=True`:
![image](https://user-images.githubusercontent.com/4105014/66451376-29a95500-ea2a-11e9-8465-72554c3dbc6a.png)
![image](https://user-images.githubusercontent.com/4105014/66451397-404fac00-ea2a-11e9-8e9c-0d70678507fa.png)

```python
import cv2
import numpy as np
import imgaug as ia


def ia_augmentation_text(images, random_state, parents, hooks):
    for image in images:
        h, w = image.shape[:2]
        y_text = np.random.randint(int(0.75*h), h-20)
        s_text = np.random.randint(20, max(int(0.1*h), 30))
        n_text = 2 * (w-20) // s_text

        image[...] = ia.draw_text(image, y_text, 10, random_string(n_text), color=(255, 255, 255), size=s_text)

    return images

ia_augmenter_text = iaa.Lambda(func_images=ia_augmentation_text)
ia_sometimes = lambda aug: iaa.Sometimes(0.5, aug)
ia_augmenter_img = iaa.Sequential([
    # geometrical
    ia_sometimes(
        iaa.OneOf([
            # iaa.Affine(
            #     rotate=(-30, 30),
            #     shear=(-16, 16),
            #     order=[0, 1],
            #     cval=(0, 255),
            #     mode='constant',
            #     fit_output=True,
            # ),
            iaa.PerspectiveTransform(scale=(0.01, 0.15),
                                     fit_output=True)
        ]),
    ),
    # blur mosaic
    ia_sometimes(
        iaa.OneOf([
            iaa.GaussianBlur((0, 5.0)),
            iaa.MotionBlur(k=15),
            iaa.JpegCompression(compression=(85, 100)),
        ]),
    ),
    # noise blackout
    ia_sometimes(
        iaa.OneOf([
            iaa.AdditiveGaussianNoise(scale=0.2*255, per_channel=0.5),
            iaa.Dropout(p=(0, 0.2), per_channel=0.5),
            iaa.CoarseDropout(0.2, size_percent=0.05, per_channel=0.5),
            iaa.CoarseSaltAndPepper(0.2, size_percent=0.05, per_channel=0.5),
        ])
    ),
    # contrast brightness
    ia_sometimes(
        iaa.OneOf([
            iaa.LinearContrast((0.5, 1.5)),
            iaa.GammaContrast((0.5, 2.0)),
            iaa.AddToSaturation((-50, 50))
        ])
    ),
    # color changes
    ia_sometimes(
        iaa.OneOf([
            iaa.UniformColorQuantization(n_colors=16),
            iaa.Grayscale(alpha=(0.0, 1.0))
        ])
    ),
    # text
    ia_sometimes(
        ia_augmenter_text
    ),
    # horizontal flip
    ia_sometimes(
        iaa.Fliplr(0.5)
    )
])

bbox=np.array([210,163,129,187])
im = cv2.imread('d535880338a040b426d215e35cd122c1.jpg')
cv2.rectangle(im, (bbox[0], bbox[1]), (bbox[0]+bbox[2], bbox[1]+bbox[3]), (0,255,0), 1, cv2.LINE_AA)
images = im[np.newaxis, ...]
bbs=[[ia.BoundingBox(x1=bbox[0], y1=bbox[1], x2=bbox[0]+bbox[2], y2=bbox[1]+bbox[3])]]

while True:
    ims_out, bboxes_out = ia_augmenter_img(images=images, bounding_boxes=bbs)
    im_out = ims_out[0]
    bbox_out = bboxes_out[0][0]
    print(bbox_out)
    cv2.rectangle(im_out, (int(bbox_out.x1), int(bbox_out.y1)), (int(bbox_out.x2), int(bbox_out.y2)), (0,0,255), 1, cv2.LINE_AA)
    cv2.imshow('aug', im_out)
    if cv2.waitKey(0) & 0xFF == ord("q"):
        break

```