### PR TITLE
Fix SnowflakesLayer intermittent crash on gate noise size of 0.

### DIFF
--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -865,8 +865,8 @@ class SnowflakesLayer(meta.Augmenter):
 
         height, width, nb_channels = image.shape
         downscale_factor = np.clip(1.0 - flake_size_sample, 0.001, 1.0)
-        height_down = int(height*downscale_factor)
-        width_down = int(width*downscale_factor)
+        height_down = max(1, int(height*downscale_factor))
+        width_down = max(1, int(width*downscale_factor))
         noise = self._generate_noise(
             height_down,
             width_down,


### PR DESCRIPTION
Found that `SnowFlakesLayer` will occasionally crash as a result of the `gate_noise` size being zero (ultimately deriving from a value sampled from `flake_size`). The fix in this PR is to force a minimum size of (1, 1) for the `gate_noise`. 

The following code reproduces the issue:
```
import imgaug as ia

snow = ia.augmenters.weather.Snowflakes(
  flake_size=(0.5, 1), 
  speed=(0.003, 0.03)
)

image = ia.quokka(size=(512, 512))

for i in range(1000):
    image_aug = snow.augment_image(image)
print("done")
```

The error output is:
```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-1-29d7554150ca> in <module>
      9 
     10 for i in range(1000):
---> 11     image_aug = snow.augment_image(image)
     12 print("done")

/workspace/code/imgaug/imgaug/augmenters/meta.py in augment_image(self, image, hooks)
    712             "Expected image to have shape (height, width, [channels]), "
    713             "got shape %s." % (image.shape,))
--> 714         return self.augment_images([image], hooks=hooks)[0]
    715 
    716     def augment_images(self, images, parents=None, hooks=None):

/workspace/code/imgaug/imgaug/augmenters/meta.py in augment_images(self, images, parents, hooks)
    778             UnnormalizedBatch(images=images),
    779             parents=parents,
--> 780             hooks=hooks
    781         ).images_aug
    782 

/workspace/code/imgaug/imgaug/augmenters/meta.py in augment_batch(self, batch, parents, hooks)
    598                     random_state=self.random_state,
    599                     parents=parents if parents is not None else [],
--> 600                     hooks=hooks)
    601 
    602         # revert augmentables being set to None for non-activated augmenters

/workspace/code/imgaug/imgaug/augmenters/meta.py in _augment_batch(self, batch, random_state, parents, hooks)
   3295                         batch_sub,
   3296                         parents=parents + [self],
-> 3297                         hooks=hooks
   3298                     )
   3299                     batch = batch.invert_subselect_rows_by_indices_(active,

/workspace/code/imgaug/imgaug/augmenters/meta.py in augment_batch(self, batch, parents, hooks)
    598                     random_state=self.random_state,
    599                     parents=parents if parents is not None else [],
--> 600                     hooks=hooks)
    601 
    602         # revert augmentables being set to None for non-activated augmenters

/workspace/code/imgaug/imgaug/augmenters/weather.py in _augment_batch(self, batch, random_state, parents, hooks)
    832         rss = random_state.duplicate(len(images))
    833         for i, (image, rs) in enumerate(zip(images, rss)):
--> 834             batch.images[i] = self.draw_on_image(image, rs)
    835         return batch
    836 

/workspace/code/imgaug/imgaug/augmenters/weather.py in draw_on_image(self, image, random_state)
    881         noise = self._gate(noise, gate_noise, self.gate_noise_size, rss[1])
    882         noise = ia.imresize_single_image(noise, (height, width),
--> 883                                          interpolation="cubic")
    884 
    885         # apply a bit of gaussian blur and then motion blur according to

/workspace/code/imgaug/imgaug/imgaug.py in imresize_single_image(image, sizes, interpolation)
   1600 
   1601     rs = imresize_many_images(
-> 1602         image[np.newaxis, :, :, :], sizes, interpolation=interpolation)
   1603     if grayscale:
   1604         return rs[0, :, :, 0]

/workspace/code/imgaug/imgaug/imgaug.py in imresize_many_images(images, sizes, interpolation)
   1458         "width and/or number of channels of zero. "
   1459         "Observed shapes were: %s." % (
-> 1460             str([image.shape for image in images]),))
   1461 
   1462     ip = interpolation

AssertionError: Cannot resize images, because at least one image has a height and/or width and/or number of channels of zero. Observed shapes were: [(0, 0, 1)].
```