### PR TITLE
Add wrappers for imagecorruptions library

### DIFF
--- a/changelogs/master/added/20191218_imagecorruptions.md
+++ b/changelogs/master/added/20191218_imagecorruptions.md
@@ -1,0 +1,62 @@
+# Added Wrappers for `imagecorruptions` Package #530
+
+Added wrappers around the functions from package
+[bethgelab/imagecorruptions](https://github.com/bethgelab/imagecorruptions).
+The functions in that package were used in some recent papers and are added
+here for convenience.
+The wrappers produce arrays containing values identical to the output
+arrays from the corresponding `imagecorruptions` functions when called
+via the `imagecorruptions.corrupt()` (verified via unittests).
+The interfaces of the wrapper functions are identical to the
+`imagecorruptions` functions, with the only difference of also supporting
+`seed` parameters.
+
+* Added module `imgaug.augmenters.imgcorruptlike`. The `like` signals that
+  the augmentation functions do not *have* to wrap `imagecorruptions`
+  internally. They merely have to produce the same outputs.
+* Added the following functions to module `imgaug.augmenters.imgcorruptlike`:
+    * `apply_gaussian_noise()`
+    * `apply_shot_noise()`
+    * `apply_impulse_noise()`
+    * `apply_speckle_noise()`
+    * `apply_gaussian_blur()`
+    * `apply_glass_blur()` (improved performance over original function)
+    * `apply_defocus_blur()`
+    * `apply_motion_blur()`
+    * `apply_zoom_blur()`
+    * `apply_fog()`
+    * `apply_snow()`
+    * `apply_spatter()`
+    * `apply_contrast()`
+    * `apply_brightness()`
+    * `apply_saturate()`
+    * `apply_jpeg_compression()`
+    * `apply_pixelate()`
+    * `apply_elastic_transform()`
+* Added function
+  `imgaug.augmenters.imgcorruptlike.get_corruption_names(subset)`.
+  Similar to `imagecorruptions.get_corruption_names(subset)`, but returns a
+  tuple
+  `(list of corruption method names, list of corruption method functions)`,
+  instead of only the names.
+* Added the following augmenters to module `imgaug.augmenters.imgcorruptlike`:
+    * `GaussianNoise`
+    * `ShotNoise`
+    * `ImpulseNoise`
+    * `SpeckleNoise`
+    * `GaussianBlur`
+    * `GlassBlur`
+    * `DefocusBlur`
+    * `MotionBlur`
+    * `ZoomBlur`
+    * `Fog`
+    * `Frost`
+    * `Snow`
+    * `Spatter`
+    * `Contrast`
+    * `Brightness`
+    * `Saturate`
+    * `JpegCompression`
+    * `Pixelate`
+    * `ElasticTransform`
+* Added context `imgaug.random.temporary_numpy_seed()`.

--- a/imgaug/augmenters/__init__.py
+++ b/imgaug/augmenters/__init__.py
@@ -12,6 +12,7 @@ from imgaug.augmenters.debug import *
 from imgaug.augmenters.edges import *
 from imgaug.augmenters.flip import *
 from imgaug.augmenters.geometric import *
+import imgaug.augmenters.imgcorruptlike  # use as iaa.imgcorrupt.<Augmenter>
 from imgaug.augmenters.meta import *
 import imgaug.augmenters.pillike  # use via: iaa.pillike.*
 from imgaug.augmenters.pooling import *

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -1,0 +1,1851 @@
+"""
+Augmenters that wrap methods from ``imagecorruptions`` package.
+
+See https://github.com/bethgelab/imagecorruptions for the package.
+
+List of augmenters:
+
+    * :class:`GaussianNoise`
+    * :class:`ShotNoise`
+    * :class:`ImpulseNoise`
+    * :class:`SpeckleNoise`
+    * :class:`GaussianBlur`
+    * :class:`GlassBlur`
+    * :class:`DefocusBlur`
+    * :class:`MotionBlur`
+    * :class:`ZoomBlur`
+    * :class:`Fog`
+    * :class:`Frost`
+    * :class:`Snow`
+    * :class:`Spatter`
+    * :class:`Contrast`
+    * :class:`Brightness`
+    * :class:`Saturate`
+    * :class:`JpegCompression`
+    * :class:`Pixelate`
+    * :class:`ElasticTransform`
+
+.. note::
+
+    The functions provided here have identical outputs to the ones in
+    ``imagecorruptions`` when called using the ``corrupt()`` function of
+    that package. E.g. the outputs are always ``uint8`` and not
+    ``float32`` or ``float64``.
+
+Example usage::
+
+    >>> # Skip the doctests in this file as the imagecorruptions package is
+    >>> # not available in all python versions that are otherwise supported
+    >>> # by imgaug.
+    >>> # doctest: +SKIP
+    >>> import imgaug as ia
+    >>> import imgaug.augmenters as iaa
+    >>> import numpy as np
+    >>> image = np.zeros((64, 64, 3), dtype=np.uint8)
+    >>> names, funcs = iaa.imgcorruptlike.get_corruption_names("validation")
+    >>> for name, func in zip(names, funcs):
+    >>>     image_aug = func(image, severity=5, seed=1)
+    >>>     image_aug = ia.draw_text(image_aug, x=20, y=20, text=name)
+    >>>     ia.imshow(image_aug)
+
+    Use e.g. ``iaa.imgcorruptlike.GaussianNoise(severity=2)(images=...)`` to
+    create and apply a specific augmenter.
+
+"""
+from __future__ import print_function, division, absolute_import
+
+import warnings
+
+import numpy as np
+
+import imgaug as ia
+from .. import dtypes as iadt
+from .. import random as iarandom
+from .. import parameters as iap
+from . import meta
+
+# TODO add optional dependency
+
+_MISSING_PACKAGE_ERROR_MSG = (
+    "Could not import package `imagecorruptions`. This is an optional "
+    "dependency of imgaug and must be installed manually in order "
+    "to use augmenters from `imgaug.augmenters.imgcorrupt`. "
+    "Use e.g. `pip install imagecorruptions` to install it. See also "
+    "https://github.com/bethgelab/imagecorruptions for the repository "
+    "of the package."
+)
+
+
+def _clipped_zoom_no_scipy_warning(img, zoom_factor):
+    from scipy.ndimage import zoom as scizoom
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", ".*output shape of zoom.*")
+
+        # clipping along the width dimension:
+        ch0 = int(np.ceil(img.shape[0] / float(zoom_factor)))
+        top0 = (img.shape[0] - ch0) // 2
+
+        # clipping along the height dimension:
+        ch1 = int(np.ceil(img.shape[1] / float(zoom_factor)))
+        top1 = (img.shape[1] - ch1) // 2
+
+        img = scizoom(img[top0:top0 + ch0, top1:top1 + ch1],
+                      (zoom_factor, zoom_factor, 1), order=1)
+
+        return img
+
+
+def _call_imgcorrupt_func(fname, seed, convert_to_pil, *args, **kwargs):
+    """Apply an ``imagecorruptions`` function.
+
+    The dtype support below is basically a placeholder to which the
+    augmentation functions can point to decrease the amount of documentation.
+
+    dtype support::
+
+        * ``uint8``: yes; indirectly tested (1)
+        * ``uint16``: no
+        * ``uint32``: no
+        * ``uint64``: no
+        * ``int8``: no
+        * ``int16``: no
+        * ``int32``: no
+        * ``int64``: no
+        * ``float16``: no
+        * ``float32``: no
+        * ``float64``: no
+        * ``float128``: no
+        * ``bool``: no
+
+        - (1) Tested by comparison with function in ``imagecorruptions``
+              package.
+
+    """
+    # import imagecorruptions, note that it is an optional dependency
+    try:
+        # imagecorruptions sets its own warnings filter rule via
+        # warnings.simplefilter(). That rule is the in effect for the whole
+        # program and not just the module. So to prevent that here
+        # we use catch_warnings(), which uintuitively does not by default
+        # catch warnings but saves and restores the warnings filter settings.
+        with warnings.catch_warnings():
+            import imagecorruptions.corruptions as corruptions
+    except ImportError:
+        raise ImportError(_MISSING_PACKAGE_ERROR_MSG)
+
+    # Monkeypatch clip_zoom() as that causes warnings in some scipy versions,
+    # and the implementation here suppresses these warnings. They suppress
+    # all UserWarnings on a module level instead, which seems very exhaustive.
+    corruptions.clipped_zoom = _clipped_zoom_no_scipy_warning
+
+    image = args[0]
+
+    iadt.gate_dtypes(
+        image,
+        allowed=["uint8"],
+        disallowed=["bool",
+                    "uint16", "uint32", "uint64", "uint128", "uint256",
+                    "int8", "int16", "int32", "int64", "int128", "int256",
+                    "float16", "float32", "float64", "float96", "float128",
+                    "float256"],
+        augmenter=None)
+
+    input_shape = image.shape
+
+    height, width = input_shape[0:2]
+    assert height >= 32 and width >= 32, (
+        "Expected the provided image to have a width and height of at least "
+        "32 pixels, as that is the lower limit that the wrapped "
+        "imagecorruptions functions use. Got shape %s." % (image.shape,))
+
+    ndim = image.ndim
+    assert ndim == 2 or (ndim == 3 and (image.shape[2] in [1, 3])), (
+        "Expected input image to have shape (height, width) or "
+        "(height, width, 1) or (height, width, 3). Got shape %s." % (
+            image.shape,))
+
+    if ndim == 2:
+        image = image[..., np.newaxis]
+    if image.shape[-1] == 1:
+        image = np.tile(image, (1, 1, 3))
+
+    if convert_to_pil:
+        import PIL.Image
+        image = PIL.Image.fromarray(image)
+
+    with iarandom.temporary_numpy_seed(seed):
+        if ia.is_callable(fname):
+            image_aug = fname(image, *args[1:], **kwargs)
+        else:
+            image_aug = getattr(corruptions, fname)(image, *args[1:], **kwargs)
+
+    if convert_to_pil:
+        image_aug = np.asarray(image_aug)
+
+    if ndim == 2:
+        image_aug = image_aug[:, :, 0]
+    elif input_shape[-1] == 1:
+        image_aug = image_aug[:, :, 0:1]
+
+    # this cast is done at the end of imagecorruptions.__init__.corrupt()
+    image_aug = np.uint8(image_aug)
+
+    return image_aug
+
+
+def get_corruption_names(subset="common"):
+    """Get a named subset of image corruption functions.
+
+    .. note::
+
+        This function returns the augmentation names (as strings) *and* the
+        corresponding augmentation functions, while ``get_corruption_names()``
+        in ``imagecorruptions`` only returns the augmentation names.
+
+    Parameters
+    ----------
+    subset : {'common', 'validation', 'all'}, optional.
+        Name of the subset of image corruption functions.
+
+    Returns
+    -------
+    list of str
+        Names of the corruption methods, e.g. "gaussian_noise".
+
+    list of callable
+        Function corresponding to the name. Is one of the
+        ``apply_*()`` functions in this module. Apply e.g.
+        via ``func(image, severity=2, seed=123)``.
+
+    """
+    # import imagecorruptions, note that it is an optional dependency
+    try:
+        # imagecorruptions sets its own warnings filter rule via
+        # warnings.simplefilter(). That rule is the in effect for the whole
+        # program and not just the module. So to prevent that here
+        # we use catch_warnings(), which uintuitively does not by default
+        # catch warnings but saves and restores the warnings filter settings.
+        with warnings.catch_warnings():
+            import imagecorruptions
+    except ImportError:
+        raise ImportError(_MISSING_PACKAGE_ERROR_MSG)
+
+    cnames = imagecorruptions.get_corruption_names(subset)
+    funcs = [globals()["apply_%s" % (cname,)] for cname in cnames]
+
+    return cnames, funcs
+
+
+# ----------------------------------------------------------------------------
+# Corruption functions
+# ----------------------------------------------------------------------------
+# These functions could easily be created dynamically, especially templating
+# the docstrings would save many lines of code. It is intentionally not done
+# here for the same reasons as in case of the augmenters. See the comment
+# further below at the start of the augmenter section for details.
+
+def apply_gaussian_noise(x, severity=1, seed=None):
+    """Apply ``gaussian_noise`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("gaussian_noise", seed, False, x, severity)
+
+
+def apply_shot_noise(x, severity=1, seed=None):
+    """Apply ``shot_noise`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("shot_noise", seed, False, x, severity)
+
+
+def apply_impulse_noise(x, severity=1, seed=None):
+    """Apply ``impulse_noise`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("impulse_noise", seed, False, x, severity)
+
+
+def apply_speckle_noise(x, severity=1, seed=None):
+    """Apply ``speckle_noise`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("speckle_noise", seed, False, x, severity)
+
+
+def apply_gaussian_blur(x, severity=1, seed=None):
+    """Apply ``gaussian_blur`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("gaussian_blur", seed, False, x, severity)
+
+
+def apply_glass_blur(x, severity=1, seed=None):
+    """Apply ``glass_blur`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func(_apply_glass_blur_imgaug, seed, False, x,
+                                 severity)
+
+
+def _apply_glass_blur_imgaug(x, severity=1):
+    # false positive on x_shape[0]
+    # invalid name for dx, dy
+    # pylint: disable=unsubscriptable-object, invalid-name
+
+    # original function implementation from
+    # https://github.com/bethgelab/imagecorruptions/blob/master/imagecorruptions/corruptions.py
+    # this is an improved (i.e. faster) version
+    from skimage.filters import gaussian
+
+    # sigma, max_delta, iterations
+    c = [
+        (0.7, 1, 2),
+        (0.9, 2, 1),
+        (1, 2, 3),
+        (1.1, 3, 2),
+        (1.5, 4, 2)
+    ][severity - 1]
+
+    sigma, max_delta, iterations = c
+
+    x = np.uint8(
+        gaussian(np.array(x) / 255., sigma=sigma, multichannel=True) * 255)
+    x_shape = np.array(x).shape
+
+    # locally shuffle pixels
+    nb_height = x_shape[0] - 2 * max_delta
+    nb_width = x_shape[1] - 2 * max_delta
+
+    for _ in range(iterations):
+        dxxdyy = np.random.randint(-max_delta, max_delta,
+                                   size=(nb_height, nb_width, 2,))
+        dxxdyy = dxxdyy.astype(np.int16)
+        # Rotate here, because imagecorruptions starts the replacement at the
+        # bottom right, so the first generated sample should be placed in that
+        # corner and not the top left corner.
+        # We could avoid this with some fancy (but unreadable) indexing.
+        dxxdyy = np.rot90(dxxdyy, 2, axes=(1, 0))
+
+        # Pad the array to make things easier for us.
+        # We could avoid this with a bit better indexing.
+        dxxdyy = np.pad(
+            dxxdyy,
+            ((max_delta+1, max_delta-1), (max_delta+1, max_delta-1), (0, 0)),
+            mode="constant")
+
+        for h in range(x_shape[0] - max_delta, max_delta, -1):
+            for w in range(x_shape[1] - max_delta, max_delta, -1):
+                dx, dy = dxxdyy[h, w, :]
+                h_prime, w_prime = h + dy, w + dx
+                # swap
+                x[h, w], x[h_prime, w_prime] = x[h_prime, w_prime], x[h, w]
+
+    return np.clip(
+        gaussian(x / 255., sigma=sigma, multichannel=True),
+        0, 1
+    ) * 255
+
+
+def apply_defocus_blur(x, severity=1, seed=None):
+    """Apply ``defocus_blur`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("defocus_blur", seed, False, x, severity)
+
+
+def apply_motion_blur(x, severity=1, seed=None):
+    """Apply ``motion_blur`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("motion_blur", seed, False, x, severity)
+
+
+def apply_zoom_blur(x, severity=1, seed=None):
+    """Apply ``zoom_blur`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("zoom_blur", seed, False, x, severity)
+
+
+def apply_fog(x, severity=1, seed=None):
+    """Apply ``fog`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("fog", seed, False, x, severity)
+
+
+def apply_frost(x, severity=1, seed=None):
+    """Apply ``frost`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("frost", seed, False, x, severity)
+
+
+def apply_snow(x, severity=1, seed=None):
+    """Apply ``snow`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("snow", seed, False, x, severity)
+
+
+def apply_spatter(x, severity=1, seed=None):
+    """Apply ``spatter`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("spatter", seed, True, x, severity)
+
+
+def apply_contrast(x, severity=1, seed=None):
+    """Apply ``contrast`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("contrast", seed, False, x, severity)
+
+
+def apply_brightness(x, severity=1, seed=None):
+    """Apply ``brightness`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("brightness", seed, False, x, severity)
+
+
+def apply_saturate(x, severity=1, seed=None):
+    """Apply ``saturate`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("saturate", seed, False, x, severity)
+
+
+def apply_jpeg_compression(x, severity=1, seed=None):
+    """Apply ``jpeg_compression`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("jpeg_compression", seed, True, x, severity)
+
+
+def apply_pixelate(x, severity=1, seed=None):
+    """Apply ``pixelate`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    x : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("pixelate", seed, True, x, severity)
+
+
+def apply_elastic_transform(image, severity=1, seed=None):
+    """Apply ``elastic_transform`` from ``imagecorruptions``.
+
+    dtype support::
+
+        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+
+    Parameters
+    ----------
+    image : ndarray
+        Image array.
+        Expected to have shape ``(H,W)``, ``(H,W,1)`` or ``(H,W,3)`` with
+        dtype ``uint8`` and a minimum height/width of ``32``.
+
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    seed : None or int, optional
+        Seed for the random number generation to use.
+
+    Returns
+    -------
+    ndarray
+        Corrupted image.
+
+    """
+    return _call_imgcorrupt_func("elastic_transform", seed, False, image,
+                                 severity)
+
+
+# ----------------------------------------------------------------------------
+# Augmenters
+# ----------------------------------------------------------------------------
+# The augmenter definitions below are almost identical and mainly differ in
+# the names and functions used. It would be fairly trivial to write a
+# function that would create these augmenters dynamically (and one is listed
+# below as a comment). The downside is that in these cases the documentation
+# would also be generated dynamically, which leads to numerous problems:
+# (1) users couldn't easily read the documentation while scrolling through
+# the code file, (2) IDEs might not be able to use it for code suggestions,
+# (3) tools like pylint can't detect and validate it, (4) the imgaug-doc
+# tools to parse dtype support don't work with dynamically generated
+# documentation (and neither with dynamically generated classes).
+# Even though it's by far more code, it seems like the better choice overall
+# to just write it out.
+
+# Example function to dynamically generate augmenters, kept for possible
+# future uses:
+# def _create_augmenter(class_name, func_name):
+#     func = globals()["apply_%s" % (func_name,)]
+#
+#     def __init__(self, severity=1, name=None, deterministic=False,
+#                  random_state=None):
+#         super(self.__class__, self).__init__(
+#             func, severity, name=name, deterministic=deterministic,
+#             random_state=random_state)
+#
+#     augmenter_class = type(class_name,
+#                            (_ImgcorruptAugmenterBase,),
+#                            {"__init__": __init__})
+#
+#     augmenter_class.__doc__ = """
+#     Wrapper around function :func:`imagecorruption.%s`.
+#
+#     dtype support::
+#
+#         See :func:`imgaug.augmenters.imgcorruptlike.apply_%s`.
+#
+#     Parameters
+#     ----------
+#     severity : int, optional
+#         Strength of the corruption, with valid values being
+#         ``1 <= severity <= 5``.
+#
+#     name : None or str, optional
+#         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+#
+#     deterministic : bool, optional
+#         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+#
+#     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+#         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+#
+#     Examples
+#     --------
+#     >>> import imgaug.augmenters as iaa
+#     >>> aug = iaa.%s(severity=2)
+#
+#     Create an augmenter around :func:`imagecorruption.%s`. Apply it to
+#     images using e.g. ``aug(images=[image1, image2, ...])``.
+#
+#     """ % (func_name, func_name, class_name, func_name)
+#
+#     return augmenter_class
+
+
+class _ImgcorruptAugmenterBase(meta.Augmenter):
+    def __init__(self, func, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(_ImgcorruptAugmenterBase, self).__init__(
+            name=name, deterministic=deterministic, random_state=random_state)
+
+        self.func = func
+        self.severity = iap.handle_discrete_param(
+            severity, "severity", value_range=(1, 5), tuple_to_uniform=True,
+            list_to_choice=True, allow_floats=False)
+
+    def _augment_batch(self, batch, random_state, parents, hooks):
+        if batch.images is None:
+            return batch
+
+        severities, seeds = self._draw_samples(len(batch.images),
+                                               random_state=random_state)
+
+        for image, severity, seed in zip(batch.images, severities, seeds):
+            image[...] = self.func(image, severity=severity, seed=seed)
+
+        return batch
+
+    def _draw_samples(self, nb_rows, random_state):
+        severities = self.severity.draw_samples((nb_rows,),
+                                                random_state=random_state)
+        seeds = random_state.generate_seeds_(nb_rows)
+
+        return severities, seeds
+
+    def get_parameters(self):
+        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        return [self.severity]
+
+
+class GaussianNoise(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.gaussian_noise`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_gaussian_noise`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.GaussianNoise(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.gaussian_noise`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(GaussianNoise, self).__init__(
+            apply_gaussian_noise, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class ShotNoise(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.shot_noise`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_shot_noise`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.ShotNoise(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.shot_noise`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(ShotNoise, self).__init__(
+            apply_shot_noise, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class ImpulseNoise(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.impulse_noise`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_impulse_noise`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.ImpulseNoise(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.impulse_noise`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(ImpulseNoise, self).__init__(
+            apply_impulse_noise, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class SpeckleNoise(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.speckle_noise`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_speckle_noise`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.SpeckleNoise(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.speckle_noise`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(SpeckleNoise, self).__init__(
+            apply_speckle_noise, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class GaussianBlur(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.gaussian_blur`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_gaussian_blur`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.GaussianBlur(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.gaussian_blur`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(GaussianBlur, self).__init__(
+            apply_gaussian_blur, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class GlassBlur(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.glass_blur`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_glass_blur`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.GlassBlur(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.glass_blur`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(GlassBlur, self).__init__(
+            apply_glass_blur, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class DefocusBlur(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.defocus_blur`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_defocus_blur`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.DefocusBlur(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.defocus_blur`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(DefocusBlur, self).__init__(
+            apply_defocus_blur, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class MotionBlur(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.motion_blur`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_motion_blur`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.MotionBlur(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.motion_blur`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(MotionBlur, self).__init__(
+            apply_motion_blur, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class ZoomBlur(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.zoom_blur`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_zoom_blur`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.ZoomBlur(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.zoom_blur`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(ZoomBlur, self).__init__(
+            apply_zoom_blur, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Fog(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.fog`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_fog`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Fog(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.fog`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Fog, self).__init__(
+            apply_fog, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Frost(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.frost`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_frost`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Frost(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.frost`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Frost, self).__init__(
+            apply_frost, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Snow(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.snow`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_snow`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Snow(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.snow`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Snow, self).__init__(
+            apply_snow, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Spatter(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.spatter`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_spatter`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Spatter(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.spatter`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Spatter, self).__init__(
+            apply_spatter, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Contrast(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.contrast`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_contrast`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Contrast(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.contrast`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Contrast, self).__init__(
+            apply_contrast, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Brightness(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.brightness`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_brightness`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Brightness(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.brightness`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Brightness, self).__init__(
+            apply_brightness, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Saturate(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.saturate`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_saturate`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Saturate(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.saturate`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Saturate, self).__init__(
+            apply_saturate, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class JpegCompression(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.jpeg_compression`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_jpeg_compression`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.JpegCompression(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.jpeg_compression`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(JpegCompression, self).__init__(
+            apply_jpeg_compression, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class Pixelate(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.pixelate`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_pixelate`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.Pixelate(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.pixelate`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(Pixelate, self).__init__(
+            apply_pixelate, severity,
+            name=name, deterministic=deterministic, random_state=random_state)
+
+
+class ElasticTransform(_ImgcorruptAugmenterBase):
+    """
+    Wrapper around function :func:`imagecorruption.elastic_transform`.
+
+    .. note ::
+
+        This augmenter only affects images. Other data is not changed.
+
+    dtype support::
+
+        See
+        :func:`imgaug.augmenters.imgcorruptlike.apply_elastic_transform`.
+
+    Parameters
+    ----------
+    severity : int, optional
+        Strength of the corruption, with valid values being
+        ``1 <= severity <= 5``.
+
+    name : None or str, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    deterministic : bool, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+
+    Examples
+    --------
+    >>> # doctest: +SKIP
+    >>> import imgaug.augmenters as iaa
+    >>> aug = iaa.imgcorruptlike.ElasticTransform(severity=2)
+
+    Create an augmenter around :func:`imagecorruption.elastic_transform`.
+    Apply it to images using e.g. ``aug(images=[image1, image2, ...])``.
+
+    """
+
+    def __init__(self, severity=1,
+                 name=None, deterministic=False, random_state=None):
+        super(ElasticTransform, self).__init__(
+            apply_elastic_transform, severity,
+            name=name, deterministic=deterministic, random_state=random_state)

--- a/imgaug/random.py
+++ b/imgaug/random.py
@@ -1543,3 +1543,36 @@ def polyfill_random(generator, size, dtype="float32", out=None):
             out[...] = result
         return result
     return generator.random(size=size, dtype=dtype, out=out)
+
+
+# TODO add tests
+class temporary_numpy_seed(object):
+    """Context to temporarily alter the random state of ``numpy.random``.
+
+    The random state's internal state will be set back to the original one
+    once the context finishes.
+
+    Parameters
+    ----------
+    entropy : None or int
+        The seed value to use.
+        If `None` then the seed will not be altered and the internal state
+        of ``numpy.random`` will not be reset back upon context exit (i.e.
+        this context will do nothing).
+
+    """
+    # pylint complains about class name
+    # pylint: disable=invalid-name
+
+    def __init__(self, entropy=None):
+        self.old_state = None
+        self.entropy = entropy
+
+    def __enter__(self):
+        if self.entropy is not None:
+            self.old_state = np.random.get_state()
+            np.random.seed(self.entropy)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.entropy is not None:
+            np.random.set_state(self.old_state)

--- a/test/augmenters/test_imgcorruptlike.py
+++ b/test/augmenters/test_imgcorruptlike.py
@@ -1,0 +1,374 @@
+from __future__ import print_function, division, absolute_import
+
+import sys
+# unittest only added in 3.4 self.subTest()
+if sys.version_info[0] < 3 or sys.version_info[1] < 4:
+    import unittest2 as unittest
+else:
+    import unittest
+# unittest.mock is not available in 2.7 (though unittest2 might contain it?)
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+import functools
+
+import matplotlib
+matplotlib.use('Agg')  # fix execution of tests involving matplotlib on travis
+import numpy as np
+
+import imgaug as ia
+from imgaug import augmenters as iaa
+from imgaug import random as iarandom
+from imgaug import parameters as iap
+
+# imagecorruptions cannot be installed in <=3.4 due to their
+# scikit-image requirement
+SUPPORTS_LIBRARY = (sys.version_info[0] == 3 and sys.version_info[1] >= 5)
+
+if SUPPORTS_LIBRARY:
+    import imagecorruptions
+    from imagecorruptions import corrupt
+
+
+class Test_get_imgcorrupt_subset(unittest.TestCase):
+    @unittest.skipUnless(SUPPORTS_LIBRARY,
+                         "imagecorruptions can only be tested for python 3.5+")
+    def test_by_comparison_with_imagecorruptions(self):
+        subset_names = ["common", "validation", "all"]
+        for subset in subset_names:
+            with self.subTest(subset=subset):
+                func_names, funcs = iaa.imgcorruptlike.get_corruption_names(
+                    subset)
+                func_names_exp = imagecorruptions.get_corruption_names(subset)
+
+                assert func_names == func_names_exp
+                for func_name, func in zip(func_names, funcs):
+                    assert getattr(
+                        iaa.imgcorruptlike, "apply_%s" % (func_name,)
+                    ) is func
+
+    @unittest.skipUnless(SUPPORTS_LIBRARY,
+                         "imagecorruptions can only be tested for python 3.5+")
+    def test_subset_functions(self):
+        subset_names = ["common", "validation", "all"]
+        for subset in subset_names:
+            func_names, funcs = iaa.imgcorruptlike.get_corruption_names(subset)
+            image = np.mod(
+                np.arange(32*32*3), 256
+            ).reshape((32, 32, 3)).astype(np.uint8)
+
+            for func_name, func in zip(func_names, funcs):
+                with self.subTest(subset=subset, name=func_name):
+                    # don't verify here whether e.g. only seed 2 produces
+                    # different results from seed 1, because some methods
+                    # are only dependent on the severity
+                    image_aug1 = func(image, severity=5, seed=1)
+                    image_aug2 = func(image, severity=5, seed=1)
+                    image_aug3 = func(image, severity=1, seed=2)
+                    assert not np.array_equal(image, image_aug1)
+                    assert not np.array_equal(image, image_aug2)
+                    assert not np.array_equal(image_aug2, image_aug3)
+                    assert np.array_equal(image_aug1, image_aug2)
+
+
+class _CompareFuncWithImageCorruptions(unittest.TestCase):
+    def _test_by_comparison_with_imagecorruptions(
+            self,
+            fname,
+            shapes=((64, 64), (64, 64, 1), (64, 64, 3)),
+            dtypes=("uint8",),
+            severities=(1, 2, 3, 4, 5),
+            seeds=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)):
+        for shape in shapes:
+            for dtype in dtypes:
+                for severity in severities:
+                    for seed in seeds:
+                        with self.subTest(shape=shape, severity=severity,
+                                          seed=seed):
+                            image_imgaug = self.create_image_imgaug(
+                                shape, dtype, 1000 + seed)
+                            image_imgcor = np.copy(image_imgaug)
+
+                            self._run_single_comparison_test(
+                                fname, image_imgaug, image_imgcor, severity,
+                                seed)
+
+    @classmethod
+    def create_image_imgaug(cls, shape, dtype, seed, tile=None):
+        rng = iarandom.RNG(1000 + seed)
+
+        if dtype.startswith("uint"):
+            image = rng.integers(0, 256, size=shape, dtype=dtype)
+        else:
+            assert dtype.startswith("float")
+            image = rng.uniform(0.0, 1.0, size=shape)
+            image = image.astype(dtype)
+
+        if tile is not None:
+            image = np.tile(image, tile)
+
+        return image
+
+    @classmethod
+    def _run_single_comparison_test(cls, fname, image_imgaug, image_imgcor,
+                                    severity, seed):
+        image_imgaug_sum = np.sum(image_imgaug)
+        image_imgcor_sum = np.sum(image_imgcor)
+
+        image_aug, image_aug_exp = cls._generate_augmented_images(
+            fname, image_imgaug, image_imgcor, severity, seed)
+
+        # assert that the original image is unchanged,
+        # i.e. it was not augmented in-place
+        assert np.isclose(np.sum(image_imgcor), image_imgcor_sum, rtol=0,
+                          atol=1e-4)
+        assert np.isclose(np.sum(image_imgaug), image_imgaug_sum, rtol=0,
+                          atol=1e-4)
+
+        # assert that the functions returned numpy arrays and not PIL images
+        assert ia.is_np_array(image_aug_exp)
+        assert ia.is_np_array(image_aug)
+
+        assert image_aug.shape == image_imgaug.shape
+        assert image_aug.dtype.name == image_aug_exp.dtype.name
+
+        atol = 1e-4  # set this to 0.5+1e-4 if output is converted to uint8
+        assert np.allclose(image_aug, image_aug_exp, rtol=0, atol=atol)
+
+    @classmethod
+    def _generate_augmented_images(cls, fname, image_imgaug, image_imgcor,
+                                   severity, seed):
+        func_imgaug = getattr(
+            iaa.imgcorruptlike,
+            "apply_%s" % (fname,))
+        func_imagecor = functools.partial(corrupt, corruption_name=fname)
+
+        with iarandom.temporary_numpy_seed(seed):
+            image_aug_exp = func_imagecor(image_imgcor, severity=severity)
+            if not ia.is_np_array(image_aug_exp):
+                image_aug_exp = np.asarray(image_aug_exp)
+            if image_imgcor.ndim == 2:
+                image_aug_exp = image_aug_exp[:, :, 0]
+            elif image_imgcor.shape[-1] == 1:
+                image_aug_exp = image_aug_exp[:, :, 0:1]
+
+        image_aug = func_imgaug(image_imgaug, severity=severity,
+                                seed=seed)
+
+        return image_aug, image_aug_exp
+
+
+@unittest.skipUnless(SUPPORTS_LIBRARY,
+                     "imagecorruptions can only be tested for python 3.5+")
+class Test_apply_functions(_CompareFuncWithImageCorruptions):
+    def test_apply_gaussian_noise(self):
+        self._test_by_comparison_with_imagecorruptions("gaussian_noise")
+
+    def test_apply_shot_noise(self):
+        self._test_by_comparison_with_imagecorruptions("shot_noise")
+
+    def test_apply_impulse_noise(self):
+        self._test_by_comparison_with_imagecorruptions("impulse_noise")
+
+    def test_apply_speckle_noise(self):
+        self._test_by_comparison_with_imagecorruptions("speckle_noise")
+
+    def test_apply_gaussian_blur(self):
+        self._test_by_comparison_with_imagecorruptions("gaussian_blur")
+
+    def test_apply_glass_blur(self):
+        # glass_blur() is extremely slow, so we run only a reduced set
+        # of tests here
+        self._test_by_comparison_with_imagecorruptions(
+            "glass_blur",
+            shapes=[(32, 32), (32, 32, 1), (32, 32, 3)],
+            severities=[1, 4],
+            seeds=[1, 2, 3])
+
+    def test_apply_defocus_blur(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "defocus_blur")
+
+    def test_apply_motion_blur(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "motion_blur")
+
+    def test_apply_zoom_blur(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "zoom_blur")
+
+    def test_apply_fog(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "fog")
+
+    def test_apply_frost(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "frost",
+            severities=[1, 5],
+            seeds=[1, 5, 10])
+
+    def test_apply_snow(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "snow")
+
+    def test_apply_spatter(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "spatter")
+
+    def test_apply_contrast(self):
+        self._test_by_comparison_with_imagecorruptions("contrast")
+
+    def test_apply_brightness(self):
+        self._test_by_comparison_with_imagecorruptions("brightness")
+
+    def test_apply_saturate(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "saturate")
+
+    def test_apply_jpeg_compression(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "jpeg_compression")
+
+    def test_apply_pixelate(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "pixelate")
+
+    def test_apply_elastic_transform(self):
+        self._test_by_comparison_with_imagecorruptions(
+            "elastic_transform")
+
+
+@unittest.skipUnless(SUPPORTS_LIBRARY,
+                     "imagecorruptions can only be tested for python 3.5+")
+class TestAugmenters(unittest.TestCase):
+    @classmethod
+    def _test_augmenter(cls, augmenter_name, func_expected,
+                        dependent_on_seed):
+        severity = 5
+        aug_cls = getattr(iaa.imgcorruptlike, augmenter_name)
+        image = np.mod(
+            np.arange(32*32*3), 256
+        ).reshape((32, 32, 3)).astype(np.uint8)
+
+        rng = iarandom.RNG(1)
+        # replay sampling of severities, not really necessary here as we
+        # use a deterministic value, but still done for good style
+        _ = iap.Deterministic(1).draw_samples((1,), rng)
+
+        # As for the functions above, we can't just change the seed value
+        # to get different augmentations as many functions are dependend
+        # only on the severity. So we change only for some functions only
+        # the seed and for the others severity+seed.
+        image_aug1 = aug_cls(severity=severity, random_state=1)(image=image)
+        image_aug2 = aug_cls(severity=severity, random_state=1)(image=image)
+        if dependent_on_seed:
+            image_aug3 = aug_cls(severity=severity, random_state=2)(
+                image=image)
+        else:
+            image_aug3 = aug_cls(severity=severity-1, random_state=2)(
+                image=image)
+        image_aug_exp = func_expected(
+            image,
+            severity=severity,
+            seed=rng.generate_seed_())
+
+        assert aug_cls(severity=severity).func is func_expected
+        assert np.array_equal(image_aug1, image_aug_exp)
+        assert np.array_equal(image_aug2, image_aug_exp)
+        assert not np.array_equal(image_aug3, image_aug2)
+
+    def test_gaussian_noise(self):
+        self._test_augmenter("GaussianNoise",
+                             iaa.imgcorruptlike.apply_gaussian_noise,
+                             True)
+
+    def test_shot_noise(self):
+        self._test_augmenter("ShotNoise",
+                             iaa.imgcorruptlike.apply_shot_noise,
+                             True)
+
+    def test_impulse_noise(self):
+        self._test_augmenter("ImpulseNoise",
+                             iaa.imgcorruptlike.apply_impulse_noise,
+                             True)
+
+    def test_speckle_noise(self):
+        self._test_augmenter("SpeckleNoise",
+                             iaa.imgcorruptlike.apply_speckle_noise,
+                             True)
+
+    def test_gaussian_blur(self):
+        self._test_augmenter("GaussianBlur",
+                             iaa.imgcorruptlike.apply_gaussian_blur,
+                             False)
+
+    def test_glass_blur(self):
+        self._test_augmenter("GlassBlur",
+                             iaa.imgcorruptlike.apply_glass_blur,
+                             False)
+
+    def test_defocus_blur(self):
+        self._test_augmenter("DefocusBlur",
+                             iaa.imgcorruptlike.apply_defocus_blur,
+                             False)
+
+    def test_motion_blur(self):
+        self._test_augmenter("MotionBlur",
+                             iaa.imgcorruptlike.apply_motion_blur,
+                             False)
+
+    def test_zoom_blur(self):
+        self._test_augmenter("ZoomBlur",
+                             iaa.imgcorruptlike.apply_zoom_blur,
+                             False)
+
+    def test_fog(self):
+        self._test_augmenter("Fog",
+                             iaa.imgcorruptlike.apply_fog,
+                             True)
+
+    def test_frost(self):
+        self._test_augmenter("Frost",
+                             iaa.imgcorruptlike.apply_frost,
+                             False)
+
+    def test_snow(self):
+        self._test_augmenter("Snow",
+                             iaa.imgcorruptlike.apply_snow,
+                             True)
+
+    def test_spatter(self):
+        self._test_augmenter("Spatter",
+                             iaa.imgcorruptlike.apply_spatter,
+                             True)
+
+    def test_contrast(self):
+        self._test_augmenter("Contrast",
+                             iaa.imgcorruptlike.apply_contrast,
+                             False)
+
+    def test_brightness(self):
+        self._test_augmenter("Brightness",
+                             iaa.imgcorruptlike.apply_brightness,
+                             False)
+
+    def test_saturate(self):
+        self._test_augmenter("Saturate",
+                             iaa.imgcorruptlike.apply_saturate,
+                             False)
+
+    def test_jpeg_compression(self):
+        self._test_augmenter("JpegCompression",
+                             iaa.imgcorruptlike.apply_jpeg_compression,
+                             False)
+
+    def test_pixelate(self):
+        self._test_augmenter("Pixelate",
+                             iaa.imgcorruptlike.apply_pixelate,
+                             False)
+
+    def test_elastic_transform(self):
+        self._test_augmenter("ElasticTransform",
+                             iaa.imgcorruptlike.apply_elastic_transform,
+                             True)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -7,3 +7,8 @@ pytest-subtests; python_version >= '3.4'
 mock; python_version < '3.3'  # unittest.mock does not exist in older versions
 unittest2; python_version < '3.4'  # in 3.4, self.subTest was added
 xdoctest >= 0.7.2
+
+# used in imgaug.augmenters.imgcorrupt
+# that library has scikit-image 15+ as a requirement, which does not exist
+# in <=3.4, so it is not tested here
+imagecorruptions; python_version >= '3.5'


### PR DESCRIPTION
This patch adds wrappers around the functions from
package
https://github.com/bethgelab/imagecorruptions.
The functions in that package were used in some recent
papers and are added here for convenience.
The wrappers produce arrays containing values
identical to the output arrays from the corresponding
`imagecorruptions` functions when called via the
`imagecorruptions.corrupt()` (verified via unittests).
The interfaces of the wrapper functions are identical to the
`imagecorruptions` functions, with the only difference of
also supporting `seed` parameters.

* Add module `imgaug.augmenters.imgcorruptlike`.
  The `like` signals that the augmentation functions do
  not *have* to wrap `imagecorruptions` internally.
  They merely have to produce the same outputs.
* Add the following functions to module
  `imgaug.augmenters.imgcorruptlike`:
    * `apply_gaussian_noise()`
    * `apply_shot_noise()`
    * `apply_impulse_noise()`
    * `apply_speckle_noise()`
    * `apply_gaussian_blur()`
    * `apply_glass_blur()`
      (improved performance over original function)
    * `apply_defocus_blur()`
    * `apply_motion_blur()`
    * `apply_zoom_blur()`
    * `apply_fog()`
    * `apply_snow()`
    * `apply_spatter()`
    * `apply_contrast()`
    * `apply_brightness()`
    * `apply_saturate()`
    * `apply_jpeg_compression()`
    * `apply_pixelate()`
    * `apply_elastic_transform()`
* Add function
  `imgaug.augmenters.imgcorruptlike.get_corruption_names(subset)`.
  Similar to `imagecorruptions.get_corruption_names(subset)`,
  but returns a tuple
  `(list of corruption method names,
    list of corruption method functions)`,
  instead of only the names.
* Add the following augmenters to module
  `imgaug.augmenters.imgcorruptlike`:
    * `GaussianNoise`
    * `ShotNoise`
    * `ImpulseNoise`
    * `SpeckleNoise`
    * `GaussianBlur`
    * `GlassBlur`
    * `DefocusBlur`
    * `MotionBlur`
    * `ZoomBlur`
    * `Fog`
    * `Frost`
    * `Snow`
    * `Spatter`
    * `Contrast`
    * `Brightness`
    * `Saturate`
    * `JpegCompression`
    * `Pixelate`
    * `ElasticTransform`
* Add context `imgaug.random.temporary_numpy_seed()`.