### PR TITLE
Add Cutout augmenter

### DIFF
--- a/changelogs/master/added/20191220_cutout.md
+++ b/changelogs/master/added/20191220_cutout.md
@@ -1,0 +1,9 @@
+# Cutout Augmenter #531
+
+* Added `imgaug.augmenters.arithmetic.apply_cutout_()`, which replaces
+  in-place a single rectangular area with a constant intensity value or a
+  constant color or gaussian noise.
+  See also the [paper](https://arxiv.org/abs/1708.04552) about Cutout.
+* Added `imgaug.augmenters.arithmetic.apply_cutout()`. Same as
+  `apply_cutout_()`, but copies the input images before applying cutout.
+* Added `imgaug.augmenters.arithmetic.Cutout`.

--- a/checks/check_cutout.py
+++ b/checks/check_cutout.py
@@ -1,0 +1,15 @@
+from __future__ import print_function, division, absolute_import
+import imgaug as ia
+import imgaug.augmenters as iaa
+
+
+def main():
+    aug = iaa.Cutout(fill_mode=["gaussian", "constant"], cval=(0, 255),
+                     fill_per_channel=0.5)
+    image = ia.quokka()
+    images_aug = aug(images=[image] * 16)
+    ia.imshow(ia.draw_grid(images_aug, cols=4, rows=4))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add Cutout augmenter

This patch adds functionality to apply cutout augmentation, as described in the corresponding paper.

The implementation of this patch uses a relative cutout size and position (rather than absolute one as in the paper's    implementation). Furthermore, RGB fill values are supported (paper implementation always drops to mean value) and replacing cutout regions with gaussian noise  (paper only supports constant values).

* Add `imgaug.augmenters.arithmetic.cutout()`
* Add `imgaug.augmenters.arithmetic.cutout_()`
* Add `imgaug.augmenters.arithmetic.Cutout` augmenter