### PR TITLE
Add in-place functions to coords-based augmentables

### DIFF
--- a/changelogs/master/added/20191221_inplace_cba_methods.md
+++ b/changelogs/master/added/20191221_inplace_cba_methods.md
@@ -1,0 +1,54 @@
+# Added in-place Methods for Coordinate-based Augmentables #532
+
+* Added `Keypoint.project_()`.
+* Added `Keypoint.shift_()`.    
+* Added `KeypointsOnImage.on_()`.
+* Added setter for `KeypontsOnImage.items`.
+* Added setter for `BoundingBoxesOnImage.items`.
+* Added setter for `LineStringsOnImage.items`.
+* Added setter for `PolygonsOnImage.items`.
+* Added `KeypointsOnImage.remove_out_of_image_fraction_()`.
+* Added `KeypointsOnImage.clip_out_of_image_fraction_()`.
+* Added `KeypointsOnImage.shift_()`.
+* Added `BoundingBox.project_()`.
+* Added `BoundingBox.extend_()`.
+* Added `BoundingBox.clip_out_of_image_()`.
+* Added `BoundingBox.shift_()`.
+* Added `BoundingBoxesOnImage.on_()`.
+* Added `BoundingBoxesOnImage.clip_out_of_image_()`.
+* Added `BoundingBoxesOnImage.remove_out_of_image_()`.
+* Added `BoundingBoxesOnImage.remove_out_of_image_fraction_()`.
+* Added `BoundingBoxesOnImage.shift_()`.
+* Added `imgaug.augmentables.utils.project_coords_()`.
+* Added `LineString.project_()`.
+* Added `LineString.shift_()`.
+* Added `LineStringsOnImage.on_()`.
+* Added `LineStringsOnImage.remove_out_of_image_()`.
+* Added `LineStringsOnImage.remove_out_of_image_fraction_()`.
+* Added `LineStringsOnImage.clip_out_of_image_()`.
+* Added `LineStringsOnImage.shift_()`.
+* Added `Polygon.project_()`.
+* Added `Polygon.shift_()`.
+* Added `Polygon.on_()`.
+* Added `Polygon.subdivide_()`.
+* Added `PolygonsOnImage.remove_out_of_image_()`.
+* Added `PolygonsOnImage.remove_out_of_image_fraction_()`.
+* Added `PolygonsOnImage.clip_out_of_image_()`.
+* Added `PolygonsOnImage.shift_()`.
+* Added `PolygonsOnImage.subdivide_()`.
+* Switched `BoundingBoxesOnImage.copy()` to a custom copy operation (away
+  from module `copy` module).
+* Added parameters `bounding_boxes` and `shape` to
+  BoundingBoxesOnImage.copy()`.
+* Added parameters `bounding_boxes` and `shape` to
+  BoundingBoxesOnImage.deepcopy()`.
+* Switched `KeypointsOnImage.copy()` to a custom copy operation (away
+  from module `copy` module).
+* Switched `PolygonsOnImage.copy()` to a custom copy operation (away
+  from module `copy` module).
+* Added parameters `polygons` and `shape` to
+  PolygonsOnImage.copy()`.
+* Added parameters `polygons` and `shape` to
+  PolygonsOnImage.deepcopy()`.
+* Switched augmenters to use in-place functions for keypoints,
+  bounding boxes, line strings and polygons.

--- a/checks/check_jigsaw.py
+++ b/checks/check_jigsaw.py
@@ -6,10 +6,14 @@ import timeit
 
 def main():
     image = ia.quokka_square((200, 200))
+    kpsoi = ia.quokka_keypoints((200, 200), extract="square")
     aug = iaa.Jigsaw(10, 10)
 
-    images_aug = aug(images=[image] * 16)
-    ia.imshow(ia.draw_grid(images_aug))
+    images_aug, kpsois_aug = aug(images=[image] * 16,
+                                 keypoints=[kpsoi] * 16)
+    images_show = [kpsoi_aug.draw_on_image(image_aug)
+                   for image_aug, kpsoi_aug in zip(images_aug, kpsois_aug)]
+    ia.imshow(ia.draw_grid(images_show))
 
     gen_time = timeit.timeit(
         "iaa.generate_jigsaw_destinations(10, 10, 2, rng)",

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -10,8 +10,8 @@ import cv2
 
 from .. import imgaug as ia
 from .base import IAugmentable
-from .utils import (normalize_shape, project_coords, interpolate_points,
-                    _remove_out_of_image_fraction)
+from .utils import (normalize_shape, project_coords_, interpolate_points,
+                    _remove_out_of_image_fraction_)
 
 
 # TODO Add Line class and make LineString a list of Line elements
@@ -309,6 +309,35 @@ class LineString(object):
         """
         return self.compute_distance(other, default=np.inf) < max_distance
 
+    def project_(self, from_shape, to_shape):
+        """Project the line string onto a differently shaped image in-place.
+
+        E.g. if a point of the line string is on its original image at
+        ``x=(10 of 100 pixels)`` and ``y=(20 of 100 pixels)`` and is projected
+        onto a new image with size ``(width=200, height=200)``, its new
+        position will be ``(x=20, y=40)``.
+
+        This is intended for cases where the original image is resized.
+        It cannot be used for more complex changes (e.g. padding, cropping).
+
+        Parameters
+        ----------
+        from_shape : tuple of int or ndarray
+            Shape of the original image. (Before resize.)
+
+        to_shape : tuple of int or ndarray
+            Shape of the new image. (After resize.)
+
+        Returns
+        -------
+        imgaug.augmentables.lines.LineString
+            Line string with new coordinates.
+            The object may have been modified in-place.
+
+        """
+        self.coords = project_coords_(self.coords, from_shape, to_shape)
+        return self
+
     def project(self, from_shape, to_shape):
         """Project the line string onto a differently shaped image.
 
@@ -334,8 +363,7 @@ class LineString(object):
             Line string with new coordinates.
 
         """
-        coords_proj = project_coords(self.coords, from_shape, to_shape)
-        return self.copy(coords=coords_proj)
+        return self.deepcopy().project_(from_shape, to_shape)
 
     def compute_out_of_image_fraction(self, image):
         """Compute fraction of polygon area outside of the image plane.
@@ -629,6 +657,42 @@ class LineString(object):
             result.append(inter_sorted)
         return result
 
+    def shift_(self, top=None, right=None, bottom=None, left=None):
+        """Move this line string along the x/y-axis in-place.
+
+        Parameters
+        ----------
+        top : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            top (towards the bottom).
+
+        right : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            right (towards the left).
+
+        bottom : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            bottom (towards the top).
+
+        left : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            left (towards the right).
+
+        Returns
+        -------
+        result : imgaug.augmentables.lines.LineString
+            Shifted line string.
+            The object may have been modified in-place.
+
+        """
+        top = top if top is not None else 0
+        right = right if right is not None else 0
+        bottom = bottom if bottom is not None else 0
+        left = left if left is not None else 0
+        self.coords[:, 0] += left - right
+        self.coords[:, 1] += top - bottom
+        return self
+
     # TODO convert this to x/y params?
     def shift(self, top=None, right=None, bottom=None, left=None):
         """Move this line string along the x/y-axis.
@@ -657,14 +721,8 @@ class LineString(object):
             Shifted line string.
 
         """
-        top = top if top is not None else 0
-        right = right if right is not None else 0
-        bottom = bottom if bottom is not None else 0
-        left = left if left is not None else 0
-        coords = np.copy(self.coords)
-        coords[:, 0] += left - right
-        coords[:, 1] += top - bottom
-        return self.copy(coords=coords)
+        return self.deepcopy().shift_(top=top, right=right,
+                                      bottom=bottom, left=left)
 
     def draw_mask(self, image_shape, size_lines=1, size_points=0,
                   raise_if_out_of_image=False):
@@ -1628,6 +1686,18 @@ class LineStringsOnImage(IAugmentable):
         """
         return self.line_strings
 
+    @items.setter
+    def items(self, value):
+        """Set the line strings in this container.
+
+        Parameters
+        ----------
+        value : list of LineString
+            Line strings within this container.
+
+        """
+        self.line_strings = value
+
     @property
     def empty(self):
         """Estimate whether this object contains zero line strings.
@@ -1639,6 +1709,34 @@ class LineStringsOnImage(IAugmentable):
 
         """
         return len(self.line_strings) == 0
+
+    def on_(self, image):
+        """Project the line strings from one image shape to a new one in-place.
+
+        Parameters
+        ----------
+        image : ndarray or tuple of int
+            The new image onto which to project.
+            Either an image with shape ``(H,W,[C])`` or a tuple denoting
+            such an image shape.
+
+        Returns
+        -------
+        imgaug.augmentables.lines.LineStrings
+            Object containing all projected line strings.
+            The object and its items may have been modified in-place.
+
+        """
+        # pylint: disable=invalid-name
+        on_shape = normalize_shape(image)
+        if on_shape[0:2] == self.shape[0:2]:
+            self.shape = on_shape  # channels may differ
+            return self
+
+        for i, item in enumerate(self.items):
+            self.line_strings[i] = item.project_(self.shape, on_shape)
+        self.shape = on_shape
+        return self
 
     def on(self, image):
         """Project the line strings from one image shape to a new one.
@@ -1657,12 +1755,7 @@ class LineStringsOnImage(IAugmentable):
 
         """
         # pylint: disable=invalid-name
-        shape = normalize_shape(image)
-        if shape[0:2] == self.shape[0:2]:
-            return self.deepcopy()
-        line_strings = [ls.project(self.shape, shape)
-                        for ls in self.line_strings]
-        return self.deepcopy(line_strings=line_strings, shape=shape)
+        return self.deepcopy().on_(image)
 
     @classmethod
     def from_xy_arrays(cls, xy, shape):
@@ -1800,6 +1893,32 @@ class LineStringsOnImage(IAugmentable):
 
         return image
 
+    def remove_out_of_image_(self, fully=True, partly=False):
+        """
+        Remove all LS that are fully/partially outside of an image in-place.
+
+        Parameters
+        ----------
+        fully : bool, optional
+            Whether to remove line strings that are fully outside of the image.
+
+        partly : bool, optional
+            Whether to remove line strings that are partially outside of the
+            image.
+
+        Returns
+        -------
+        imgaug.augmentables.lines.LineStringsOnImage
+            Reduced set of line strings. Those that are fully/partially
+            outside of the given image plane are removed.
+            The object and its items may have been modified in-place.
+
+        """
+        self.line_strings = [
+            ls for ls in self.line_strings
+            if not ls.is_out_of_image(self.shape, fully=fully, partly=partly)]
+        return self
+
     def remove_out_of_image(self, fully=True, partly=False):
         """
         Remove all line strings that are fully/partially outside of an image.
@@ -1820,10 +1939,30 @@ class LineStringsOnImage(IAugmentable):
             outside of the given image plane are removed.
 
         """
-        lss_clean = [ls for ls in self.line_strings
-                     if not ls.is_out_of_image(
-                         self.shape, fully=fully, partly=partly)]
-        return LineStringsOnImage(lss_clean, shape=self.shape)
+        return self.copy().remove_out_of_image_(fully=fully, partly=partly)
+
+    def remove_out_of_image_fraction_(self, fraction):
+        """Remove all LS with an OOI fraction of at least `fraction` in-place.
+
+        'OOI' is the abbreviation for 'out of image'.
+
+        Parameters
+        ----------
+        fraction : number
+            Minimum out of image fraction that a line string has to have in
+            order to be removed. A fraction of ``1.0`` removes only line
+            strings that are ``100%`` outside of the image. A fraction of
+            ``0.0`` removes all line strings.
+
+        Returns
+        -------
+        imgaug.augmentables.lines.LineStringsOnImage
+            Reduced set of line strings, with those that had an out of image
+            fraction greater or equal the given one removed.
+            The object and its items may have been modified in-place.
+
+        """
+        return _remove_out_of_image_fraction_(self, fraction)
 
     def remove_out_of_image_fraction(self, fraction):
         """Remove all LS with an out of image fraction of at least `fraction`.
@@ -1843,7 +1982,37 @@ class LineStringsOnImage(IAugmentable):
             fraction greater or equal the given one removed.
 
         """
-        return _remove_out_of_image_fraction(self, fraction, LineStringsOnImage)
+        return self.copy().remove_out_of_image_fraction_(fraction)
+
+    def clip_out_of_image_(self):
+        """
+        Clip off all parts of the LSs that are outside of an image in-place.
+
+        .. note::
+
+            The result can contain fewer line strings than the input did. That
+            happens when a polygon is fully outside of the image plane.
+
+        .. note::
+
+            The result can also contain *more* line strings than the input
+            did. That happens when distinct parts of a line string are only
+            connected by line segments that are outside of the image plane and
+            hence will be clipped off, resulting in two or more unconnected
+            line string parts that are left in the image plane.
+
+        Returns
+        -------
+        imgaug.augmentables.lines.LineStringsOnImage
+            Line strings, clipped to fall within the image dimensions.
+            The count of output line strings may differ from the input count.
+
+        """
+        self.line_strings = [
+            ls_clipped
+            for ls in self.line_strings
+            for ls_clipped in ls.clip_out_of_image(self.shape)]
+        return self
 
     def clip_out_of_image(self):
         """
@@ -1869,10 +2038,40 @@ class LineStringsOnImage(IAugmentable):
             The count of output line strings may differ from the input count.
 
         """
-        lss_cut = [ls_clipped
-                   for ls in self.line_strings
-                   for ls_clipped in ls.clip_out_of_image(self.shape)]
-        return LineStringsOnImage(lss_cut, shape=self.shape)
+        return self.copy().clip_out_of_image_()
+
+    def shift_(self, top=None, right=None, bottom=None, left=None):
+        """Move the line strings along the x/y-axis in-place.
+
+        Parameters
+        ----------
+        top : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            top (towards the bottom).
+
+        right : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            right (towads the left).
+
+        bottom : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            bottom (towards the top).
+
+        left : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            left (towards the right).
+
+        Returns
+        -------
+        imgaug.augmentables.lines.LineStringsOnImage
+            Shifted line strings.
+            The object and its items may have been modified in-place.
+
+        """
+        for i, ls in enumerate(self.line_strings):
+            self.line_strings[i] = ls.shift_(top=top, right=right,
+                                             bottom=bottom, left=left)
+        return self
 
     def shift(self, top=None, right=None, bottom=None, left=None):
         """Move the line strings along the x/y-axis.
@@ -1901,9 +2100,8 @@ class LineStringsOnImage(IAugmentable):
             Shifted line strings.
 
         """
-        lss_new = [ls.shift(top=top, right=right, bottom=bottom, left=left)
-                   for ls in self.line_strings]
-        return LineStringsOnImage(lss_new, shape=self.shape)
+        return self.deepcopy().shift_(top=top, right=right,
+                                      bottom=bottom, left=left)
 
     def to_xy_array(self):
         """Convert all line string coordinates to one array of shape ``(N,2)``.
@@ -2048,9 +2246,13 @@ class LineStringsOnImage(IAugmentable):
             Shallow copy.
 
         """
-        lss = self.line_strings if line_strings is None else line_strings
-        shape = self.shape if shape is None else shape
-        return LineStringsOnImage(line_strings=lss, shape=shape)
+        if line_strings is None:
+            line_strings = self.line_strings[:]
+        if shape is None:
+            # use tuple() here in case the shape was provided as a list
+            shape = tuple(self.shape)
+
+        return LineStringsOnImage(line_strings, shape)
 
     def deepcopy(self, line_strings=None, shape=None):
         """Create a deep copy of the object.
@@ -2075,11 +2277,14 @@ class LineStringsOnImage(IAugmentable):
             Deep copy.
 
         """
-        lss = self.line_strings if line_strings is None else line_strings
-        shape = self.shape if shape is None else shape
-        return LineStringsOnImage(
-            line_strings=[ls.deepcopy() for ls in lss],
-            shape=tuple(shape))
+        # Manual copy is far faster than deepcopy, so use manual copy here.
+        if line_strings is None:
+            line_strings = [ls.deepcopy() for ls in self.line_strings]
+        if shape is None:
+            # use tuple() here in case the shape was provided as a list
+            shape = tuple(self.shape)
+
+        return LineStringsOnImage(line_strings, shape)
 
     def __iter__(self):
         """Iterate over the line strings in this container.

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -1,7 +1,6 @@
 """Classes dealing with polygons."""
 from __future__ import print_function, division, absolute_import
 
-import copy
 import traceback
 import collections
 
@@ -15,7 +14,7 @@ from .. import imgaug as ia
 from .. import random as iarandom
 from .base import IAugmentable
 from .utils import (normalize_shape, interpolate_points,
-                    _remove_out_of_image_fraction)
+                    _remove_out_of_image_fraction_, project_coords_)
 
 
 def recover_psois_(psois, psois_orig, recoverer, random_state):
@@ -275,6 +274,35 @@ class Polygon(object):
         xx = self.xx
         return max(xx) - min(xx)
 
+    def project_(self, from_shape, to_shape):
+        """Project the polygon onto an image with different shape in-place.
+
+        The relative coordinates of all points remain the same.
+        E.g. a point at ``(x=20, y=20)`` on an image
+        ``(width=100, height=200)`` will be projected on a new
+        image ``(width=200, height=100)`` to ``(x=40, y=10)``.
+
+        This is intended for cases where the original image is resized.
+        It cannot be used for more complex changes (e.g. padding, cropping).
+
+        Parameters
+        ----------
+        from_shape : tuple of int
+            Shape of the original image. (Before resize.)
+
+        to_shape : tuple of int
+            Shape of the new image. (After resize.)
+
+        Returns
+        -------
+        imgaug.augmentables.polys.Polygon
+            Polygon object with new coordinates.
+            The object may have been modified in-place.
+
+        """
+        self.exterior = project_coords_(self.coords, from_shape, to_shape)
+        return self
+
     def project(self, from_shape, to_shape):
         """Project the polygon onto an image with different shape.
 
@@ -300,11 +328,7 @@ class Polygon(object):
             Polygon object with new coordinates.
 
         """
-        if from_shape[0:2] == to_shape[0:2]:
-            return self.copy()
-        ls_proj = self.to_line_string(closed=False).project(
-            from_shape, to_shape)
-        return self.copy(exterior=ls_proj.coords)
+        return self.deepcopy().project_(from_shape, to_shape)
 
     def find_closest_point_index(self, x, y, return_distance=False):
         """Find the index of the exterior point closest to given coordinates.
@@ -614,6 +638,42 @@ class Polygon(object):
 
         return polygons_reordered
 
+    def shift_(self, top=None, right=None, bottom=None, left=None):
+        """Move this polygon along the x/y-axis in-place.
+
+        Parameters
+        ----------
+        top : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            top (towards the bottom).
+
+        right : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            right (towards the left).
+
+        bottom : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            bottom (towards the top).
+
+        left : None or int, optional
+            Amount of pixels by which to shift this object *from* the
+            left (towards the right).
+
+        Returns
+        -------
+        imgaug.augmentables.polys.Polygon
+            Shifted polygon.
+            The object may have been modified in-place.
+
+        """
+        top = top if top is not None else 0
+        right = right if right is not None else 0
+        bottom = bottom if bottom is not None else 0
+        left = left if left is not None else 0
+        self.exterior[:, 0] += left - right
+        self.exterior[:, 1] += top - bottom
+        return self
+
     def shift(self, top=None, right=None, bottom=None, left=None):
         """Move this polygon along the x/y-axis.
 
@@ -641,9 +701,8 @@ class Polygon(object):
             Shifted polygon.
 
         """
-        ls_shifted = self.to_line_string(closed=False).shift(
-            top=top, right=right, bottom=bottom, left=left)
-        return self.copy(exterior=ls_shifted.coords)
+        return self.deepcopy().shift_(top=top, right=right,
+                                      bottom=bottom, left=left)
 
     # TODO separate this into draw_face_on_image() and draw_border_on_image()
     # TODO add tests for line thickness
@@ -963,6 +1022,32 @@ class Polygon(object):
         )
         return self.deepcopy(exterior=exterior)
 
+    def subdivide_(self, points_per_edge):
+        """Derive a new poly with ``N`` interpolated points per edge in-place.
+
+        See :func:`imgaug.augmentables.lines.LineString.subdivide` for details.
+
+        Parameters
+        ----------
+        points_per_edge : int
+            Number of points to interpolate on each edge.
+
+        Returns
+        -------
+        imgaug.augmentables.polys.Polygon
+            Polygon with subdivided edges.
+            The object may have been modified in-place.
+
+        """
+        if len(self.exterior) == 1:
+            return self
+        ls = self.to_line_string(closed=True)
+        ls_sub = ls.subdivide(points_per_edge)
+        # [:-1] even works if the polygon contains zero points
+        exterior_subdivided = ls_sub.coords[:-1]
+        self.exterior = exterior_subdivided
+        return self
+
     def subdivide(self, points_per_edge):
         """Derive a new polygon with ``N`` interpolated points per edge.
 
@@ -979,13 +1064,7 @@ class Polygon(object):
             Polygon with subdivided edges.
 
         """
-        if len(self.exterior) == 1:
-            return self.deepcopy()
-        ls = self.to_line_string(closed=True)
-        ls_sub = ls.subdivide(points_per_edge)
-        # [:-1] even works if the polygon contains zero points
-        exterior_subdivided = ls_sub.coords[:-1]
-        return Polygon(exterior_subdivided, label=self.label)
+        return self.deepcopy().subdivide_(points_per_edge)
 
     def to_shapely_polygon(self):
         """Convert this polygon to a ``Shapely`` ``Polygon``.
@@ -1362,6 +1441,18 @@ class PolygonsOnImage(IAugmentable):
         """
         return self.polygons
 
+    @items.setter
+    def items(self, value):
+        """Set the polygons in this container.
+
+        Parameters
+        ----------
+        value : list of Polygon
+            Polygons within this container.
+
+        """
+        self.polygons = value
+
     @property
     def empty(self):
         """Estimate whether this object contains zero polygons.
@@ -1373,6 +1464,33 @@ class PolygonsOnImage(IAugmentable):
 
         """
         return len(self.polygons) == 0
+
+    def on_(self, image):
+        """Project all polygons from one image shape to a new one in-place.
+
+        Parameters
+        ----------
+        image : ndarray or tuple of int
+            New image onto which the polygons are to be projected.
+            May also simply be that new image's shape ``tuple``.
+
+        Returns
+        -------
+        imgaug.augmentables.polys.PolygonsOnImage
+            Object containing all projected polygons.
+            The object and its items may have been modified in-place.
+
+        """
+        # pylint: disable=invalid-name
+        on_shape = normalize_shape(image)
+        if on_shape[0:2] == self.shape[0:2]:
+            self.shape = on_shape  # channels may differ
+            return self
+
+        for i, item in enumerate(self.items):
+            self.polygons[i] = item.project_(self.shape, on_shape)
+        self.shape = on_shape
+        return self
 
     def on(self, image):
         """Project all polygons from one image shape to a new one.
@@ -1389,13 +1507,7 @@ class PolygonsOnImage(IAugmentable):
             Object containing all projected polygons.
 
         """
-        # pylint: disable=invalid-name
-        shape = normalize_shape(image)
-        if shape[0:2] == self.shape[0:2]:
-            return self.deepcopy()
-        polygons = [poly.project(self.shape, shape) for poly in self.polygons]
-        # TODO use deepcopy() here
-        return PolygonsOnImage(polygons, shape)
+        return self.deepcopy().on_(image)
 
     def draw_on_image(self,
                       image,
@@ -1507,6 +1619,33 @@ class PolygonsOnImage(IAugmentable):
             )
         return image
 
+    def remove_out_of_image_(self, fully=True, partly=False):
+        """Remove all polygons that are fully/partially OOI in-place.
+
+        'OOI' is the abbreviation for 'out of image'.
+
+        Parameters
+        ----------
+        fully : bool, optional
+            Whether to remove polygons that are fully outside of the image.
+
+        partly : bool, optional
+            Whether to remove polygons that are partially outside of the image.
+
+        Returns
+        -------
+        imgaug.augmentables.polys.PolygonsOnImage
+            Reduced set of polygons. Those that are fully/partially
+            outside of the given image plane are removed.
+            The object and its items may have been modified in-place.
+
+        """
+        self.polygons = [
+            poly for poly in self.polygons
+            if not poly.is_out_of_image(self.shape, fully=fully, partly=partly)
+        ]
+        return self
+
     def remove_out_of_image(self, fully=True, partly=False):
         """Remove all polygons that are fully/partially outside of an image.
 
@@ -1525,12 +1664,28 @@ class PolygonsOnImage(IAugmentable):
             outside of the given image plane are removed.
 
         """
-        polys_clean = [
-            poly for poly in self.polygons
-            if not poly.is_out_of_image(self.shape, fully=fully, partly=partly)
-        ]
-        # TODO use deepcopy() here
-        return PolygonsOnImage(polys_clean, shape=self.shape)
+        return self.deepcopy().remove_out_of_image_(fully, partly)
+
+    def remove_out_of_image_fraction_(self, fraction):
+        """Remove all Polys with an OOI fraction of ``>=fraction`` in-place.
+
+        Parameters
+        ----------
+        fraction : number
+            Minimum out of image fraction that a polygon has to have in
+            order to be removed. A fraction of ``1.0`` removes only polygons
+            that are ``100%`` outside of the image. A fraction of ``0.0``
+            removes all polygons.
+
+        Returns
+        -------
+        imgaug.augmentables.polys.PolygonsOnImage
+            Reduced set of polygons, with those that had an out of image
+            fraction greater or equal the given one removed.
+            The object and its items may have been modified in-place.
+
+        """
+        return _remove_out_of_image_fraction_(self, fraction)
 
     def remove_out_of_image_fraction(self, fraction):
         """Remove all Polys with an out of image fraction of ``>=fraction``.
@@ -1550,7 +1705,39 @@ class PolygonsOnImage(IAugmentable):
             fraction greater or equal the given one removed.
 
         """
-        return _remove_out_of_image_fraction(self, fraction, PolygonsOnImage)
+        return self.copy().remove_out_of_image_fraction_(fraction)
+
+    def clip_out_of_image_(self):
+        """Clip off all parts from all polygons that are OOI in-place.
+
+        'OOI' is the abbreviation for 'out of image'.
+
+        .. note::
+
+            The result can contain fewer polygons than the input did. That
+            happens when a polygon is fully outside of the image plane.
+
+        .. note::
+
+            The result can also contain *more* polygons than the input
+            did. That happens when distinct parts of a polygon are only
+            connected by areas that are outside of the image plane and hence
+            will be clipped off, resulting in two or more unconnected polygon
+            parts that are left in the image plane.
+
+        Returns
+        -------
+        imgaug.augmentables.polys.PolygonsOnImage
+            Polygons, clipped to fall within the image dimensions.
+            The count of output polygons may differ from the input count.
+            The object and its items may have been modified in-place.
+
+        """
+        self.polygons = [
+            poly_clipped
+            for poly in self.polygons
+            for poly_clipped in poly.clip_out_of_image(self.shape)]
+        return self
 
     def clip_out_of_image(self):
         """Clip off all parts from all polygons that are outside of an image.
@@ -1575,15 +1762,39 @@ class PolygonsOnImage(IAugmentable):
             The count of output polygons may differ from the input count.
 
         """
-        polys_cut = [
-            poly.clip_out_of_image(self.shape)
-            for poly
-            in self.polygons
-            if poly.is_partly_within_image(self.shape)
-        ]
-        polys_cut_flat = [poly for poly_lst in polys_cut for poly in poly_lst]
-        # TODO use deepcopy() here
-        return PolygonsOnImage(polys_cut_flat, shape=self.shape)
+        return self.copy().clip_out_of_image_()
+
+    def shift_(self, top=None, right=None, bottom=None, left=None):
+        """Move the polygons along the x/y-axis in-place.
+
+        Parameters
+        ----------
+        top : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            top (towards the bottom).
+
+        right : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            right (towads the left).
+
+        bottom : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            bottom (towards the top).
+
+        left : None or int, optional
+            Amount of pixels by which to shift all objects *from* the
+            left (towards the right).
+
+        Returns
+        -------
+        imgaug.augmentables.polys.PolygonsOnImage
+            Shifted polygons.
+
+        """
+        for i, poly in enumerate(self.polygons):
+            self.polygons[i] = poly.shift_(top=top, right=right,
+                                           bottom=bottom, left=left)
+        return self
 
     def shift(self, top=None, right=None, bottom=None, left=None):
         """Move the polygons along the x/y-axis.
@@ -1612,12 +1823,26 @@ class PolygonsOnImage(IAugmentable):
             Shifted polygons.
 
         """
-        polys_new = [
-            poly.shift(top=top, right=right, bottom=bottom, left=left)
-            for poly
-            in self.polygons
-        ]
-        return PolygonsOnImage(polys_new, shape=self.shape)
+        return self.deepcopy().shift_(top=top, right=right,
+                                      bottom=bottom, left=left)
+
+    def subdivide_(self, points_per_edge):
+        """Interpolate ``N`` points on each polygon.
+
+        Parameters
+        ----------
+        points_per_edge : int
+            Number of points to interpolate on each edge.
+
+        Returns
+        -------
+        imgaug.augmentables.polys.PolygonsOnImage
+            Subdivided polygons.
+
+        """
+        for i, poly in enumerate(self.polygons):
+            self.polygons[i] = poly.subdivide_(points_per_edge)
+        return self
 
     def subdivide(self, points_per_edge):
         """Interpolate ``N`` points on each polygon.
@@ -1633,8 +1858,7 @@ class PolygonsOnImage(IAugmentable):
             Subdivided polygons.
 
         """
-        polys_new = [poly.subdivide(points_per_edge) for poly in self.polygons]
-        return PolygonsOnImage(polys_new, shape=self.shape)
+        return self.deepcopy().subdivide_(points_per_edge)
 
     def to_xy_array(self):
         """Convert all polygon coordinates to one array of shape ``(N,2)``.
@@ -1759,8 +1983,22 @@ class PolygonsOnImage(IAugmentable):
         self.shape = kpsoi.shape
         return self
 
-    def copy(self):
+    def copy(self, polygons=None, shape=None):
         """Create a shallow copy of this object.
+
+        Parameters
+        ----------
+        polygons : None or list of imgaug.augmentables.polys.Polygons, optional
+            List of polygons on the image.
+            If not ``None``, then the ``polygons`` attribute of the copied
+            object will be set to this value.
+
+        shape : None or tuple of int or ndarray, optional
+            The shape of the image on which the objects are placed.
+            Either an image with shape ``(H,W,[C])`` or a tuple denoting
+            such an image shape.
+            If not ``None``, then the ``shape`` attribute of the copied object
+            will be set to this value.
 
         Returns
         -------
@@ -1768,10 +2006,30 @@ class PolygonsOnImage(IAugmentable):
             Shallow copy.
 
         """
-        return copy.copy(self)
+        if polygons is None:
+            polygons = self.polygons[:]
+        if shape is None:
+            # use tuple() here in case the shape was provided as a list
+            shape = tuple(self.shape)
 
-    def deepcopy(self):
+        return PolygonsOnImage(polygons, shape)
+
+    def deepcopy(self, polygons=None, shape=None):
         """Create a deep copy of this object.
+
+        Parameters
+        ----------
+        polygons : None or list of imgaug.augmentables.polys.Polygons, optional
+            List of polygons on the image.
+            If not ``None``, then the ``polygons`` attribute of the copied
+            object will be set to this value.
+
+        shape : None or tuple of int or ndarray, optional
+            The shape of the image on which the objects are placed.
+            Either an image with shape ``(H,W,[C])`` or a tuple denoting
+            such an image shape.
+            If not ``None``, then the ``shape`` attribute of the copied object
+            will be set to this value.
 
         Returns
         -------
@@ -1779,10 +2037,14 @@ class PolygonsOnImage(IAugmentable):
             Deep copy.
 
         """
-        # Manual copy is far faster than deepcopy for PolygonsOnImage,
-        # so use manual copy here too
-        polys = [poly.deepcopy() for poly in self.polygons]
-        return PolygonsOnImage(polys, tuple(self.shape))
+        # Manual copy is far faster than deepcopy, so use manual copy here.
+        if polygons is None:
+            polygons = [poly.deepcopy() for poly in self.polygons]
+        if shape is None:
+            # use tuple() here in case the shape was provided as a list
+            shape = tuple(self.shape)
+
+        return PolygonsOnImage(polygons, shape)
 
     def __iter__(self):
         """Iterate over the polygons in this container.

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -249,11 +249,12 @@ class _DebugGridCBAsOICell(_IDebugGridCell):
         image_rsp, size_rs, paddings = _resizepad_to_size(
             self.image, (height, width), cval=_COLOR_GRID_BACKGROUND)
 
-        cbasoi = self.cbasoi.on(size_rs)
+        cbasoi = self.cbasoi.deepcopy()
+        cbasoi = cbasoi.on_(size_rs)
         if isinstance(cbasoi, ia.KeypointsOnImage):
-            cbasoi = cbasoi.shift(y=paddings[0], x=paddings[3])
+            cbasoi = cbasoi.shift_(y=paddings[0], x=paddings[3])
         else:
-            cbasoi = cbasoi.shift(top=paddings[0], left=paddings[3])
+            cbasoi = cbasoi.shift_(top=paddings[0], left=paddings[3])
         cbasoi.shape = image_rsp.shape
 
         return cbasoi.draw_on_image(image_rsp)

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -3657,7 +3657,7 @@ class PerspectiveTransform(meta.Augmenter):
                         kp.x = coords[0]
                         kp.y = coords[1]
                 if self.keep_size:
-                    kpsoi = kpsoi.on(shape_orig)
+                    kpsoi = kpsoi.on_(shape_orig)
                 result[i] = kpsoi
 
         return result
@@ -4799,7 +4799,7 @@ class Rot90(meta.Augmenter):
                 kpsoi_i.shape = shape_aug
 
                 if self.keep_size and (h, w) != (h_aug, w_aug):
-                    kpsoi_i = kpsoi_i.on(shape_orig)
+                    kpsoi_i = kpsoi_i.on_(shape_orig)
                     kpsoi_i.shape = shape_orig
 
                 result.append(kpsoi_i)
@@ -4970,7 +4970,7 @@ class WithPolarWarping(meta.Augmenter):
             return batch, (False, batch_contained_polygons)
 
         psois = [bbsoi.to_polygons_on_image() for bbsoi in batch.bounding_boxes]
-        psois = [psoi.subdivide(2) for psoi in psois]
+        psois = [psoi.subdivide_(2) for psoi in psois]
 
         # Mark Polygons that are really Bounding Boxes
         for psoi in psois:

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -4854,7 +4854,7 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
             if column.name in ["keypoints", "bounding_boxes", "polygons",
                                "line_strings"]:
                 for i, cbaoi in enumerate(column.value):
-                    column.value[i] = cbaoi.remove_out_of_image_fraction(
+                    column.value[i] = cbaoi.remove_out_of_image_fraction_(
                         self.fraction)
 
         return batch
@@ -4924,7 +4924,7 @@ class ClipCBAsToImagePlanes(Augmenter):
             if column.name in ["keypoints", "bounding_boxes", "polygons",
                                "line_strings"]:
                 for i, cbaoi in enumerate(column.value):
-                    column.value[i] = cbaoi.clip_out_of_image()
+                    column.value[i] = cbaoi.clip_out_of_image_()
 
         return batch
 

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -166,7 +166,7 @@ class _AbstractPoolingBase(meta.Augmenter):
                 new_shape = _compute_shape_after_pooling(
                     kpsoi.shape, ksize_h, ksize_w)
 
-                keypoints_on_images[i] = kpsoi.on(new_shape)
+                keypoints_on_images[i] = kpsoi.on_(new_shape)
 
         return keypoints_on_images
 

--- a/test/augmentables/test_bbs.py
+++ b/test/augmentables/test_bbs.py
@@ -20,6 +20,372 @@ import imgaug as ia
 import imgaug.random as iarandom
 
 
+class TestBoundingBox_project_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.project_(*args, **kwargs)
+
+    def test_project_same_shape(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, (10, 10), (10, 10))
+
+        assert np.isclose(bb2.y1, 10)
+        assert np.isclose(bb2.x1, 20)
+        assert np.isclose(bb2.y2, 30)
+        assert np.isclose(bb2.x2, 40)
+
+    def test_project_upscale_by_2(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, (10, 10), (20, 20))
+
+        assert np.isclose(bb2.y1, 10*2)
+        assert np.isclose(bb2.x1, 20*2)
+        assert np.isclose(bb2.y2, 30*2)
+        assert np.isclose(bb2.x2, 40*2)
+
+    def test_project_downscale_by_2(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, (10, 10), (5, 5))
+
+        assert np.isclose(bb2.y1, 10*0.5)
+        assert np.isclose(bb2.x1, 20*0.5)
+        assert np.isclose(bb2.y2, 30*0.5)
+        assert np.isclose(bb2.x2, 40*0.5)
+
+    def test_project_onto_wider_image(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, (10, 10), (10, 20))
+
+        assert np.isclose(bb2.y1, 10*1)
+        assert np.isclose(bb2.x1, 20*2)
+        assert np.isclose(bb2.y2, 30*1)
+        assert np.isclose(bb2.x2, 40*2)
+
+    def test_project_onto_higher_image(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, (10, 10), (20, 10))
+
+        assert np.isclose(bb2.y1, 10*2)
+        assert np.isclose(bb2.x1, 20*1)
+        assert np.isclose(bb2.y2, 30*2)
+        assert np.isclose(bb2.x2, 40*1)
+
+    def test_inplaceness(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, (10, 10), (10, 10))
+
+        if self._is_inplace:
+            assert bb2 is bb
+        else:
+            assert bb2 is not bb
+
+
+class TestBoundingBox_project(TestBoundingBox_project_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.project(*args, **kwargs)
+
+
+class TestBoundingBox_extend_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.extend_(*args, **kwargs)
+
+    def test_extend_all_sides_by_1(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, all_sides=1)
+
+        assert bb2.y1 == 10-1
+        assert bb2.y2 == 30+1
+        assert bb2.x1 == 20-1
+        assert bb2.x2 == 40+1
+
+    def test_extend_all_sides_by_minus_1(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, all_sides=-1)
+
+        assert bb2.y1 == 10-(-1)
+        assert bb2.y2 == 30+(-1)
+        assert bb2.x1 == 20-(-1)
+        assert bb2.x2 == 40+(-1)
+
+    def test_extend_top_by_1(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, top=1)
+
+        assert bb2.y1 == 10-1
+        assert bb2.y2 == 30+0
+        assert bb2.x1 == 20-0
+        assert bb2.x2 == 40+0
+
+    def test_extend_right_by_1(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, right=1)
+
+        assert bb2.y1 == 10-0
+        assert bb2.y2 == 30+0
+        assert bb2.x1 == 20-0
+        assert bb2.x2 == 40+1
+
+    def test_extend_bottom_by_1(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, bottom=1)
+
+        assert bb2.y1 == 10-0
+        assert bb2.y2 == 30+1
+        assert bb2.x1 == 20-0
+        assert bb2.x2 == 40+0
+
+    def test_extend_left_by_1(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, left=1)
+
+        assert bb2.y1 == 10-0
+        assert bb2.y2 == 30+0
+        assert bb2.x1 == 20-1
+        assert bb2.x2 == 40+0
+
+    def test_inplaceness(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, all_sides=1)
+
+        if self._is_inplace:
+            assert bb2 is bb
+        else:
+            assert bb2 is not bb
+
+
+class TestBoundingBox_extend(TestBoundingBox_extend_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.extend(*args, **kwargs)
+
+
+class TestBoundingBox_clip_out_of_image_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.clip_out_of_image_(*args, **kwargs)
+
+    def test_clip_out_of_image_with_bb_fully_inside_image(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb_cut = self._func(bb, (100, 100, 3))
+
+        assert bb_cut.y1 == 10
+        assert bb_cut.x1 == 20
+        assert bb_cut.y2 == 30
+        assert bb_cut.x2 == 40
+
+    def test_clip_out_of_image_with_array_as_shape(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        image = np.zeros((100, 100, 3), dtype=np.uint8)
+
+        bb_cut = bb.clip_out_of_image(image)
+
+        assert bb_cut.y1 == 10
+        assert bb_cut.x1 == 20
+        assert bb_cut.y2 == 30
+        assert bb_cut.x2 == 40
+
+    def test_clip_out_of_image_with_bb_too_high(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb_cut = self._func(bb, (20, 100, 3))
+
+        assert bb_cut.y1 == 10
+        assert bb_cut.x1 == 20
+        assert np.isclose(bb_cut.y2, 20)
+        assert bb_cut.x2 == 40
+
+    def test_clip_out_of_image_with_bb_too_wide(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb_cut = self._func(bb, (100, 30, 3))
+
+        assert bb_cut.y1 == 10
+        assert bb_cut.x1 == 20
+        assert bb_cut.y2 == 30
+        assert np.isclose(bb_cut.x2, 30)
+
+    def test_inplaceness(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+
+        bb2 = self._func(bb, (100, 100, 3))
+
+        if self._is_inplace:
+            assert bb2 is bb
+        else:
+            assert bb2 is not bb
+
+
+class TestBoundingBox_clip_out_of_image(TestBoundingBox_clip_out_of_image_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.clip_out_of_image(*args, **kwargs)
+
+
+class TestBoundingBox_shift_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.shift_(*args, **kwargs)
+
+    def test_shift_top_by_zero(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_top = self._func(bb, top=0)
+        assert bb_top.y1 == 10
+        assert bb_top.x1 == 20
+        assert bb_top.y2 == 30
+        assert bb_top.x2 == 40
+
+    def test_shift_right_by_zero(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_right = self._func(bb, right=0)
+        assert bb_right.y1 == 10
+        assert bb_right.x1 == 20
+        assert bb_right.y2 == 30
+        assert bb_right.x2 == 40
+
+    def test_shift_bottom_by_zero(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_bottom = self._func(bb, bottom=0)
+        assert bb_bottom.y1 == 10
+        assert bb_bottom.x1 == 20
+        assert bb_bottom.y2 == 30
+        assert bb_bottom.x2 == 40
+
+    def test_shift_left_by_zero(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_left = self._func(bb, left=0)
+        assert bb_left.y1 == 10
+        assert bb_left.x1 == 20
+        assert bb_left.y2 == 30
+        assert bb_left.x2 == 40
+
+    def test_shift_top_by_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_top = self._func(bb, top=1)
+        assert bb_top.y1 == 10+1
+        assert bb_top.x1 == 20
+        assert bb_top.y2 == 30+1
+        assert bb_top.x2 == 40
+
+    def test_shift_right_by_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_right = self._func(bb, right=1)
+        assert bb_right.y1 == 10
+        assert bb_right.x1 == 20-1
+        assert bb_right.y2 == 30
+        assert bb_right.x2 == 40-1
+
+    def test_shift_bottom_by_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_bottom = self._func(bb, bottom=1)
+        assert bb_bottom.y1 == 10-1
+        assert bb_bottom.x1 == 20
+        assert bb_bottom.y2 == 30-1
+        assert bb_bottom.x2 == 40
+
+    def test_shift_left_by_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_left = self._func(bb, left=1)
+        assert bb_left.y1 == 10
+        assert bb_left.x1 == 20+1
+        assert bb_left.y2 == 30
+        assert bb_left.x2 == 40+1
+
+    def test_shift_top_by_minus_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_top = self._func(bb, top=-1)
+        assert bb_top.y1 == 10-1
+        assert bb_top.x1 == 20
+        assert bb_top.y2 == 30-1
+        assert bb_top.x2 == 40
+
+    def test_shift_right_by_minus_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_right = self._func(bb, right=-1)
+        assert bb_right.y1 == 10
+        assert bb_right.x1 == 20+1
+        assert bb_right.y2 == 30
+        assert bb_right.x2 == 40+1
+
+    def test_shift_bottom_by_minus_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_bottom = self._func(bb, bottom=-1)
+        assert bb_bottom.y1 == 10+1
+        assert bb_bottom.x1 == 20
+        assert bb_bottom.y2 == 30+1
+        assert bb_bottom.x2 == 40
+
+    def test_shift_left_by_minus_one(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_left = self._func(bb, left=-1)
+        assert bb_left.y1 == 10
+        assert bb_left.x1 == 20-1
+        assert bb_left.y2 == 30
+        assert bb_left.x2 == 40-1
+
+    def test_shift_all_sides_by_individual_amounts(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb_mix = self._func(bb, top=1, bottom=2, left=3, right=4)
+        assert bb_mix.y1 == 10+1-2
+        assert bb_mix.x1 == 20+3-4
+        assert bb_mix.y2 == 30+3-4
+        assert bb_mix.x2 == 40+1-2
+
+    def test_inplaceness(self):
+        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = self._func(bb, top=0)
+
+        if self._is_inplace:
+            assert bb2 is bb
+        else:
+            assert bb2 is not bb
+
+
+class TestBoundingBox_shift(TestBoundingBox_shift_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, cba, *args, **kwargs):
+        return cba.shift(*args, **kwargs)
+
+
 class TestBoundingBox(unittest.TestCase):
     def test___init__(self):
         bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
@@ -134,116 +500,6 @@ class TestBoundingBox(unittest.TestCase):
         assert bb.contains(ia.Keypoint(x=2.5, y=1.5)) is True
         assert bb.contains(ia.Keypoint(x=2, y=1)) is True
         assert bb.contains(ia.Keypoint(x=0, y=0)) is False
-
-    def test_project_same_shape(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.project((10, 10), (10, 10))
-
-        assert np.isclose(bb2.y1, 10)
-        assert np.isclose(bb2.x1, 20)
-        assert np.isclose(bb2.y2, 30)
-        assert np.isclose(bb2.x2, 40)
-
-    def test_project_upscale_by_2(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.project((10, 10), (20, 20))
-
-        assert np.isclose(bb2.y1, 10*2)
-        assert np.isclose(bb2.x1, 20*2)
-        assert np.isclose(bb2.y2, 30*2)
-        assert np.isclose(bb2.x2, 40*2)
-
-    def test_project_downscale_by_2(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.project((10, 10), (5, 5))
-
-        assert np.isclose(bb2.y1, 10*0.5)
-        assert np.isclose(bb2.x1, 20*0.5)
-        assert np.isclose(bb2.y2, 30*0.5)
-        assert np.isclose(bb2.x2, 40*0.5)
-
-    def test_project_onto_wider_image(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.project((10, 10), (10, 20))
-
-        assert np.isclose(bb2.y1, 10*1)
-        assert np.isclose(bb2.x1, 20*2)
-        assert np.isclose(bb2.y2, 30*1)
-        assert np.isclose(bb2.x2, 40*2)
-
-    def test_project_onto_higher_image(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.project((10, 10), (20, 10))
-
-        assert np.isclose(bb2.y1, 10*2)
-        assert np.isclose(bb2.x1, 20*1)
-        assert np.isclose(bb2.y2, 30*2)
-        assert np.isclose(bb2.x2, 40*1)
-
-    def test_extend_all_sides_by_1(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.extend(all_sides=1)
-
-        assert bb2.y1 == 10-1
-        assert bb2.y2 == 30+1
-        assert bb2.x1 == 20-1
-        assert bb2.x2 == 40+1
-
-    def test_extend_all_sides_by_minus_1(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.extend(all_sides=-1)
-
-        assert bb2.y1 == 10-(-1)
-        assert bb2.y2 == 30+(-1)
-        assert bb2.x1 == 20-(-1)
-        assert bb2.x2 == 40+(-1)
-
-    def test_extend_top_by_1(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.extend(top=1)
-
-        assert bb2.y1 == 10-1
-        assert bb2.y2 == 30+0
-        assert bb2.x1 == 20-0
-        assert bb2.x2 == 40+0
-
-    def test_extend_right_by_1(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.extend(right=1)
-
-        assert bb2.y1 == 10-0
-        assert bb2.y2 == 30+0
-        assert bb2.x1 == 20-0
-        assert bb2.x2 == 40+1
-
-    def test_extend_bottom_by_1(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.extend(bottom=1)
-
-        assert bb2.y1 == 10-0
-        assert bb2.y2 == 30+1
-        assert bb2.x1 == 20-0
-        assert bb2.x2 == 40+0
-
-    def test_extend_left_by_1(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb2 = bb.extend(left=1)
-
-        assert bb2.y1 == 10-0
-        assert bb2.y2 == 30+0
-        assert bb2.x1 == 20-1
-        assert bb2.x2 == 40+0
 
     def test_intersection(self):
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
@@ -410,151 +666,6 @@ class TestBoundingBox(unittest.TestCase):
                 observed = bb.is_out_of_image(shape,
                                               partly=partly, fully=fully)
                 assert observed is expected
-
-    def test_clip_out_of_image_with_bb_fully_inside_image(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb_cut = bb.clip_out_of_image((100, 100, 3))
-
-        assert bb_cut.y1 == 10
-        assert bb_cut.x1 == 20
-        assert bb_cut.y2 == 30
-        assert bb_cut.x2 == 40
-
-    def test_clip_out_of_image_with_array_as_shape(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        image = np.zeros((100, 100, 3), dtype=np.uint8)
-
-        bb_cut = bb.clip_out_of_image(image)
-
-        assert bb_cut.y1 == 10
-        assert bb_cut.x1 == 20
-        assert bb_cut.y2 == 30
-        assert bb_cut.x2 == 40
-
-    def test_clip_out_of_image_with_bb_too_high(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb_cut = bb.clip_out_of_image((20, 100, 3))
-
-        assert bb_cut.y1 == 10
-        assert bb_cut.x1 == 20
-        assert np.isclose(bb_cut.y2, 20)
-        assert bb_cut.x2 == 40
-
-    def test_clip_out_of_image_with_bb_too_wide(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-
-        bb_cut = bb.clip_out_of_image((100, 30, 3))
-
-        assert bb_cut.y1 == 10
-        assert bb_cut.x1 == 20
-        assert bb_cut.y2 == 30
-        assert np.isclose(bb_cut.x2, 30)
-
-    def test_shift_top_by_zero(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_top = bb.shift(top=0)
-        assert bb_top.y1 == 10
-        assert bb_top.x1 == 20
-        assert bb_top.y2 == 30
-        assert bb_top.x2 == 40
-
-    def test_shift_right_by_zero(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_right = bb.shift(right=0)
-        assert bb_right.y1 == 10
-        assert bb_right.x1 == 20
-        assert bb_right.y2 == 30
-        assert bb_right.x2 == 40
-
-    def test_shift_bottom_by_zero(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_bottom = bb.shift(bottom=0)
-        assert bb_bottom.y1 == 10
-        assert bb_bottom.x1 == 20
-        assert bb_bottom.y2 == 30
-        assert bb_bottom.x2 == 40
-
-    def test_shift_left_by_zero(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_left = bb.shift(left=0)
-        assert bb_left.y1 == 10
-        assert bb_left.x1 == 20
-        assert bb_left.y2 == 30
-        assert bb_left.x2 == 40
-
-    def test_shift_top_by_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_top = bb.shift(top=1)
-        assert bb_top.y1 == 10+1
-        assert bb_top.x1 == 20
-        assert bb_top.y2 == 30+1
-        assert bb_top.x2 == 40
-
-    def test_shift_right_by_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_right = bb.shift(right=1)
-        assert bb_right.y1 == 10
-        assert bb_right.x1 == 20-1
-        assert bb_right.y2 == 30
-        assert bb_right.x2 == 40-1
-
-    def test_shift_bottom_by_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_bottom = bb.shift(bottom=1)
-        assert bb_bottom.y1 == 10-1
-        assert bb_bottom.x1 == 20
-        assert bb_bottom.y2 == 30-1
-        assert bb_bottom.x2 == 40
-
-    def test_shift_left_by_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_left = bb.shift(left=1)
-        assert bb_left.y1 == 10
-        assert bb_left.x1 == 20+1
-        assert bb_left.y2 == 30
-        assert bb_left.x2 == 40+1
-
-    def test_shift_top_by_minus_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_top = bb.shift(top=-1)
-        assert bb_top.y1 == 10-1
-        assert bb_top.x1 == 20
-        assert bb_top.y2 == 30-1
-        assert bb_top.x2 == 40
-
-    def test_shift_right_by_minus_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_right = bb.shift(right=-1)
-        assert bb_right.y1 == 10
-        assert bb_right.x1 == 20+1
-        assert bb_right.y2 == 30
-        assert bb_right.x2 == 40+1
-
-    def test_shift_bottom_by_minus_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_bottom = bb.shift(bottom=-1)
-        assert bb_bottom.y1 == 10+1
-        assert bb_bottom.x1 == 20
-        assert bb_bottom.y2 == 30+1
-        assert bb_bottom.x2 == 40
-
-    def test_shift_left_by_minus_one(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_left = bb.shift(left=-1)
-        assert bb_left.y1 == 10
-        assert bb_left.x1 == 20-1
-        assert bb_left.y2 == 30
-        assert bb_left.x2 == 40-1
-
-    def test_shift_all_sides_by_individual_amounts(self):
-        bb = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb_mix = bb.shift(top=1, bottom=2, left=3, right=4)
-        assert bb_mix.y1 == 10+1-2
-        assert bb_mix.x1 == 20+3-4
-        assert bb_mix.y2 == 30+3-4
-        assert bb_mix.x2 == 40+1-2
 
     @classmethod
     def _get_standard_draw_on_image_vars(cls):
@@ -1072,6 +1183,150 @@ class TestBoundingBox(unittest.TestCase):
         )
 
 
+class TestBoundingBoxesOnImage_items_setter(unittest.TestCase):
+    def test_with_list_of_bounding_boxes(self):
+        bbs = [ia.BoundingBox(x1=1, y1=2, x2=3, y2=4),
+               ia.BoundingBox(x1=3, y1=4, x2=5, y2=6)]
+        bbsoi = ia.BoundingBoxesOnImage([], shape=(10, 20, 3))
+        bbsoi.items = bbs
+        assert np.all([
+            (bb_i.x1 == bb_j.x1
+             and bb_i.y1 == bb_j.y1
+             and bb_i.x2 == bb_j.x2
+             and bb_i.y2 == bb_j.y2)
+            for bb_i, bb_j
+            in zip(bbsoi.bounding_boxes, bbs)
+        ])
+
+
+class TestBoundingBoxesOnImage_on_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, cbaoi, *args, **kwargs):
+        return cbaoi.on_(*args, **kwargs)
+
+    def test_on_same_height_width(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_projected = self._func(bbsoi, (40, 50))
+
+        assert bbsoi_projected.bounding_boxes[0].y1 == 10
+        assert bbsoi_projected.bounding_boxes[0].x1 == 20
+        assert bbsoi_projected.bounding_boxes[0].y2 == 30
+        assert bbsoi_projected.bounding_boxes[0].x2 == 40
+        assert bbsoi_projected.bounding_boxes[1].y1 == 15
+        assert bbsoi_projected.bounding_boxes[1].x1 == 25
+        assert bbsoi_projected.bounding_boxes[1].y2 == 35
+        assert bbsoi_projected.bounding_boxes[1].x2 == 45
+        assert bbsoi_projected.shape == (40, 50)
+
+    def test_on_upscaled_by_2(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_projected = self._func(bbsoi, (40*2, 50*2, 3))
+
+        assert bbsoi_projected.bounding_boxes[0].y1 == 10*2
+        assert bbsoi_projected.bounding_boxes[0].x1 == 20*2
+        assert bbsoi_projected.bounding_boxes[0].y2 == 30*2
+        assert bbsoi_projected.bounding_boxes[0].x2 == 40*2
+        assert bbsoi_projected.bounding_boxes[1].y1 == 15*2
+        assert bbsoi_projected.bounding_boxes[1].x1 == 25*2
+        assert bbsoi_projected.bounding_boxes[1].y2 == 35*2
+        assert bbsoi_projected.bounding_boxes[1].x2 == 45*2
+        assert bbsoi_projected.shape == (40*2, 50*2, 3)
+
+    def test_on_upscaled_by_2_with_shape_given_as_array(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_projected = self._func(bbsoi, np.zeros((40*2, 50*2, 3), dtype=np.uint8))
+
+        assert bbsoi_projected.bounding_boxes[0].y1 == 10*2
+        assert bbsoi_projected.bounding_boxes[0].x1 == 20*2
+        assert bbsoi_projected.bounding_boxes[0].y2 == 30*2
+        assert bbsoi_projected.bounding_boxes[0].x2 == 40*2
+        assert bbsoi_projected.bounding_boxes[1].y1 == 15*2
+        assert bbsoi_projected.bounding_boxes[1].x1 == 25*2
+        assert bbsoi_projected.bounding_boxes[1].y2 == 35*2
+        assert bbsoi_projected.bounding_boxes[1].x2 == 45*2
+        assert bbsoi_projected.shape == (40*2, 50*2, 3)
+
+    def test_inplaceness(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi2 = self._func(bbsoi, (40, 50))
+
+        if self._is_inplace:
+            assert bbsoi2 is bbsoi
+        else:
+            assert bbsoi2 is not bbsoi
+
+
+class TestBoundingBoxesOnImage_on(TestBoundingBoxesOnImage_on_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, cbaoi, *args, **kwargs):
+        return cbaoi.on(*args, **kwargs)
+
+
+class TestBoundingBoxesOnImage_clip_out_of_image_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, cbaoi, *args, **kwargs):
+        return cbaoi.clip_out_of_image_()
+
+    def test_clip_out_of_image(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_clip = self._func(bbsoi)
+
+        assert len(bbsoi_clip.bounding_boxes) == 2
+        assert bbsoi_clip.bounding_boxes[0].y1 == 10
+        assert bbsoi_clip.bounding_boxes[0].x1 == 20
+        assert bbsoi_clip.bounding_boxes[0].y2 == 30
+        assert bbsoi_clip.bounding_boxes[0].x2 == 40
+        assert bbsoi_clip.bounding_boxes[1].y1 == 15
+        assert bbsoi_clip.bounding_boxes[1].x1 == 25
+        assert bbsoi_clip.bounding_boxes[1].y2 == 35
+        assert np.isclose(bbsoi_clip.bounding_boxes[1].x2, 50)
+
+    def test_inplaceness(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi2 = self._func(bbsoi, (40, 50))
+
+        if self._is_inplace:
+            assert bbsoi2 is bbsoi
+        else:
+            assert bbsoi2 is not bbsoi
+
+
+class TestBoundingBoxesOnImage_clip_out_of_image(TestBoundingBoxesOnImage_clip_out_of_image_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, cbaoi, *args, **kwargs):
+        return cbaoi.clip_out_of_image()
+
+
 class TestBoundingBoxesOnImage(unittest.TestCase):
     def test___init__(self):
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
@@ -1124,54 +1379,6 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
     def test_empty_when_bbs_actually_empty(self):
         bbsoi = ia.BoundingBoxesOnImage([], shape=(40, 50, 3))
         assert bbsoi.empty
-
-    def test_on_same_height_width(self):
-        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
-        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
-
-        bbsoi_projected = bbsoi.on((40, 50))
-
-        assert bbsoi_projected.bounding_boxes[0].y1 == 10
-        assert bbsoi_projected.bounding_boxes[0].x1 == 20
-        assert bbsoi_projected.bounding_boxes[0].y2 == 30
-        assert bbsoi_projected.bounding_boxes[0].x2 == 40
-        assert bbsoi_projected.bounding_boxes[1].y1 == 15
-        assert bbsoi_projected.bounding_boxes[1].x1 == 25
-        assert bbsoi_projected.bounding_boxes[1].y2 == 35
-        assert bbsoi_projected.bounding_boxes[1].x2 == 45
-
-    def test_on_upscaled_by_2(self):
-        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
-        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
-
-        bbsoi_projected = bbsoi.on((40*2, 50*2, 3))
-
-        assert bbsoi_projected.bounding_boxes[0].y1 == 10*2
-        assert bbsoi_projected.bounding_boxes[0].x1 == 20*2
-        assert bbsoi_projected.bounding_boxes[0].y2 == 30*2
-        assert bbsoi_projected.bounding_boxes[0].x2 == 40*2
-        assert bbsoi_projected.bounding_boxes[1].y1 == 15*2
-        assert bbsoi_projected.bounding_boxes[1].x1 == 25*2
-        assert bbsoi_projected.bounding_boxes[1].y2 == 35*2
-        assert bbsoi_projected.bounding_boxes[1].x2 == 45*2
-
-    def test_on_upscaled_by_2_with_shape_given_as_array(self):
-        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
-        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
-        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
-
-        bbsoi_projected = bbsoi.on(np.zeros((40*2, 50*2, 3), dtype=np.uint8))
-
-        assert bbsoi_projected.bounding_boxes[0].y1 == 10*2
-        assert bbsoi_projected.bounding_boxes[0].x1 == 20*2
-        assert bbsoi_projected.bounding_boxes[0].y2 == 30*2
-        assert bbsoi_projected.bounding_boxes[0].x2 == 40*2
-        assert bbsoi_projected.bounding_boxes[1].y1 == 15*2
-        assert bbsoi_projected.bounding_boxes[1].x1 == 25*2
-        assert bbsoi_projected.bounding_boxes[1].y2 == 35*2
-        assert bbsoi_projected.bounding_boxes[1].x2 == 45*2
 
     def test_from_xyxy_array_float(self):
         xyxy = np.float32([
@@ -1529,6 +1736,17 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
         assert np.all(image_drawn[35+0, 45+0, :] == [0, 255, 0])
         assert np.all(image_drawn[35+1, 45+1, :] == [0, 0, 0])
 
+    def test_remove_out_of_image_(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_removed = bbsoi.remove_out_of_image_(fully=True, partly=True)
+
+        assert len(bbsoi_removed.bounding_boxes) == 1
+        assert bbsoi_removed.bounding_boxes[0] == bb1
+        assert bbsoi_removed is bbsoi
+
     def test_remove_out_of_image(self):
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
         bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
@@ -1538,6 +1756,20 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
 
         assert len(bbsoi_removed.bounding_boxes) == 1
         assert bbsoi_removed.bounding_boxes[0] == bb1
+        assert bbsoi_removed is not bbsoi
+
+    def test_remove_out_of_image_fraction_(self):
+        item1 = ia.BoundingBox(y1=1, x1=5, y2=6, x2=9)
+        item2 = ia.BoundingBox(y1=1, x1=5, y2=6, x2=15)
+        item3 = ia.BoundingBox(y1=1, x1=15, y2=6, x2=25)
+        cbaoi = ia.BoundingBoxesOnImage([item1, item2, item3],
+                                        shape=(10, 10, 3))
+
+        cbaoi_reduced = cbaoi.remove_out_of_image_fraction_(0.6)
+
+        assert len(cbaoi_reduced.items) == 2
+        assert cbaoi_reduced.items == [item1, item2]
+        assert cbaoi_reduced is cbaoi
 
     def test_remove_out_of_image_fraction(self):
         item1 = ia.BoundingBox(y1=1, x1=5, y2=6, x2=9)
@@ -1550,23 +1782,25 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
 
         assert len(cbaoi_reduced.items) == 2
         assert cbaoi_reduced.items == [item1, item2]
+        assert cbaoi_reduced is not cbaoi
 
-    def test_clip_out_of_image(self):
+    def test_shift_(self):
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
         bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
         bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
 
-        bbsoi_clip = bbsoi.clip_out_of_image()
+        bbsoi_shifted = bbsoi.shift_(right=1)
 
-        assert len(bbsoi_clip.bounding_boxes) == 2
-        assert bbsoi_clip.bounding_boxes[0].y1 == 10
-        assert bbsoi_clip.bounding_boxes[0].x1 == 20
-        assert bbsoi_clip.bounding_boxes[0].y2 == 30
-        assert bbsoi_clip.bounding_boxes[0].x2 == 40
-        assert bbsoi_clip.bounding_boxes[1].y1 == 15
-        assert bbsoi_clip.bounding_boxes[1].x1 == 25
-        assert bbsoi_clip.bounding_boxes[1].y2 == 35
-        assert np.isclose(bbsoi_clip.bounding_boxes[1].x2, 50)
+        assert len(bbsoi_shifted.bounding_boxes) == 2
+        assert bbsoi_shifted.bounding_boxes[0].y1 == 10
+        assert bbsoi_shifted.bounding_boxes[0].x1 == 20 - 1
+        assert bbsoi_shifted.bounding_boxes[0].y2 == 30
+        assert bbsoi_shifted.bounding_boxes[0].x2 == 40 - 1
+        assert bbsoi_shifted.bounding_boxes[1].y1 == 15
+        assert bbsoi_shifted.bounding_boxes[1].x1 == 25 - 1
+        assert bbsoi_shifted.bounding_boxes[1].y2 == 35
+        assert bbsoi_shifted.bounding_boxes[1].x2 == 51 - 1
+        assert bbsoi_shifted is bbsoi
 
     def test_shift(self):
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
@@ -1584,6 +1818,7 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
         assert bbsoi_shifted.bounding_boxes[1].x1 == 25 - 1
         assert bbsoi_shifted.bounding_boxes[1].y2 == 35
         assert bbsoi_shifted.bounding_boxes[1].x2 == 51 - 1
+        assert bbsoi_shifted is not bbsoi
 
     def test_to_keypoints_on_image(self):
         bbsoi = ia.BoundingBoxesOnImage(
@@ -1705,6 +1940,29 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
         assert bbsoi.bounding_boxes[0].y1 == 0
         assert bbsoi_copy.bounding_boxes[0].y1 == 0
 
+    def test_copy_bounding_boxes_set(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
+        bb3 = ia.BoundingBox(y1=15+1, x1=25+1, y2=35+1, x2=51+1)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_copy = bbsoi.copy(bounding_boxes=[bb3])
+
+        assert bbsoi_copy is not bbsoi
+        assert bbsoi_copy.shape == (40, 50, 3)
+        assert bbsoi_copy.bounding_boxes == [bb3]
+
+    def test_copy_shape_set(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_copy = bbsoi.copy(shape=(40+1, 50+1, 3))
+
+        assert bbsoi_copy is not bbsoi
+        assert bbsoi_copy.shape == (40+1, 50+1, 3)
+        assert bbsoi_copy.bounding_boxes == [bb1, bb2]
+
     def test_deepcopy(self):
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
         bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
@@ -1725,6 +1983,31 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
         bbsoi_copy.bounding_boxes[0].y1 = 0
         assert bbsoi.bounding_boxes[0].y1 == 10
         assert bbsoi_copy.bounding_boxes[0].y1 == 0
+
+    def test_deepcopy_bounding_boxes_set(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
+        bb3 = ia.BoundingBox(y1=15+1, x1=25+1, y2=35+1, x2=51+1)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_copy = bbsoi.deepcopy(bounding_boxes=[bb3])
+
+        assert bbsoi_copy is not bbsoi
+        assert bbsoi_copy.shape == (40, 50, 3)
+        assert bbsoi_copy.bounding_boxes == [bb3]
+
+    def test_deepcopy_shape_set(self):
+        bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
+        bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)
+        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=(40, 50, 3))
+
+        bbsoi_copy = bbsoi.deepcopy(shape=(40+1, 50+1, 3))
+
+        assert bbsoi_copy is not bbsoi
+        assert bbsoi_copy.shape == (40+1, 50+1, 3)
+        assert len(bbsoi_copy.bounding_boxes) == 2
+        assert bbsoi_copy.bounding_boxes[0].coords_almost_equals(bb1)
+        assert bbsoi_copy.bounding_boxes[1].coords_almost_equals(bb2)
 
     def test___iter__(self):
         cbas = [ia.BoundingBox(x1=0, y1=0, x2=2, y2=2),

--- a/test/augmentables/test_kps.py
+++ b/test/augmentables/test_kps.py
@@ -19,6 +19,112 @@ import numpy as np
 import imgaug as ia
 
 
+class TestKeypoint_project_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, kp, from_shape, to_shape):
+        return kp.project_(from_shape, to_shape)
+
+    def test_project_same_image_size(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, (10, 10), (10, 10))
+        assert kp2.y == 1
+        assert kp2.x == 2
+
+    def test_project_onto_higher_image(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, (10, 10), (20, 10))
+        assert kp2.y == 2
+        assert kp2.x == 2
+
+    def test_project_onto_wider_image(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, (10, 10), (10, 20))
+        assert kp2.y == 1
+        assert kp2.x == 4
+
+    def test_project_onto_higher_and_wider_image(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, (10, 10), (20, 20))
+        assert kp2.y == 2
+        assert kp2.x == 4
+
+    def test_inplaceness(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, (10, 10), (10, 10))
+        if self._is_inplace:
+            assert kp is kp2
+        else:
+            assert kp is not kp2
+
+
+class TestKeypoint_project(TestKeypoint_project_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, kp, from_shape, to_shape):
+        return kp.project(from_shape, to_shape)
+
+
+class TestKeypoint_shift_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, kp, *args, **kwargs):
+        return kp.shift_(*args, **kwargs)
+
+    def test_shift_on_y_axis(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, y=1)
+        assert kp2.y == 2
+        assert kp2.x == 2
+
+    def test_shift_on_y_axis_by_negative_amount(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, y=-1)
+        assert kp2.y == 0
+        assert kp2.x == 2
+
+    def test_shift_on_x_axis(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, x=1)
+        assert kp2.y == 1
+        assert kp2.x == 3
+
+    def test_shift_on_x_axis_by_negative_amount(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, x=-1)
+        assert kp2.y == 1
+        assert kp2.x == 1
+
+    def test_shift_on_both_axis(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, y=1, x=2)
+        assert kp2.y == 2
+        assert kp2.x == 4
+
+    def test_inplaceness(self):
+        kp = ia.Keypoint(y=1, x=2)
+        kp2 = self._func(kp, x=1)
+        if self._is_inplace:
+            assert kp is kp2
+        else:
+            assert kp is not kp2
+
+
+class TestKeypoint_shift(TestKeypoint_shift_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, kp, *args, **kwargs):
+        return kp.shift(*args, **kwargs)
+
+
 class TestKeypoint(unittest.TestCase):
     def test___init__(self):
         kp = ia.Keypoint(y=1, x=2)
@@ -70,30 +176,6 @@ class TestKeypoint(unittest.TestCase):
         assert np.allclose(xy, (1, 2))
         assert xy.dtype.name == "int32"
 
-    def test_project_same_image_size(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.project((10, 10), (10, 10))
-        assert kp2.y == 1
-        assert kp2.x == 2
-
-    def test_project_onto_higher_image(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.project((10, 10), (20, 10))
-        assert kp2.y == 2
-        assert kp2.x == 2
-
-    def test_project_onto_wider_image(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.project((10, 10), (10, 20))
-        assert kp2.y == 1
-        assert kp2.x == 4
-
-    def test_project_onto_higher_and_wider_image(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.project((10, 10), (20, 20))
-        assert kp2.y == 2
-        assert kp2.x == 4
-
     def test_is_out_of_image(self):
         kp = ia.Keypoint(y=1, x=2)
         image_shape = (10, 20, 3)
@@ -129,36 +211,6 @@ class TestKeypoint(unittest.TestCase):
         image_shape = (10, 20, 3)
         fraction = kp.compute_out_of_image_fraction(image_shape)
         assert np.isclose(fraction, 1.0)
-
-    def test_shift_on_y_axis(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.shift(y=1)
-        assert kp2.y == 2
-        assert kp2.x == 2
-
-    def test_shift_on_y_axis_by_negative_amount(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.shift(y=-1)
-        assert kp2.y == 0
-        assert kp2.x == 2
-
-    def test_shift_on_x_axis(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.shift(x=1)
-        assert kp2.y == 1
-        assert kp2.x == 3
-
-    def test_shift_on_x_axis_by_negative_amount(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.shift(x=-1)
-        assert kp2.y == 1
-        assert kp2.x == 1
-
-    def test_shift_on_both_axis(self):
-        kp = ia.Keypoint(y=1, x=2)
-        kp2 = kp.shift(y=1, x=2)
-        assert kp2.y == 2
-        assert kp2.x == 4
 
     def test_draw_on_image(self):
         kp = ia.Keypoint(x=0, y=0)
@@ -362,6 +414,177 @@ class TestKeypoint(unittest.TestCase):
         )
 
 
+class TestKeypointsOnImage_items_setter(unittest.TestCase):
+    def test_with_list_of_keypoints(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpsoi = ia.KeypointsOnImage(keypoints=[], shape=(10, 20, 3))
+        kpsoi.items = kps
+        assert np.all([
+            kp_i.x == kp_j.x and kp_i.y == kp_j.y
+            for kp_i, kp_j
+            in zip(kpsoi.keypoints, kps)
+        ])
+
+
+class TestKeypointsOnImage_on_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, kpsoi, *args, **kwargs):
+        return kpsoi.on_(*args, **kwargs)
+
+    def test_same_image_size(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(10, 20, 3))
+
+        kpi2 = self._func(kpi, (10, 20, 3))
+
+        assert np.all([
+            kp_i.x == kp_j.x and kp_i.y == kp_j.y
+            for kp_i, kp_j
+            in zip(kpi.keypoints, kpi2.keypoints)
+        ])
+        assert kpi2.shape == (10, 20, 3)
+
+    def test_wider_image(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(10, 20, 3))
+
+        kpi2 = self._func(kpi, (20, 40, 3))
+
+        assert kpi2.keypoints[0].x == 2
+        assert kpi2.keypoints[0].y == 4
+        assert kpi2.keypoints[1].x == 6
+        assert kpi2.keypoints[1].y == 8
+        assert kpi2.shape == (20, 40, 3)
+
+    def test_wider_image_shape_given_as_array(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(10, 20, 3))
+
+        image = np.zeros((20, 40, 3), dtype=np.uint8)
+        kpi2 = self._func(kpi, image)
+
+        assert kpi2.keypoints[0].x == 2
+        assert kpi2.keypoints[0].y == 4
+        assert kpi2.keypoints[1].x == 6
+        assert kpi2.keypoints[1].y == 8
+        assert kpi2.shape == image.shape
+
+    def test_inplaceness(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(10, 20, 3))
+
+        kpi2 = self._func(kpi, (10, 20, 3))
+
+        if self._is_inplace:
+            assert kpi is kpi2
+        else:
+            assert kpi is not kpi2
+
+
+class TestKeypointsOnImage_on(TestKeypointsOnImage_on_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, kpsoi, *args, **kwargs):
+        return kpsoi.on(*args, **kwargs)
+
+
+class TestKeypointsOnImage_shift_(unittest.TestCase):
+    @property
+    def _is_inplace(self):
+        return True
+
+    def _func(self, kpsoi, *args, **kwargs):
+        return kpsoi.shift_(*args, **kwargs)
+
+    def test_shift_by_zero_on_both_axis(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
+        kpi2 = self._func(kpi, x=0, y=0)
+        assert kpi2.keypoints[0].x == 1
+        assert kpi2.keypoints[0].y == 2
+        assert kpi2.keypoints[1].x == 3
+        assert kpi2.keypoints[1].y == 4
+
+    def test_shift_by_1_on_x_axis(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
+
+        kpi2 = self._func(kpi, x=1)
+
+        assert kpi2.keypoints[0].x == 1 + 1
+        assert kpi2.keypoints[0].y == 2
+        assert kpi2.keypoints[1].x == 3 + 1
+        assert kpi2.keypoints[1].y == 4
+
+    def test_shift_by_negative_1_on_x_axis(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
+
+        kpi2 = self._func(kpi, x=-1)
+
+        assert kpi2.keypoints[0].x == 1 - 1
+        assert kpi2.keypoints[0].y == 2
+        assert kpi2.keypoints[1].x == 3 - 1
+        assert kpi2.keypoints[1].y == 4
+
+    def test_shift_by_1_on_y_axis(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
+
+        kpi2 = self._func(kpi, y=1)
+
+        assert kpi2.keypoints[0].x == 1
+        assert kpi2.keypoints[0].y == 2 + 1
+        assert kpi2.keypoints[1].x == 3
+        assert kpi2.keypoints[1].y == 4 + 1
+
+    def test_shift_by_negative_1_on_y_axis(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
+
+        kpi2 = self._func(kpi, y=-1)
+
+        assert kpi2.keypoints[0].x == 1
+        assert kpi2.keypoints[0].y == 2 - 1
+        assert kpi2.keypoints[1].x == 3
+        assert kpi2.keypoints[1].y == 4 - 1
+
+    def test_shift_on_both_axis(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
+
+        kpi2 = self._func(kpi, x=1, y=2)
+
+        assert kpi2.keypoints[0].x == 1 + 1
+        assert kpi2.keypoints[0].y == 2 + 2
+        assert kpi2.keypoints[1].x == 3 + 1
+        assert kpi2.keypoints[1].y == 4 + 2
+
+    def test_inplaceness(self):
+        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
+        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
+        kpi2 = self._func(kpi, x=0, y=0)
+
+        if self._is_inplace:
+            assert kpi is kpi2
+        else:
+            assert kpi is not kpi2
+
+
+class TestKeypointsOnImage_shift(TestKeypointsOnImage_shift_):
+    @property
+    def _is_inplace(self):
+        return False
+
+    def _func(self, kpsoi, *args, **kwargs):
+        return kpsoi.shift(*args, **kwargs)
+
+
 class TestKeypointsOnImage(unittest.TestCase):
     def test_items(self):
         kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
@@ -396,41 +619,6 @@ class TestKeypointsOnImage(unittest.TestCase):
             shape=image
         )
         assert kpi.shape == (10, 20, 3)
-
-    def test_on__same_image_size(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(10, 20, 3))
-
-        kpi2 = kpi.on((10, 20, 3))
-
-        assert np.all([
-            kp_i.x == kp_j.x and kp_i.y == kp_j.y
-            for kp_i, kp_j
-            in zip(kpi.keypoints, kpi2.keypoints)
-        ])
-
-    def test_on__wider_image(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(10, 20, 3))
-
-        kpi2 = kpi.on((20, 40, 3))
-
-        assert kpi2.keypoints[0].x == 2
-        assert kpi2.keypoints[0].y == 4
-        assert kpi2.keypoints[1].x == 6
-        assert kpi2.keypoints[1].y == 8
-
-    def test_on__wider_image_shape_given_as_array(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(10, 20, 3))
-
-        image = np.zeros((20, 40, 3), dtype=np.uint8)
-        kpi2 = kpi.on(image)
-
-        assert kpi2.keypoints[0].x == 2
-        assert kpi2.keypoints[0].y == 4
-        assert kpi2.keypoints[1].x == 6
-        assert kpi2.keypoints[1].y == 8
 
     def test_draw_on_image(self):
         kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
@@ -609,7 +797,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         assert "Cannot draw keypoint" in str(context.exception)
 
     @classmethod
-    def _test_clip_remove_frac(cls, func):
+    def _test_clip_remove_frac(cls, func, inplace):
         item1 = ia.Keypoint(x=5, y=1)
         item2 = ia.Keypoint(x=15, y=1)
         cbaoi = ia.KeypointsOnImage([item1, item2], shape=(10, 10, 3))
@@ -617,83 +805,36 @@ class TestKeypointsOnImage(unittest.TestCase):
         cbaoi_reduced = func(cbaoi)
 
         assert len(cbaoi_reduced.items) == 1
-        assert cbaoi_reduced.items == [item1]
+        assert np.allclose(cbaoi_reduced.to_xy_array(), [item1.xy])
+        if inplace:
+            assert cbaoi_reduced is cbaoi
+        else:
+            assert cbaoi_reduced is not cbaoi
+            assert len(cbaoi.items) == 2
+
+    def test_remove_out_of_image_fraction_(self):
+        def _func(cbaoi):
+            return cbaoi.remove_out_of_image_fraction_(0.6)
+
+        self._test_clip_remove_frac(_func, True)
 
     def test_remove_out_of_image_fraction(self):
         def _func(cbaoi):
             return cbaoi.remove_out_of_image_fraction(0.6)
 
-        self._test_clip_remove_frac(_func)
+        self._test_clip_remove_frac(_func, False)
+
+    def test_clip_out_of_image_fraction_(self):
+        def _func(cbaoi):
+            return cbaoi.clip_out_of_image_()
+
+        self._test_clip_remove_frac(_func, True)
 
     def test_clip_out_of_image_fraction(self):
         def _func(cbaoi):
             return cbaoi.clip_out_of_image()
 
-        self._test_clip_remove_frac(_func)
-
-    def test_shift_by_zero_on_both_axis(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
-        kpi2 = kpi.shift(x=0, y=0)
-        assert kpi2.keypoints[0].x == kpi.keypoints[0].x
-        assert kpi2.keypoints[0].y == kpi.keypoints[0].y
-        assert kpi2.keypoints[1].x == kpi.keypoints[1].x
-        assert kpi2.keypoints[1].y == kpi.keypoints[1].y
-
-    def test_shift_by_1_on_x_axis(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
-
-        kpi2 = kpi.shift(x=1)
-
-        assert kpi2.keypoints[0].x == kpi.keypoints[0].x + 1
-        assert kpi2.keypoints[0].y == kpi.keypoints[0].y
-        assert kpi2.keypoints[1].x == kpi.keypoints[1].x + 1
-        assert kpi2.keypoints[1].y == kpi.keypoints[1].y
-
-    def test_shift_by_negative_1_on_x_axis(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
-
-        kpi2 = kpi.shift(x=-1)
-
-        assert kpi2.keypoints[0].x == kpi.keypoints[0].x - 1
-        assert kpi2.keypoints[0].y == kpi.keypoints[0].y
-        assert kpi2.keypoints[1].x == kpi.keypoints[1].x - 1
-        assert kpi2.keypoints[1].y == kpi.keypoints[1].y
-
-    def test_shift_by_1_on_y_axis(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
-
-        kpi2 = kpi.shift(y=1)
-
-        assert kpi2.keypoints[0].x == kpi.keypoints[0].x
-        assert kpi2.keypoints[0].y == kpi.keypoints[0].y + 1
-        assert kpi2.keypoints[1].x == kpi.keypoints[1].x
-        assert kpi2.keypoints[1].y == kpi.keypoints[1].y + 1
-
-    def test_shift_by_negative_1_on_y_axis(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
-
-        kpi2 = kpi.shift(y=-1)
-
-        assert kpi2.keypoints[0].x == kpi.keypoints[0].x
-        assert kpi2.keypoints[0].y == kpi.keypoints[0].y - 1
-        assert kpi2.keypoints[1].x == kpi.keypoints[1].x
-        assert kpi2.keypoints[1].y == kpi.keypoints[1].y - 1
-
-    def test_shift_on_both_axis(self):
-        kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
-
-        kpi2 = kpi.shift(x=1, y=2)
-
-        assert kpi2.keypoints[0].x == kpi.keypoints[0].x + 1
-        assert kpi2.keypoints[0].y == kpi.keypoints[0].y + 2
-        assert kpi2.keypoints[1].x == kpi.keypoints[1].x + 1
-        assert kpi2.keypoints[1].y == kpi.keypoints[1].y + 2
+        self._test_clip_remove_frac(_func, False)
 
     def test_to_xy_array(self):
         kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
@@ -1123,6 +1264,29 @@ class TestKeypointsOnImage(unittest.TestCase):
         assert kpi2.keypoints[1].x == 3
         assert kpi2.keypoints[1].y == 4
 
+    def test_copy_keypoints_set(self):
+        kp1 = ia.Keypoint(x=1, y=2)
+        kp2 = ia.Keypoint(x=3, y=4)
+        kp3 = ia.Keypoint(x=5, y=6)
+        kpsoi = ia.KeypointsOnImage([kp1, kp2], shape=(40, 50, 3))
+
+        kpsoi_copy = kpsoi.copy(keypoints=[kp3])
+
+        assert kpsoi_copy is not kpsoi
+        assert kpsoi_copy.shape == (40, 50, 3)
+        assert kpsoi_copy.keypoints == [kp3]
+
+    def test_copy_shape_set(self):
+        kp1 = ia.Keypoint(x=1, y=2)
+        kp2 = ia.Keypoint(x=3, y=4)
+        kpsoi = ia.KeypointsOnImage([kp1, kp2], shape=(40, 50, 3))
+
+        kpsoi_copy = kpsoi.copy(shape=(40+1, 50+1, 3))
+
+        assert kpsoi_copy is not kpsoi
+        assert kpsoi_copy.shape == (40+1, 50+1, 3)
+        assert kpsoi_copy.keypoints == [kp1, kp2]
+
     def test_deepcopy(self):
         kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
@@ -1140,6 +1304,31 @@ class TestKeypointsOnImage(unittest.TestCase):
         assert kpi2.keypoints[0].y == 2
         assert kpi2.keypoints[1].x == 3
         assert kpi2.keypoints[1].y == 4
+
+    def test_deepcopy_keypoints_set(self):
+        kp1 = ia.Keypoint(x=1, y=2)
+        kp2 = ia.Keypoint(x=3, y=4)
+        kp3 = ia.Keypoint(x=5, y=6)
+        kpsoi = ia.KeypointsOnImage([kp1, kp2], shape=(40, 50, 3))
+
+        kpsoi_copy = kpsoi.deepcopy(keypoints=[kp3])
+
+        assert kpsoi_copy is not kpsoi
+        assert kpsoi_copy.shape == (40, 50, 3)
+        assert kpsoi_copy.keypoints == [kp3]
+
+    def test_deepcopy_shape_set(self):
+        kp1 = ia.Keypoint(x=1, y=2)
+        kp2 = ia.Keypoint(x=3, y=4)
+        kpsoi = ia.KeypointsOnImage([kp1, kp2], shape=(40, 50, 3))
+
+        kpsoi_copy = kpsoi.deepcopy(shape=(40+1, 50+1, 3))
+
+        assert kpsoi_copy is not kpsoi
+        assert kpsoi_copy.shape == (40+1, 50+1, 3)
+        assert len(kpsoi_copy.keypoints) == 2
+        assert kpsoi_copy.keypoints[0].coords_almost_equals(kp1)
+        assert kpsoi_copy.keypoints[1].coords_almost_equals(kp2)
 
     def test___iter__(self):
         cbas = [ia.Keypoint(x=1, y=2),


### PR DESCRIPTION
This patch adds in-place versions of existing functions to coordinate-based augmentable classes,
i.e. keypoints, BBs, LineStrings and Polygons (both single instances and *OnImage containers).
The in-place functions should improve performance during augmentation by re-instantiating objects less often.

The should decrease a bit the performance problems mentioned in #426, though probably not by too much.