### PR TITLE
Remove 'dont import from this module' messages

### DIFF
--- a/changelogs/master/changed/20191230_dont_import_msgs.md
+++ b/changelogs/master/changed/20191230_dont_import_msgs.md
@@ -1,0 +1,10 @@
+# Removed Outdated "Don't Import from this Module" Messages #539
+
+The docstring of each module in ``imgaug.augmenters`` previously included a
+suggestion to not directly import from that module, but instead use
+``imgaug.augmenters.<AugmenterName>``. That was due to the categorization
+still being unstable. As the categorization has now been fairly stable
+for a long time, the suggestion was removed from all modules. Calling
+``imgaug.augmenters.<AugmenterName>`` instead of
+``imgaug.augmenters.<ModuleName>.<AugmenterName>`` is however still the
+preferred way.

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -1,15 +1,6 @@
 """
 Augmenters that perform simple arithmetic changes.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead::
-
-    from imgaug import augmenters as iaa
-
-and then e.g.::
-
-    seq = iaa.Sequential([iaa.Add((-5, 5)), iaa.Multiply((0.9, 1.1))])
-
 List of augmenters:
 
     * Add

--- a/imgaug/augmenters/artistic.py
+++ b/imgaug/augmenters/artistic.py
@@ -1,5 +1,5 @@
 """
-Augmenters that perform apply artistic image filters.
+Augmenters that apply artistic image filters.
 
 List of augmenters:
 

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -1,17 +1,6 @@
 """
 Augmenters that blend two images with each other.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Alpha(0.5, iaa.Add((-5, 5)))
-    ])
-
 List of augmenters:
 
     * Alpha

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -1,18 +1,6 @@
 """
 Augmenters that blur images.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.GaussianBlur((0.0, 3.0)),
-        iaa.AverageBlur((2, 5))
-    ])
-
 List of augmenters:
 
     * GaussianBlur

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -1,18 +1,6 @@
 """
 Augmenters that affect image colors or image colorspaces.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Grayscale((0.0, 1.0)),
-        iaa.AddToHueAndSaturation((-10, 10))
-    ])
-
 List of augmenters:
 
     * InColorspace (deprecated)

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -1,15 +1,6 @@
 """
 Augmenters that perform contrast changes.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([iaa.GammaContrast((0.5, 1.5))])
-
 List of augmenters:
 
     * GammaContrast

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -1,18 +1,6 @@
 """
 Augmenters that are based on applying convolution kernels to images.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Sharpen((0.0, 1.0)),
-        iaa.Emboss((0.0, 1.0))
-    ])
-
 List of augmenters:
 
     * Convolve

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -1,16 +1,5 @@
 """Augmenters that help with debugging.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.SaveDebugImageEveryNBatches(...)
-    ])
-
 List of augmenters:
     * SaveDebugImageEveryNBatches
 

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -1,22 +1,13 @@
 """
 Augmenters that deal with edge detection.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Canny()
-    ])
-
 List of augmenters:
 
     * Canny
 
-EdgeDetect and DirectedEdgeDetect are currently still in `convolutional.py`.
+:class:`imgaug.augmenters.convolutional.EdgeDetect` and
+:class:`imgaug.augmenters.convolutional.DirectedEdgeDetect` are currently
+still in ``convolutional.py``.
 
 """
 from __future__ import print_function, division, absolute_import

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -1,18 +1,6 @@
 """
 Augmenters that apply mirroring/flipping operations to images.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Fliplr((0.0, 1.0)),
-        iaa.Flipud((0.0, 1.0))
-    ])
-
 List of augmenters:
 
     * Fliplr

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1,17 +1,5 @@
 """Augmenters that apply affine or similar transformations.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Affine(...),
-        iaa.PerspectiveTransform(...)
-    ])
-
 List of augmenters:
     * Affine
     * ScaleX

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -2,15 +2,6 @@
 Augmenters that don't apply augmentations themselves, but are needed
 for meta usage.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([...])
-
 List of augmenters:
 
     * Augmenter (base class for all augmenters)

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -1,17 +1,6 @@
 """
 Augmenters that apply pooling operations to images.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.AveragePooling((1, 3))
-    ])
-
 List of augmenters:
 
     * AveragePooling

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -1,17 +1,6 @@
 """
 Augmenters that apply changes to images based on segmentation methods.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Superpixels(...)
-    ])
-
 List of augmenters:
 
     * Superpixels

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -1,18 +1,6 @@
 """
 Augmenters that somehow change the size of the images.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead ::
-
-    from imgaug import augmenters as iaa
-
-and then e.g. ::
-
-    seq = iaa.Sequential([
-        iaa.Resize({"height": 32, "width": 64})
-        iaa.Crop((0, 20))
-    ])
-
 List of augmenters:
 
     * Resize

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -1,15 +1,6 @@
 """
 Augmenters that create weather effects.
 
-Do not import directly from this file, as the categorization is not final.
-Use instead::
-
-    from imgaug import augmenters as iaa
-
-and then e.g.::
-
-    seq = iaa.Sequential([iaa.Snowflakes()])
-
 List of augmenters:
 
     * FastSnowyLandscape


### PR DESCRIPTION
The docstring of each module in imgaug.augmenters
previously included a suggestion to not directly
import from that module, but instead use
imgaug.augmenters.<AugmenterName>. That was due
to the categorization being still unstable.

As the categorization has now been fairly stable
for a long time, the suggestion is removed with
this patch.