### PR TITLE
Add convenient implementations of __len__ for CBAOIs

### DIFF
--- a/changelogs/master/20191113_iterable_augmentables.md
+++ b/changelogs/master/20191113_iterable_augmentables.md
@@ -1,4 +1,4 @@
-# Simplified Access to Coordinates and Items in Augmentables #495
+# Simplified Access to Coordinates and Items in Augmentables #495 #541
 
 * Added module `imgaug.augmentables.base`.
 * Added interface `imgaug.augmentables.base.IAugmentable`, implemented by
@@ -8,6 +8,10 @@
   (keypoints, bounding boxes, polygons, line strings), e.g.
   `bbsoi = BoundingBoxesOnImage(bbs, shape=...); for bb in bbsoi: ...`.
   would iterate now over `bbs`.
+* Added implementations of `__len__` methods to coordinate-based `*OnImage`
+  instances, e.g.
+  `bbsoi = BoundingBoxesOnImage(bbs, shape=...); print(len(bbsoi))`
+  would now print the number of bounding boxes in `bbsoi`.
 * Added ability to iterate over coordinates of `BoundingBox` (top-left,
   bottom-right), `Polygon` and `LineString` via `for xy in obj: ...`.
 * Added ability to access coordinates of `BoundingBox`, `Polygon` and

--- a/imgaug/augmentables/bbs.py
+++ b/imgaug/augmentables/bbs.py
@@ -1646,6 +1646,17 @@ class BoundingBoxesOnImage(IAugmentable):
         """
         return iter(self.bounding_boxes)
 
+    def __len__(self):
+        """Get the number of items in this instance.
+
+        Returns
+        -------
+        int
+            Number of items in this instance.
+
+        """
+        return len(self.items)
+
     def __repr__(self):
         return self.__str__()
 

--- a/imgaug/augmentables/kps.py
+++ b/imgaug/augmentables/kps.py
@@ -1263,6 +1263,17 @@ class KeypointsOnImage(IAugmentable):
         """
         return iter(self.items)
 
+    def __len__(self):
+        """Get the number of items in this instance.
+
+        Returns
+        -------
+        int
+            Number of items in this instance.
+
+        """
+        return len(self.items)
+
     def __repr__(self):
         return self.__str__()
 

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -2094,6 +2094,17 @@ class LineStringsOnImage(IAugmentable):
         """
         return iter(self.line_strings)
 
+    def __len__(self):
+        """Get the number of items in this instance.
+
+        Returns
+        -------
+        int
+            Number of items in this instance.
+
+        """
+        return len(self.items)
+
     def __repr__(self):
         return self.__str__()
 

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -1797,6 +1797,17 @@ class PolygonsOnImage(IAugmentable):
         """
         return iter(self.polygons)
 
+    def __len__(self):
+        """Get the number of items in this instance.
+
+        Returns
+        -------
+        int
+            Number of items in this instance.
+
+        """
+        return len(self.items)
+
     def __repr__(self):
         return self.__str__()
 

--- a/test/augmentables/test_bbs.py
+++ b/test/augmentables/test_bbs.py
@@ -1741,6 +1741,12 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
             i += 1
         assert i == 0
 
+    def test___len__(self):
+        cbas = [ia.BoundingBox(x1=0, y1=0, x2=2, y2=2),
+                ia.BoundingBox(x1=1, y1=2, x2=3, y2=4)]
+        cbasoi = ia.BoundingBoxesOnImage(cbas, shape=(40, 50, 3))
+        assert len(cbasoi) == 2
+
     def test_string_conversion(self):
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
         bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=51)

--- a/test/augmentables/test_kps.py
+++ b/test/augmentables/test_kps.py
@@ -1156,6 +1156,12 @@ class TestKeypointsOnImage(unittest.TestCase):
             i += 1
         assert i == 0
 
+    def test___len__(self):
+        cbas = [ia.Keypoint(x=1, y=2),
+                ia.Keypoint(x=3, y=4)]
+        cbasoi = ia.KeypointsOnImage(cbas, shape=(40, 50, 3))
+        assert len(cbasoi) == 2
+
     def test_string_conversion(self):
         kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))

--- a/test/augmentables/test_lines.py
+++ b/test/augmentables/test_lines.py
@@ -2441,6 +2441,12 @@ class TestLineStringsOnImage(unittest.TestCase):
             i += 1
         assert i == 0
 
+    def test___len__(self):
+        cbas = [ia.LineString([(0, 0), (1, 1)]),
+                ia.LineString([(1, 2), (3, 4)])]
+        cbasoi = ia.LineStringsOnImage(cbas, shape=(40, 50, 3))
+        assert len(cbasoi) == 2
+
     def test___repr__(self):
         def _func(obj):
             return obj.__repr__()

--- a/test/augmentables/test_polys.py
+++ b/test/augmentables/test_polys.py
@@ -2839,6 +2839,14 @@ class TestPolygonsOnImage___iter__(unittest.TestCase):
         assert i == 0
 
 
+class TestPolygonsOnImage___len__(unittest.TestCase):
+    def test_with_two_polygons(self):
+        cbas = [ia.Polygon([(0, 0), (1, 0), (1, 1)]),
+                ia.Polygon([(1, 0), (2, 2), (1.5, 3)])]
+        cbasoi = ia.PolygonsOnImage(cbas, shape=(40, 50, 3))
+        assert len(cbasoi) == 2
+
+
 class TestPolygonsOnImage___repr___and___str__(unittest.TestCase):
     def test_with_zero_polygons(self):
         poly_oi = ia.PolygonsOnImage([], shape=(10, 11, 3))


### PR DESCRIPTION
This patch adds implementations of the `__len__`
magic method to coordinate-based `*OnImage`
classes, e.g. `BoundingBoxesOnImage`. This allows
to call `len(cbaoi)` to get the count of items
within the instance, e.g. the number of bounding
boxes.