### PR TITLE
Standardize shift interfaces of Coordinate-Based Augmentables

### DIFF
--- a/changelogs/master/changed/20200103_standardized_shift_interfaces.md
+++ b/changelogs/master/changed/20200103_standardized_shift_interfaces.md
@@ -1,0 +1,32 @@
+# Standardized `shift()` Interfaces of Coordinate-Based Augmentables #548
+
+The interfaces for shift operations of all coordinate-based
+augmentables (Keypoints, BoundingBoxes, LineStrings, Polygons)
+were standardized. All of these augmentables have now the same
+interface for shift operations. Previously, Keypoints used
+a different interface (using `x` and `y` arguments) than the
+other augmentables (using `top`, `right`, `bottom`, `left`
+arguments). All augmentables use now the interface of Keypoints
+as that is simpler and less ambiguous. Old arguments are still
+accepted, but will produce deprecation warnings. Change the
+arguments to `x` and `y` following `x=left-right` and
+`y=top-bottom`.
+
+**[breaking]** This breaks if one relied on calling `shift()` functions of
+`BoundingBox`, `LineString`, `Polygon`, `BoundingBoxesOnImage`,
+`LineStringsOnImage` or `PolygonsOnImage` without named arguments.
+E.g. `bb = BoundingBox(...); bb_shifted = bb.shift(1, 2, 3, 4);`
+will produce unexpected outputs now (equivalent to
+`shift(x=1, y=2, top=3, right=4, bottom=0, left=0)`),
+while `bb_shifted = bb.shift(top=1, right=2, bottom=3, left=4)` will still
+work as expected.
+
+* Added arguments `x`, `y` to `BoundingBox.shift()`, `LineString.shift()`
+  and `Polygon.shift()`.
+* Added arguments `x`, `y` to `BoundingBoxesOnImage.shift()`,
+  `LineStringsOnImage.shift()` and `PolygonsOnImage.shift()`.
+* Marked arguments `top`, `right`, `bottom`, `left` in
+  `BoundingBox.shift()`, `LineString.shift()` and `Polygon.shift()`
+  as deprecated. This also affects the corresponding `*OnImage`
+  classes.
+* Added function `testutils.wrap_shift_deprecation()`.

--- a/imgaug/augmentables/bbs.py
+++ b/imgaug/augmentables/bbs.py
@@ -10,7 +10,8 @@ import skimage.measure
 from .. import imgaug as ia
 from .base import IAugmentable
 from .utils import (normalize_shape, project_coords,
-                    _remove_out_of_image_fraction_)
+                    _remove_out_of_image_fraction_,
+                    _normalize_shift_args)
 
 
 # TODO functions: square(), to_aspect_ratio(), contains_point()
@@ -633,25 +634,38 @@ class BoundingBox(object):
         """
         return self.deepcopy().clip_out_of_image_(image)
 
-    # TODO convert this to x/y params?
-    def shift_(self, top=None, right=None, bottom=None, left=None):
+    def shift_(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move this bounding box along the x/y-axis in-place.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -662,35 +676,46 @@ class BoundingBox(object):
             The object may have been modified in-place.
 
         """
-        top = top if top is not None else 0
-        right = right if right is not None else 0
-        bottom = bottom if bottom is not None else 0
-        left = left if left is not None else 0
-        self.x1 = self.x1 + left - right
-        self.x2 = self.x2 + left - right
-        self.y1 = self.y1 + top - bottom
-        self.y2 = self.y2 + top - bottom
+        x, y = _normalize_shift_args(
+            x, y, top=top, right=right, bottom=bottom, left=left)
+        self.x1 += x
+        self.x2 += x
+        self.y1 += y
+        self.y2 += y
         return self
 
-    # TODO convert this to x/y params?
-    def shift(self, top=None, right=None, bottom=None, left=None):
+    def shift(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move this bounding box along the x/y-axis.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -700,7 +725,7 @@ class BoundingBox(object):
             Shifted bounding box.
 
         """
-        return self.deepcopy().shift_(top, right, bottom, left)
+        return self.deepcopy().shift_(x, y, top, right, bottom, left)
 
     def draw_label_on_image(self, image, color=(0, 255, 0),
                             color_text=None, color_bg=None, alpha=1.0, size=1,
@@ -1825,24 +1850,38 @@ class BoundingBoxesOnImage(IAugmentable):
         """
         return self.deepcopy().clip_out_of_image_()
 
-    def shift_(self, top=None, right=None, bottom=None, left=None):
+    def shift_(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move all BBs along the x/y-axis in-place.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1854,28 +1893,43 @@ class BoundingBoxesOnImage(IAugmentable):
 
         """
         for i, bb in enumerate(self.bounding_boxes):
-            self.bounding_boxes[i] = bb.shift_(top=top, right=right,
+            self.bounding_boxes[i] = bb.shift_(x=x, y=y,
+                                               top=top, right=right,
                                                bottom=bottom, left=left)
         return self
 
-    def shift(self, top=None, right=None, bottom=None, left=None):
+    def shift(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move all BBs along the x/y-axis.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1885,7 +1939,8 @@ class BoundingBoxesOnImage(IAugmentable):
             Shifted bounding boxes.
 
         """
-        return self.deepcopy().shift_(top=top, right=right,
+        return self.deepcopy().shift_(x=x, y=y,
+                                      top=top, right=right,
                                       bottom=bottom, left=left)
 
     def to_keypoints_on_image(self):

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -10,8 +10,11 @@ import cv2
 
 from .. import imgaug as ia
 from .base import IAugmentable
-from .utils import (normalize_shape, project_coords_, interpolate_points,
-                    _remove_out_of_image_fraction_)
+from .utils import (normalize_shape,
+                    project_coords_,
+                    interpolate_points,
+                    _remove_out_of_image_fraction_,
+                    _normalize_shift_args)
 
 
 # TODO Add Line class and make LineString a list of Line elements
@@ -657,24 +660,38 @@ class LineString(object):
             result.append(inter_sorted)
         return result
 
-    def shift_(self, top=None, right=None, bottom=None, left=None):
+    def shift_(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move this line string along the x/y-axis in-place.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -685,33 +702,44 @@ class LineString(object):
             The object may have been modified in-place.
 
         """
-        top = top if top is not None else 0
-        right = right if right is not None else 0
-        bottom = bottom if bottom is not None else 0
-        left = left if left is not None else 0
-        self.coords[:, 0] += left - right
-        self.coords[:, 1] += top - bottom
+        x, y = _normalize_shift_args(
+            x, y, top=top, right=right, bottom=bottom, left=left)
+        self.coords[:, 0] += x
+        self.coords[:, 1] += y
         return self
 
-    # TODO convert this to x/y params?
-    def shift(self, top=None, right=None, bottom=None, left=None):
+    def shift(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move this line string along the x/y-axis.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -721,7 +749,8 @@ class LineString(object):
             Shifted line string.
 
         """
-        return self.deepcopy().shift_(top=top, right=right,
+        return self.deepcopy().shift_(x=x, y=y,
+                                      top=top, right=right,
                                       bottom=bottom, left=left)
 
     def draw_mask(self, image_shape, size_lines=1, size_points=0,
@@ -2040,24 +2069,38 @@ class LineStringsOnImage(IAugmentable):
         """
         return self.copy().clip_out_of_image_()
 
-    def shift_(self, top=None, right=None, bottom=None, left=None):
+    def shift_(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move the line strings along the x/y-axis in-place.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -2069,28 +2112,43 @@ class LineStringsOnImage(IAugmentable):
 
         """
         for i, ls in enumerate(self.line_strings):
-            self.line_strings[i] = ls.shift_(top=top, right=right,
+            self.line_strings[i] = ls.shift_(x=x, y=y,
+                                             top=top, right=right,
                                              bottom=bottom, left=left)
         return self
 
-    def shift(self, top=None, right=None, bottom=None, left=None):
+    def shift(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move the line strings along the x/y-axis.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -2100,7 +2158,8 @@ class LineStringsOnImage(IAugmentable):
             Shifted line strings.
 
         """
-        return self.deepcopy().shift_(top=top, right=right,
+        return self.deepcopy().shift_(x=x, y=y,
+                                      top=top, right=right,
                                       bottom=bottom, left=left)
 
     def to_xy_array(self):

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -13,8 +13,11 @@ import skimage.measure
 from .. import imgaug as ia
 from .. import random as iarandom
 from .base import IAugmentable
-from .utils import (normalize_shape, interpolate_points,
-                    _remove_out_of_image_fraction_, project_coords_)
+from .utils import (normalize_shape,
+                    interpolate_points,
+                    _remove_out_of_image_fraction_,
+                    project_coords_,
+                    _normalize_shift_args)
 
 
 def recover_psois_(psois, psois_orig, recoverer, random_state):
@@ -638,24 +641,38 @@ class Polygon(object):
 
         return polygons_reordered
 
-    def shift_(self, top=None, right=None, bottom=None, left=None):
+    def shift_(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move this polygon along the x/y-axis in-place.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -666,32 +683,44 @@ class Polygon(object):
             The object may have been modified in-place.
 
         """
-        top = top if top is not None else 0
-        right = right if right is not None else 0
-        bottom = bottom if bottom is not None else 0
-        left = left if left is not None else 0
-        self.exterior[:, 0] += left - right
-        self.exterior[:, 1] += top - bottom
+        x, y = _normalize_shift_args(
+            x, y, top=top, right=right, bottom=bottom, left=left)
+        self.exterior[:, 0] += x
+        self.exterior[:, 1] += y
         return self
 
-    def shift(self, top=None, right=None, bottom=None, left=None):
+    def shift(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move this polygon along the x/y-axis.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -701,7 +730,8 @@ class Polygon(object):
             Shifted polygon.
 
         """
-        return self.deepcopy().shift_(top=top, right=right,
+        return self.deepcopy().shift_(x=x, y=y,
+                                      top=top, right=right,
                                       bottom=bottom, left=left)
 
     # TODO separate this into draw_face_on_image() and draw_border_on_image()
@@ -1764,24 +1794,38 @@ class PolygonsOnImage(IAugmentable):
         """
         return self.copy().clip_out_of_image_()
 
-    def shift_(self, top=None, right=None, bottom=None, left=None):
+    def shift_(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move the polygons along the x/y-axis in-place.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1792,28 +1836,43 @@ class PolygonsOnImage(IAugmentable):
 
         """
         for i, poly in enumerate(self.polygons):
-            self.polygons[i] = poly.shift_(top=top, right=right,
+            self.polygons[i] = poly.shift_(x=x, y=y,
+                                           top=top, right=right,
                                            bottom=bottom, left=left)
         return self
 
-    def shift(self, top=None, right=None, bottom=None, left=None):
+    def shift(self, x=0, y=0, top=None, right=None, bottom=None, left=None):
         """Move the polygons along the x/y-axis.
+
+        The origin ``(0, 0)`` is at the top left of the image.
 
         Parameters
         ----------
+        x : number, optional
+            Value to be added to all x-coordinates. Positive values shift
+            towards the right images.
+
+        y : number, optional
+            Value to be added to all y-coordinates. Positive values shift
+            towards the bottom images.
+
         top : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
+            **Deprecated.**
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1823,7 +1882,8 @@ class PolygonsOnImage(IAugmentable):
             Shifted polygons.
 
         """
-        return self.deepcopy().shift_(top=top, right=right,
+        return self.deepcopy().shift_(x=x, y=y,
+                                      top=top, right=right,
                                       bottom=bottom, left=left)
 
     def subdivide_(self, points_per_edge):

--- a/imgaug/augmentables/utils.py
+++ b/imgaug/augmentables/utils.py
@@ -340,3 +340,21 @@ def _remove_out_of_image_fraction_(cbaoi, fraction):
         item for item in cbaoi.items
         if item.compute_out_of_image_fraction(cbaoi.shape) < fraction]
     return cbaoi
+
+
+def _normalize_shift_args(x, y, top=None, right=None, bottom=None, left=None):
+    """Normalize ``shift()`` arguments to x, y and handle deprecated args."""
+    if any([v is not None for v in [top, right, bottom, left]]):
+        ia.warn_deprecated(
+            "Got one of the arguments `top` (%s), `right` (%s), "
+            "`bottom` (%s), `left` (%s) in a shift() or shift_() call."
+            "These are deprecated. Use `x` and `y` instead." % (
+                top, right, bottom, left),
+            stacklevel=3)
+        top = top if top is not None else 0
+        right = right if right is not None else 0
+        bottom = bottom if bottom is not None else 0
+        left = left if left is not None else 0
+        x = x + left - right
+        y = y + top - bottom
+    return x, y

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -240,10 +240,7 @@ class _DebugGridCBAsOICell(_IDebugGridCell):
 
         cbasoi = self.cbasoi.deepcopy()
         cbasoi = cbasoi.on_(size_rs)
-        if isinstance(cbasoi, ia.KeypointsOnImage):
-            cbasoi = cbasoi.shift_(y=paddings[0], x=paddings[3])
-        else:
-            cbasoi = cbasoi.shift_(top=paddings[0], left=paddings[3])
+        cbasoi = cbasoi.shift_(y=paddings[0], x=paddings[3])
         cbasoi.shape = image_rsp.shape
 
         return cbasoi.draw_on_image(image_rsp)

--- a/test/augmenters/test_debug.py
+++ b/test/augmenters/test_debug.py
@@ -182,7 +182,7 @@ class Test_draw_debug_image(unittest.TestCase):
             for y in np.linspace(0, 256, 5):
                 bbs.append(ia.BoundingBox(x1=x, y1=y, x2=x+20, y2=y+20))
         bbsoi1 = ia.BoundingBoxesOnImage(bbs, shape=images[0].shape)
-        bbsoi2 = bbsoi1.shift(left=20)
+        bbsoi2 = bbsoi1.shift(x=20)
         image1_w_overlay = bbsoi1.draw_on_image(images[0])
         image2_w_overlay = bbsoi2.draw_on_image(images[1])
 
@@ -203,7 +203,7 @@ class Test_draw_debug_image(unittest.TestCase):
                 polys.append(ia.Polygon([(x, y), (x+20, y), (x+20, y+20),
                                          (x, y+20)]))
         psoi1 = ia.PolygonsOnImage(polys, shape=images[0].shape)
-        psoi2 = psoi1.shift(left=20)
+        psoi2 = psoi1.shift(x=20)
         image1_w_overlay = psoi1.draw_on_image(images[0])
         image2_w_overlay = psoi2.draw_on_image(images[1])
 

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -4641,7 +4641,7 @@ class TestPiecewiseAffine(unittest.TestCase):
                     (10, 80), (10, 70), (10, 60), (10, 50),
                     (10, 40), (10, 30), (10, 20), (10, 10)]
         poly = ia.Polygon(exterior)
-        psoi = ia.PolygonsOnImage([poly, poly.shift(left=1, top=1)],
+        psoi = ia.PolygonsOnImage([poly, poly.shift(x=1, y=1)],
                                   shape=(100, 80))
 
         self._test_scale_is_zero_cbaoi(psoi, "augment_polygons")
@@ -4655,14 +4655,14 @@ class TestPiecewiseAffine(unittest.TestCase):
                   (10, 80), (10, 70), (10, 60), (10, 50),
                   (10, 40), (10, 30), (10, 20), (10, 10)]
         ls = ia.LineString(coords)
-        lsoi = ia.LineStringsOnImage([ls, ls.shift(left=1, top=1)],
+        lsoi = ia.LineStringsOnImage([ls, ls.shift(x=1, y=1)],
                                      shape=(100, 80))
 
         self._test_scale_is_zero_cbaoi(lsoi, "augment_line_strings")
 
     def test_scale_is_zero_bounding_boxes(self):
         bb = ia.BoundingBox(x1=10, y1=10, x2=70, y2=20)
-        bbsoi = ia.BoundingBoxesOnImage([bb, bb.shift(left=1, top=1)],
+        bbsoi = ia.BoundingBoxesOnImage([bb, bb.shift(x=1, y=1)],
                                         shape=(100, 80))
 
         self._test_scale_is_zero_cbaoi(bbsoi, "augment_bounding_boxes")
@@ -4921,7 +4921,7 @@ class TestPiecewiseAffine(unittest.TestCase):
                   (10, 80), (10, 70), (10, 60), (10, 50),
                   (10, 40), (10, 30), (10, 20), (10, 10)]
         cba = cba_class(coords)
-        cbaoi = cbaoi_class([cba, cba.shift(left=1, top=1)],
+        cbaoi = cbaoi_class([cba, cba.shift(x=1, y=1)],
                             shape=img.shape)
 
         aug = iaa.PiecewiseAffine(scale=0.03, nb_rows=10, nb_cols=10)


### PR DESCRIPTION
This patch standardizes the shift interfaces of all
coordinate-based augmentables (Keypoints, BoundingBoxes,
LineStrings, Polygons).

All of these augmentables will then have the same
interface for shift operations. Currently, Keypoints uses
a different interface (`x` and `y` arguments) than the
other augmentables (`top`, `right`, `bottom`, `left`
arguments). All augmentables will use the interface of Keypoints
as that is simpler and less ambiguous. Old arguments will still
be accepted, but will produce deprecation warnings.

**[breaking]** This breaks if one relied on calling `shift()`
functions of `BoundingBox`, `LineString`, `Polygon`,
`BoundingBoxesOnImage`, `LineStringsOnImage` or
`PolygonsOnImage` without named arguments. E.g.
`bb = BoundingBox(...); bb_shifted = bb.shift(1, 2, 3, 4);`
will produce unexpected outputs now (equivalent to
`shift(x=1, y=2, top=3, right=4, bottom=0, left=0)`),
while
`bb_shifted = bb.shift(top=1, right=2, bottom=3, left=4)`
will still work as expected.

* Add arguments `x`, `y` to `BoundingBox.shift()`, `LineString.shift()`
  and `Polygon.shift()`.
* Add arguments `x`, `y` to `BoundingBoxesOnImage.shift()`,
  `LineStringsOnImage.shift()` and `PolygonsOnImage.shift()`.
* Marked arguments `top`, `right`, `bottom`, `left` in
  `BoundingBox.shift()`, `LineString.shift()` and `Polygon.shift()`
  as deprecated. This also affects the corresponding `*OnImage`
  classes.
* Add function `testutils.wrap_shift_deprecation()`.