### PR TITLE
Fix random.seed not always seeding in-place

### DIFF
--- a/changelogs/master/fixed/20200110_fixed_seed.md
+++ b/changelogs/master/fixed/20200110_fixed_seed.md
@@ -1,0 +1,8 @@
+# Fixed `random.seed` not always seeding in-place #557
+
+Fixed `imgaug.random.seed()` not seeding the global `RNG` in-place
+in numpy 1.17+. The (unfixed) function instead created a new
+global `RNG` with the given seed. This set the seed of augmenters
+created *after* the `seed()` call, but not of augmenters created
+*before* the `seed()` call as they would continue to use the old
+global RNG.

--- a/imgaug/random.py
+++ b/imgaug/random.py
@@ -868,10 +868,11 @@ def seed(entropy):
 
 
 def _seed_np117_(entropy):
-    # pylint: disable=global-statement
-    global GLOBAL_RNG
-    # TODO any way to seed the Generator object instead of creating a new one?
-    GLOBAL_RNG = RNG(entropy)
+    # We can't easily seed a BitGenerator in-place, nor can we easily modify
+    # a Generator's bit_generator in-place. So instead we create a new
+    # bit generator and set the current global RNG's internal bit generator
+    # state to a copy of the new bit generator's state.
+    get_global_rng().state = BIT_GENERATOR(entropy).state
 
 
 def _seed_np116_(entropy):


### PR DESCRIPTION
Fix `imgaug.random.seed()` not seeding the global `RNG` in-place
in numpy 1.17+. The (unfixed) function instead created a new
global `RNG` with the given seed. This set the seed of augmenters
created *after* the `seed()` call, but not of augmenters created
*before* the `seed()` call as they would continue to use the old
global RNG.

This is related to #555.