### PR TITLE
ElasticTransformation incorrect filling new pixels

### DIFF
--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -4578,7 +4578,7 @@ class ElasticTransformation(meta.Augmenter):
             if nb_channels <= 4:
                 result = cv2.remap(
                     image, map1, map2, interpolation=interpolation,
-                    borderMode=border_mode, borderValue=cval)
+                    borderMode=border_mode, borderValue=(cval,cval,cval))
                 if image.ndim == 3 and result.ndim == 2:
                     result = result[..., np.newaxis]
             else:
@@ -4588,7 +4588,7 @@ class ElasticTransformation(meta.Augmenter):
                     channels = image[..., current_chan_idx:current_chan_idx+4]
                     result_c = cv2.remap(
                         channels, map1, map2, interpolation=interpolation,
-                        borderMode=border_mode, borderValue=cval)
+                        borderMode=border_mode, borderValue=(cval,cval,cval))
                     if result_c.ndim == 2:
                         result_c = result_c[..., np.newaxis]
                     result.append(result_c)


### PR DESCRIPTION
For all other geometric augmentations, when applied to 3-channel pictures `cval` value interpreted as (cval,cval,cval), so you can set either black/gray/white filling of emerged pixels. However, for Elastic Transformation setting `cval=255` leads to red pixels. That is happening because cv2.remap takes RGB tuple for 3-channel images for `borderValue`. If integer passed, it is used as (cval,0,0), hence producing red pixels. 

I'm not sure this is correct way to fix this issue, but at least on my setup it works.