### PR TITLE
Mark func/class docstring links as absolute

### DIFF
--- a/imgaug/augmentables/bbs.py
+++ b/imgaug/augmentables/bbs.py
@@ -901,10 +901,10 @@ class BoundingBox(object):
 
         This will automatically also draw the label, unless it is ``None``.
         To only draw the box rectangle use
-        :func:`imgaug.augmentables.bbs.BoundingBox.draw_box_on_image`.
+        :func:`~imgaug.augmentables.bbs.BoundingBox.draw_box_on_image`.
         To draw the label even if it is ``None`` or to configure e.g. its
         color, use
-        :func:`imgaug.augmentables.bbs.BoundingBox.draw_label_on_image`.
+        :func:`~imgaug.augmentables.bbs.BoundingBox.draw_label_on_image`.
 
         Parameters
         ----------
@@ -1171,7 +1171,7 @@ class BoundingBox(object):
         """Compare this and another BB's label and coordinates.
 
         This is the same as
-        :func:`imgaug.augmentables.bbs.BoundingBox.coords_almost_equals` but
+        :func:`~imgaug.augmentables.bbs.BoundingBox.coords_almost_equals` but
         additionally compares the labels.
 
         Parameters
@@ -1182,7 +1182,7 @@ class BoundingBox(object):
 
         max_distance : number, optional
             See
-            :func:`imgaug.augmentables.bbs.BoundingBox.coords_almost_equals`.
+            :func:`~imgaug.augmentables.bbs.BoundingBox.coords_almost_equals`.
 
         Returns
         -------
@@ -1200,7 +1200,7 @@ class BoundingBox(object):
         """Convert a ``(2P,) or (P,2) ndarray`` to a BB instance.
 
         This is the inverse of
-        :func:`imgaug.BoundingBoxesOnImage.to_xyxy_array`.
+        :func:`~imgaug.BoundingBoxesOnImage.to_xyxy_array`.
 
         Parameters
         ----------
@@ -1484,7 +1484,7 @@ class BoundingBoxesOnImage(IAugmentable):
         """Convert an ``(N, 4) or (N, 2, 2) ndarray`` to a BBsOI instance.
 
         This is the inverse of
-        :func:`imgaug.BoundingBoxesOnImage.to_xyxy_array`.
+        :func:`~imgaug.BoundingBoxesOnImage.to_xyxy_array`.
 
         Parameters
         ----------
@@ -1561,7 +1561,7 @@ class BoundingBoxesOnImage(IAugmentable):
         """Convert the ``BoundingBoxesOnImage`` object to an ``(N,4) ndarray``.
 
         This is the inverse of
-        :func:`imgaug.BoundingBoxesOnImage.from_xyxy_array`.
+        :func:`~imgaug.BoundingBoxesOnImage.from_xyxy_array`.
 
         Parameters
         ----------
@@ -1647,7 +1647,7 @@ class BoundingBoxesOnImage(IAugmentable):
         """Modify the BB coordinates of this instance in-place.
 
         See
-        :func:`imgaug.augmentables.bbs.BoundingBoxesOnImage.fill_from_xyxy_array_`.
+        :func:`~imgaug.augmentables.bbs.BoundingBoxesOnImage.fill_from_xyxy_array_`.
 
         Parameters
         ----------

--- a/imgaug/augmentables/heatmaps.py
+++ b/imgaug/augmentables/heatmaps.py
@@ -135,7 +135,7 @@ class HeatmapsOnImage(IAugmentable):
         ----------
         size : None or float or iterable of int or iterable of float, optional
             Size of the rendered RGB image as ``(height, width)``.
-            See :func:`imgaug.imgaug.imresize_single_image` for details.
+            See :func:`~imgaug.imgaug.imresize_single_image` for details.
             If set to ``None``, no resizing is performed and the size of the
             heatmaps array is used.
 
@@ -307,11 +307,11 @@ class HeatmapsOnImage(IAugmentable):
             Must be ``0`` or greater.
 
         mode : string, optional
-            Padding mode to use. See :func:`imgaug.imgaug.pad` for details.
+            Padding mode to use. See :func:`~imgaug.imgaug.pad` for details.
 
         cval : number, optional
             Value to use for padding `mode` is ``constant``.
-            See :func:`imgaug.imgaug.pad` for details.
+            See :func:`~imgaug.imgaug.pad` for details.
 
         Returns
         -------
@@ -352,11 +352,11 @@ class HeatmapsOnImage(IAugmentable):
 
         mode : str, optional
             Padding mode to use.
-            See :func:`imgaug.imgaug.pad` for details.
+            See :func:`~imgaug.imgaug.pad` for details.
 
         cval : number, optional
             Value to use for padding if `mode` is ``constant``.
-            See :func:`imgaug.imgaug.pad` for details.
+            See :func:`~imgaug.imgaug.pad` for details.
 
         return_pad_amounts : bool, optional
             If ``False``, then only the padded instance will be returned.
@@ -402,7 +402,7 @@ class HeatmapsOnImage(IAugmentable):
         ----------
         block_size : int or tuple of int
             Size of each block of values to pool, aka kernel size.
-            See :func:`imgaug.imgaug.pool` for details.
+            See :func:`~imgaug.imgaug.pool` for details.
 
         Returns
         -------
@@ -424,7 +424,7 @@ class HeatmapsOnImage(IAugmentable):
         ----------
         block_size : int or tuple of int
             Size of each block of values to pool, aka kernel size.
-            See :func:`imgaug.imgaug.pool` for details.
+            See :func:`~imgaug.imgaug.pool` for details.
 
         Returns
         -------
@@ -452,11 +452,11 @@ class HeatmapsOnImage(IAugmentable):
         ----------
         sizes : float or iterable of int or iterable of float
             New size of the array in ``(height, width)``.
-            See :func:`imgaug.imgaug.imresize_single_image` for details.
+            See :func:`~imgaug.imgaug.imresize_single_image` for details.
 
         interpolation : None or str or int, optional
             The interpolation to use during resize.
-            See :func:`imgaug.imgaug.imresize_single_image` for details.
+            See :func:`~imgaug.imgaug.imresize_single_image` for details.
 
         Returns
         -------
@@ -518,7 +518,7 @@ class HeatmapsOnImage(IAugmentable):
             Minimum value of the float heatmaps that the input array
             represents. This will usually be 0.0. In most other cases it will
             be close to the interval ``[0.0, 1.0]``.
-            Calling :func:`imgaug.HeatmapsOnImage.get_arr`, will automatically
+            Calling :func:`~imgaug.HeatmapsOnImage.get_arr`, will automatically
             convert the interval ``[0.0, 1.0]`` float array to this
             ``[min, max]`` interval.
 
@@ -562,7 +562,7 @@ class HeatmapsOnImage(IAugmentable):
             Minimum value of the float heatmaps that the input array
             represents. This will usually be 0.0. In most other cases it will
             be close to the interval ``[0.0, 1.0]``.
-            Calling :func:`imgaug.HeatmapsOnImage.get_arr`, will automatically
+            Calling :func:`~imgaug.HeatmapsOnImage.get_arr`, will automatically
             convert the interval ``[0.0, 1.0]`` float array to this
             ``[min, max]`` interval.
 

--- a/imgaug/augmentables/kps.py
+++ b/imgaug/augmentables/kps.py
@@ -525,7 +525,7 @@ class Keypoint(object):
 
         max_distance : number, optional
             See
-            :func:`imgaug.augmentables.kps.Keypoint.coords_almost_equals`.
+            :func:`~imgaug.augmentables.kps.Keypoint.coords_almost_equals`.
 
         Returns
         -------

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -1420,9 +1420,9 @@ class LineString(object):
         """Generate a heatmap object from the line string.
 
         This is similar to
-        :func:`imgaug.augmentables.lines.LineString.draw_lines_heatmap_array`,
+        :func:`~imgaug.augmentables.lines.LineString.draw_lines_heatmap_array`,
         executed with ``alpha=1.0``. The result is wrapped in a
-        :class:`imgaug.augmentables.heatmaps.HeatmapsOnImage` object instead
+        :class:`~imgaug.augmentables.heatmaps.HeatmapsOnImage` object instead
         of just an array. No points are drawn.
 
         Parameters
@@ -1464,7 +1464,7 @@ class LineString(object):
         """Generate a segmentation map object from the line string.
 
         This is similar to
-        :func:`imgaug.augmentables.lines.LineString.draw_mask`.
+        :func:`~imgaug.augmentables.lines.LineString.draw_mask`.
         The result is wrapped in a ``SegmentationMapsOnImage`` object
         instead of just an array.
 
@@ -1558,10 +1558,10 @@ class LineString(object):
             ``LineString``.
 
         max_distance : float, optional
-            See :func:`imgaug.augmentables.lines.LineString.coords_almost_equals`.
+            See :func:`~imgaug.augmentables.lines.LineString.coords_almost_equals`.
 
         points_per_edge : int, optional
-            See :func:`imgaug.augmentables.lines.LineString.coords_almost_equals`.
+            See :func:`~imgaug.augmentables.lines.LineString.coords_almost_equals`.
 
         Returns
         -------
@@ -1791,7 +1791,7 @@ class LineStringsOnImage(IAugmentable):
         """Convert an ``(N,M,2)`` ndarray to a ``LineStringsOnImage`` object.
 
         This is the inverse of
-        :func:`imgaug.augmentables.lines.LineStringsOnImage.to_xy_array`.
+        :func:`~imgaug.augmentables.lines.LineStringsOnImage.to_xy_array`.
 
         Parameters
         ----------
@@ -1821,7 +1821,7 @@ class LineStringsOnImage(IAugmentable):
         """Convert this object to an iterable of ``(M,2)`` arrays of points.
 
         This is the inverse of
-        :func:`imgaug.augmentables.lines.LineStringsOnImage.from_xy_array`.
+        :func:`~imgaug.augmentables.lines.LineStringsOnImage.from_xy_array`.
 
         Parameters
         ----------

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -84,7 +84,7 @@ class Polygon(object):
     ----------
     exterior : list of imgaug.augmentables.kps.Keypoint or list of tuple of float or (N,2) ndarray
         List of points defining the polygon. May be either a ``list`` of
-        :class:`imgaug.augmentables.kps.Keypoint` objects or a ``list`` of
+        :class:`~imgaug.augmentables.kps.Keypoint` objects or a ``list`` of
         ``tuple`` s in xy-form or a numpy array of shape (N,2) for ``N``
         points in xy-form.
         All coordinates are expected to be the absolute subpixel-coordinates
@@ -1055,7 +1055,7 @@ class Polygon(object):
     def subdivide_(self, points_per_edge):
         """Derive a new poly with ``N`` interpolated points per edge in-place.
 
-        See :func:`imgaug.augmentables.lines.LineString.subdivide` for details.
+        See :func:`~imgaug.augmentables.lines.LineString.subdivide` for details.
 
         Parameters
         ----------
@@ -1081,7 +1081,7 @@ class Polygon(object):
     def subdivide(self, points_per_edge):
         """Derive a new polygon with ``N`` interpolated points per edge.
 
-        See :func:`imgaug.augmentables.lines.LineString.subdivide` for details.
+        See :func:`~imgaug.augmentables.lines.LineString.subdivide` for details.
 
         Parameters
         ----------
@@ -1157,7 +1157,7 @@ class Polygon(object):
         Returns
         -------
         list of imgaug.augmentables.kps.Keypoint
-            Exterior vertices as :class:`imgaug.augmentables.kps.Keypoint`
+            Exterior vertices as :class:`~imgaug.augmentables.kps.Keypoint`
             instances.
 
         """
@@ -1238,15 +1238,15 @@ class Polygon(object):
         ----------
         other : imgaug.augmentables.polys.Polygon or (N,2) ndarray or list of tuple
             See
-            :func:`imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
+            :func:`~imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
 
         max_distance : number, optional
             See
-            :func:`imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
+            :func:`~imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
 
         points_per_edge : int, optional
             See
-            :func:`imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
+            :func:`~imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
 
         Returns
         -------
@@ -1322,7 +1322,7 @@ class Polygon(object):
         Estimate if this polygon's and another's geometry/labels are similar.
 
         This is the same as
-        :func:`imgaug.augmentables.polys.Polygon.exterior_almost_equals` but
+        :func:`~imgaug.augmentables.polys.Polygon.exterior_almost_equals` but
         additionally compares the labels.
 
         Parameters
@@ -1332,11 +1332,11 @@ class Polygon(object):
 
         max_distance : float, optional
             See
-            :func:`imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
+            :func:`~imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
 
         points_per_edge : int, optional
             See
-            :func:`imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
+            :func:`~imgaug.augmentables.polys.Polygon.exterior_almost_equals`.
 
         Returns
         -------
@@ -1357,7 +1357,7 @@ class Polygon(object):
         ----------
         exterior : list of imgaug.augmentables.kps.Keypoint or list of tuple or (N,2) ndarray, optional
             List of points defining the polygon. See
-            :func:`imgaug.augmentables.polys.Polygon.__init__` for details.
+            :func:`~imgaug.augmentables.polys.Polygon.__init__` for details.
 
         label : None or str, optional
             If not ``None``, the ``label`` of the copied object will be set

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -218,7 +218,7 @@ class SegmentationMapsOnImage(IAugmentable):
         ----------
         size : None or float or iterable of int or iterable of float, optional
             Size of the rendered RGB image as ``(height, width)``.
-            See :func:`imgaug.imgaug.imresize_single_image` for details.
+            See :func:`~imgaug.imgaug.imresize_single_image` for details.
             If set to ``None``, no resizing is performed and the size of the
             segmentation map array is used.
 
@@ -402,11 +402,11 @@ class SegmentationMapsOnImage(IAugmentable):
             Must be ``0`` or greater.
 
         mode : str, optional
-            Padding mode to use. See :func:`imgaug.imgaug.pad` for details.
+            Padding mode to use. See :func:`~imgaug.imgaug.pad` for details.
 
         cval : number, optional
             Value to use for padding if `mode` is ``constant``.
-            See :func:`imgaug.imgaug.pad` for details.
+            See :func:`~imgaug.imgaug.pad` for details.
 
         Returns
         -------
@@ -436,11 +436,11 @@ class SegmentationMapsOnImage(IAugmentable):
 
         mode : str, optional
             Padding mode to use.
-            See :func:`imgaug.imgaug.pad` for details.
+            See :func:`~imgaug.imgaug.pad` for details.
 
         cval : number, optional
             Value to use for padding if `mode` is ``constant``.
-            See :func:`imgaug.imgaug.pad` for details.
+            See :func:`~imgaug.imgaug.pad` for details.
 
         return_pad_amounts : bool, optional
             If ``False``, then only the padded instance will be returned.
@@ -488,13 +488,13 @@ class SegmentationMapsOnImage(IAugmentable):
         ----------
         sizes : float or iterable of int or iterable of float
             New size of the array in ``(height, width)``.
-            See :func:`imgaug.imgaug.imresize_single_image` for details.
+            See :func:`~imgaug.imgaug.imresize_single_image` for details.
 
         interpolation : None or str or int, optional
             The interpolation to use during resize.
             Nearest neighbour interpolation (``"nearest"``) is almost always
             the best choice.
-            See :func:`imgaug.imgaug.imresize_single_image` for details.
+            See :func:`~imgaug.imgaug.imresize_single_image` for details.
 
         Returns
         -------
@@ -516,14 +516,14 @@ class SegmentationMapsOnImage(IAugmentable):
             Optionally the `arr` attribute to use for the new segmentation map
             instance. Will be copied from the old instance if not provided.
             See
-            :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            :func:`~imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
             for details.
 
         shape : None or tuple of int, optional
             Optionally the shape attribute to use for the the new segmentation
             map instance. Will be copied from the old instance if not provided.
             See
-            :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            :func:`~imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
             for details.
 
         Returns
@@ -548,14 +548,14 @@ class SegmentationMapsOnImage(IAugmentable):
             Optionally the `arr` attribute to use for the new segmentation map
             instance. Will be copied from the old instance if not provided.
             See
-            :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            :func:`~imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
             for details.
 
         shape : None or tuple of int, optional
             Optionally the shape attribute to use for the the new segmentation
             map instance. Will be copied from the old instance if not provided.
             See
-            :func:`imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
+            :func:`~imgaug.augmentables.segmaps.SegmentationMapsOnImage.__init__`
             for details.
 
         Returns

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -642,7 +642,7 @@ def cutout(image, x1, y1, x2, y2,
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     Parameters
     ----------
@@ -650,28 +650,28 @@ def cutout(image, x1, y1, x2, y2,
         Image to modify.
 
     x1 : number
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     y1 : number
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     x2 : number
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     y2 : number
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     fill_mode : {'constant', 'gaussian'}, optional
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     cval : number or tuple of number, optional
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     fill_per_channel : number or bool, optional
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     random_state : imgaug.random.RNG or None, optional
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     Returns
     -------
@@ -701,8 +701,8 @@ def cutout_(image, x1, y1, x2, y2,
     dtype support::
 
         minimum of (
-            :func:`imgaug.augmenters.arithmetic._fill_rectangle_gaussian_`,
-            :func:`imgaug.augmenters.arithmetic._fill_rectangle_constant_`
+            :func:`~imgaug.augmenters.arithmetic._fill_rectangle_gaussian_`,
+            :func:`~imgaug.augmenters.arithmetic._fill_rectangle_constant_`
         )
 
     Parameters
@@ -898,7 +898,7 @@ def replace_elementwise_(image, mask, replacements):
         * ``bool``: yes; tested
 
         - (1) ``uint64`` is currently not supported, because
-              :func:`imgaug.dtypes.clip_to_dtype_value_range_()` does not
+              :func:`~imgaug.dtypes.clip_to_dtype_value_range_()` does not
               support it, which again is because numpy.clip() seems to not
               support it.
         - (2) `int64` is disallowed due to being converted to `float64`
@@ -995,7 +995,7 @@ def invert(image, min_value=None, max_value=None, threshold=None,
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.invert_`.
+        See :func:`~imgaug.augmenters.arithmetic.invert_`.
 
     Parameters
     ----------
@@ -1450,7 +1450,7 @@ class Add(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.add_scalar`.
+        See :func:`~imgaug.augmenters.arithmetic.add_scalar`.
 
     Parameters
     ----------
@@ -1477,13 +1477,13 @@ class Add(meta.Augmenter):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1570,7 +1570,7 @@ class Add(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.value, self.per_channel]
 
 
@@ -1586,7 +1586,7 @@ class AddElementwise(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.add_elementwise`.
+        See :func:`~imgaug.augmenters.arithmetic.add_elementwise`.
 
     Parameters
     ----------
@@ -1613,13 +1613,13 @@ class AddElementwise(meta.Augmenter):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1681,7 +1681,7 @@ class AddElementwise(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.value, self.per_channel]
 
 
@@ -1740,13 +1740,13 @@ class AdditiveGaussianNoise(AddElementwise):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1852,13 +1852,13 @@ class AdditiveLaplaceNoise(AddElementwise):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1953,13 +1953,13 @@ class AdditivePoissonNoise(AddElementwise):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2017,7 +2017,7 @@ class Multiply(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.multiply_scalar`.
+        See :func:`~imgaug.augmenters.arithmetic.multiply_scalar`.
 
     Parameters
     ----------
@@ -2044,13 +2044,13 @@ class Multiply(meta.Augmenter):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2134,7 +2134,7 @@ class Multiply(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.mul, self.per_channel]
 
 
@@ -2149,7 +2149,7 @@ class MultiplyElementwise(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.multiply_elementwise`.
+        See :func:`~imgaug.augmenters.arithmetic.multiply_elementwise`.
 
     Parameters
     ----------
@@ -2176,13 +2176,13 @@ class MultiplyElementwise(meta.Augmenter):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2255,7 +2255,7 @@ class MultiplyElementwise(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.mul, self.per_channel]
 
 
@@ -2301,7 +2301,7 @@ class Cutout(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.cutout_`.
+        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     Parameters
     ----------
@@ -2319,7 +2319,7 @@ class Cutout(meta.Augmenter):
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         Defines the position of each area to fill.
         Analogous to the definition in e.g.
-        :class:`imgaug.augmenters.size.CropToFixedSize`.
+        :class:`~imgaug.augmenters.size.CropToFixedSize`.
         Usually, ``uniform`` (anywhere in the image) or ``normal`` (anywhere
         in the image with preference around the center) are sane values.
 
@@ -2400,13 +2400,13 @@ class Cutout(meta.Augmenter):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.bit_generator.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2589,7 +2589,7 @@ class Cutout(meta.Augmenter):
         return image
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.nb_iterations, self.position, self.size, self.squared,
                 self.fill_mode, self.cval, self.fill_per_channel]
 
@@ -2637,13 +2637,13 @@ class Dropout(MultiplyElementwise):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2817,13 +2817,13 @@ class CoarseDropout(MultiplyElementwise):
         mask, leading easily to the whole image being dropped.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2940,13 +2940,13 @@ class Dropout2d(meta.Augmenter):
         all channels.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3064,7 +3064,7 @@ class Dropout2d(meta.Augmenter):
         return imagewise_channels_to_drop, all_dropped_ids
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p, self.nb_keep_channels]
 
 
@@ -3116,13 +3116,13 @@ class TotalDropout(meta.Augmenter):
               to convert parameter `p` to a 0/1 representation.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3203,7 +3203,7 @@ class TotalDropout(meta.Augmenter):
         return drop_ids
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p]
 
 
@@ -3213,7 +3213,7 @@ class ReplaceElementwise(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.replace_elementwise_`.
+        See :func:`~imgaug.augmenters.arithmetic.replace_elementwise_`.
 
     Parameters
     ----------
@@ -3257,13 +3257,13 @@ class ReplaceElementwise(meta.Augmenter):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3362,7 +3362,7 @@ class ReplaceElementwise(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.mask, self.replacement, self.per_channel]
 
 
@@ -3401,13 +3401,13 @@ class SaltAndPepper(ReplaceElementwise):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3462,13 +3462,13 @@ class ImpulseNoise(SaltAndPepper):
               that mask will be replaced with impulse noise noise.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3576,13 +3576,13 @@ class CoarseSaltAndPepper(ReplaceElementwise):
         mask, leading easily to the whole image being replaced.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3673,13 +3673,13 @@ class Salt(ReplaceElementwise):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3790,13 +3790,13 @@ class CoarseSalt(ReplaceElementwise):
         mask, leading easily to the whole image being replaced.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3883,13 +3883,13 @@ class Pepper(ReplaceElementwise):
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3998,13 +3998,13 @@ class CoarsePepper(ReplaceElementwise):
         easily to the whole image being replaced.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4063,7 +4063,7 @@ class Invert(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.invert_`.
+        See :func:`~imgaug.augmenters.arithmetic.invert_`.
 
     Parameters
     ----------
@@ -4122,13 +4122,13 @@ class Invert(meta.Augmenter):
         If `threshold` is ``None`` this parameter has no effect.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4247,7 +4247,7 @@ class Invert(meta.Augmenter):
         )
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p, self.per_channel, self.min_value, self.max_value,
                 self.threshold, self.invert_above_threshold]
 
@@ -4297,13 +4297,13 @@ class Solarize(Invert):
         See :class:`Invert`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4363,13 +4363,13 @@ def ContrastNormalization(alpha=1.0, per_channel=False,
         lead to per-channel behaviour (i.e. same as ``True``).
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4413,7 +4413,7 @@ class JpegCompression(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.compress_jpeg`.
+        See :func:`~imgaug.augmenters.arithmetic.compress_jpeg`.
 
     Parameters
     ----------
@@ -4437,13 +4437,13 @@ class JpegCompression(meta.Augmenter):
               compression for the ``n``-th image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4482,5 +4482,5 @@ class JpegCompression(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.compression]

--- a/imgaug/augmenters/artistic.py
+++ b/imgaug/augmenters/artistic.py
@@ -235,7 +235,7 @@ class Cartoon(meta.Augmenter):
     ----------
     blur_ksize : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         Median filter kernel size.
-        See :func:`imgaug.augmenters.artistic.stylize_cartoon` for details.
+        See :func:`~imgaug.augmenters.artistic.stylize_cartoon` for details.
 
             * If ``number``: That value will be used for all images.
             * If ``tuple (a, b) of number``: A random value will be uniformly
@@ -248,7 +248,7 @@ class Cartoon(meta.Augmenter):
 
     segmentation_size : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         Mean-Shift segmentation size multiplier.
-        See :func:`imgaug.augmenters.artistic.stylize_cartoon` for details.
+        See :func:`~imgaug.augmenters.artistic.stylize_cartoon` for details.
 
             * If ``number``: That value will be used for all images.
             * If ``tuple (a, b) of number``: A random value will be uniformly
@@ -261,7 +261,7 @@ class Cartoon(meta.Augmenter):
 
     saturation : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         Saturation multiplier.
-        See :func:`imgaug.augmenters.artistic.stylize_cartoon` for details.
+        See :func:`~imgaug.augmenters.artistic.stylize_cartoon` for details.
 
             * If ``number``: That value will be used for all images.
             * If ``tuple (a, b) of number``: A random value will be uniformly
@@ -274,7 +274,7 @@ class Cartoon(meta.Augmenter):
 
     edge_prevalence : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         Multiplier for the prevalence of edges.
-        See :func:`imgaug.augmenters.artistic.stylize_cartoon` for details.
+        See :func:`~imgaug.augmenters.artistic.stylize_cartoon` for details.
 
             * If ``number``: That value will be used for all images.
             * If ``tuple (a, b) of number``: A random value will be uniformly
@@ -290,13 +290,13 @@ class Cartoon(meta.Augmenter):
         Defaults to ``RGB``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -359,6 +359,6 @@ class Cartoon(meta.Augmenter):
         )
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.blur_ksize, self.segmentation_size, self.saturation,
                 self.edge_prevalence, self.from_colorspace]

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -280,7 +280,7 @@ class BlendAlpha(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.blend.blend_alpha`.
+        See :func:`~imgaug.augmenters.blend.blend_alpha`.
 
     Parameters
     ----------
@@ -324,13 +324,13 @@ class BlendAlpha(meta.Augmenter):
         `per_channel` will be treated as True, otherwise as False.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -458,11 +458,11 @@ class BlendAlpha(meta.Augmenter):
         return _to_deterministic(self)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.factor, self.per_channel]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [lst for lst in [self.foreground, self.background]
                 if lst is not None]
 
@@ -491,7 +491,7 @@ class BlendAlphaMask(meta.Augmenter):
     between a foreground branch of augmenters and a background branch.
     (Both branches default to the identity operation if not provided.)
 
-    See also :class:`imgaug.augmenters.blend.BlendAlpha`.
+    See also :class:`~imgaug.augmenters.blend.BlendAlpha`.
 
     .. note::
 
@@ -514,7 +514,7 @@ class BlendAlphaMask(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.blend.blend_alpha`.
+        See :func:`~imgaug.augmenters.blend.blend_alpha`.
 
     Parameters
     ----------
@@ -542,13 +542,13 @@ class BlendAlphaMask(meta.Augmenter):
               converted into a ``Sequential`` and used as the augmenter.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -740,11 +740,11 @@ class BlendAlphaMask(meta.Augmenter):
         return _to_deterministic(self)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.mask_generator]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [lst for lst in [self.foreground, self.background]
                 if lst is not None]
 
@@ -773,17 +773,17 @@ class BlendAlphaElementwise(BlendAlphaMask):
     See :class:`BlendAlpha` for more details.
 
     This class is a wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     .. note::
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -827,13 +827,13 @@ class BlendAlphaElementwise(BlendAlphaMask):
         `per_channel` will be treated as True, otherwise as False.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1028,13 +1028,13 @@ class BlendAlphaSimplexNoise(BlendAlphaElementwise):
               from that parameter per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1257,13 +1257,13 @@ class BlendAlphaFrequencyNoise(BlendAlphaElementwise):
               from that parameter per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1367,8 +1367,8 @@ class BlendAlphaSomeColors(BlendAlphaMask):
     grayscale a few colors, while keeping other colors unchanged.
 
     This class is a thin wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask` together with
-    :class:`imgaug.augmenters.blend.SomeColorsMaskGen`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask` together with
+    :class:`~imgaug.augmenters.blend.SomeColorsMaskGen`.
 
     .. note::
 
@@ -1379,11 +1379,11 @@ class BlendAlphaSomeColors(BlendAlphaMask):
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspaces_`.
+        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
@@ -1408,28 +1408,28 @@ class BlendAlphaSomeColors(BlendAlphaMask):
               converted into a ``Sequential`` and used as the augmenter.
 
     nb_bins : int or tuple of int or list of int or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.SomeColorsMaskGen`.
+        See :class:`~imgaug.augmenters.blend.SomeColorsMaskGen`.
 
     smoothness : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.SomeColorsMaskGen`.
+        See :class:`~imgaug.augmenters.blend.SomeColorsMaskGen`.
 
     alpha : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.SomeColorsMaskGen`.
+        See :class:`~imgaug.augmenters.blend.SomeColorsMaskGen`.
 
     rotation_deg : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.SomeColorsMaskGen`.
+        See :class:`~imgaug.augmenters.blend.SomeColorsMaskGen`.
 
     from_colorspace : str, optional
-        See :class:`imgaug.augmenters.blend.SomeColorsMaskGen`.
+        See :class:`~imgaug.augmenters.blend.SomeColorsMaskGen`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1501,18 +1501,18 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
     mask.
 
     This class is a thin wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask` together with
-    :class:`imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask` together with
+    :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
 
     .. note::
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -1537,25 +1537,25 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
               converted into a ``Sequential`` and used as the augmenter.
 
     min_value : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
 
     max_value : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
 
     start_at : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
 
     end_at : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1613,18 +1613,18 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
     mask.
 
     This class is a thin wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask` together with
-    :class:`imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask` together with
+    :class:`~imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
 
     .. note::
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -1649,25 +1649,25 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
               converted into a ``Sequential`` and used as the augmenter.
 
     min_value : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
 
     max_value : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
 
     start_at : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
 
     end_at : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
+        See :class:`~imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1735,28 +1735,28 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
     alpha values follow a fixed pattern.
 
     This class is a thin wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask` together with
-    :class:`imgaug.augmenters.blend.RegularGridMaskGen`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask` together with
+    :class:`~imgaug.augmenters.blend.RegularGridMaskGen`.
 
     .. note::
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
     nb_rows : int or tuple of int or list of int or imgaug.parameters.StochasticParameter
         Number of rows of the checkerboard.
-        See :class:`imgaug.augmenters.blend.CheckerboardMaskGen` for details.
+        See :class:`~imgaug.augmenters.blend.CheckerboardMaskGen` for details.
 
     nb_cols : int or tuple of int or list of int or imgaug.parameters.StochasticParameter
         Number of columns of the checkerboard. Analogous to `nb_rows`.
-        See :class:`imgaug.augmenters.blend.CheckerboardMaskGen` for details.
+        See :class:`~imgaug.augmenters.blend.CheckerboardMaskGen` for details.
 
     foreground : None or imgaug.augmenters.meta.Augmenter or iterable of imgaug.augmenters.meta.Augmenter, optional
         Augmenter(s) that make up the foreground branch.
@@ -1789,13 +1789,13 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
           per batch for ``(N,)`` values -- one per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1809,7 +1809,7 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
     half of the cells in the grid are filled with ``0.0``, the remaining ones
     are unaltered. Which cells exactly are "dropped" is randomly decided
     per image. The resulting effect is similar to
-    :class:`imgaug.augmenters.arithmetic.CoarseDropout`.
+    :class:`~imgaug.augmenters.arithmetic.CoarseDropout`.
 
     >>> import imgaug.augmenters as iaa
     >>> aug = iaa.BlendAlphaRegularGrid(nb_rows=2, nb_cols=2,
@@ -1851,28 +1851,28 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
     have a value opposite to the cell's value (``0.0`` vs. ``1.0``).
 
     This class is a thin wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask` together with
-    :class:`imgaug.augmenters.blend.CheckerboardMaskGen`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask` together with
+    :class:`~imgaug.augmenters.blend.CheckerboardMaskGen`.
 
     .. note::
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
     nb_rows : int or tuple of int or list of int or imgaug.parameters.StochasticParameter
         Number of rows of the checkerboard.
-        See :class:`imgaug.augmenters.blend.CheckerboardMaskGen` for details.
+        See :class:`~imgaug.augmenters.blend.CheckerboardMaskGen` for details.
 
     nb_cols : int or tuple of int or list of int or imgaug.parameters.StochasticParameter
         Number of columns of the checkerboard. Analogous to `nb_rows`.
-        See :class:`imgaug.augmenters.blend.CheckerboardMaskGen` for details.
+        See :class:`~imgaug.augmenters.blend.CheckerboardMaskGen` for details.
 
     foreground : None or imgaug.augmenters.meta.Augmenter or iterable of imgaug.augmenters.meta.Augmenter, optional
         Augmenter(s) that make up the foreground branch.
@@ -1895,13 +1895,13 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
               converted into a ``Sequential`` and used as the augmenter.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1939,14 +1939,14 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
     by specific classes in segmentation maps.
 
     This class is a thin wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask` together with
-    :class:`imgaug.augmenters.blend.SegMapClassIdsMaskGen`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask` together with
+    :class:`~imgaug.augmenters.blend.SegMapClassIdsMaskGen`.
 
     .. note::
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     .. note::
 
@@ -1961,12 +1961,12 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
     class_ids : int or tuple of int or list of int or imgaug.parameters.StochasticParameter
-        See :class:`imgaug.augmenters.blend.SegMapClassIdsMaskGen`.
+        See :class:`~imgaug.augmenters.blend.SegMapClassIdsMaskGen`.
 
     foreground : None or imgaug.augmenters.meta.Augmenter or iterable of imgaug.augmenters.meta.Augmenter, optional
         Augmenter(s) that make up the foreground branch.
@@ -1989,16 +1989,16 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
               converted into a ``Sequential`` and used as the augmenter.
 
     nb_sample_classes : None or tuple of int or list of int or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.SegMapClassIdsMaskGen`.
+        See :class:`~imgaug.augmenters.blend.SegMapClassIdsMaskGen`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2061,14 +2061,14 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
     covers the area and has one of the requested labels.
 
     This class is a thin wrapper around
-    :class:`imgaug.augmenters.blend.BlendAlphaMask` together with
-    :class:`imgaug.augmenters.blend.BoundingBoxesMaskGen`.
+    :class:`~imgaug.augmenters.blend.BlendAlphaMask` together with
+    :class:`~imgaug.augmenters.blend.BoundingBoxesMaskGen`.
 
     .. note::
 
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
-        :class:`imgaug.augmenters.blend.BlendAlphaMask` for details.
+        :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
     .. note::
 
@@ -2077,12 +2077,12 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
     labels : None or str or list of str or imgaug.parameters.StochasticParameter
-        See :class:`imgaug.augmenters.blend.BoundingBoxesMaskGen`.
+        See :class:`~imgaug.augmenters.blend.BoundingBoxesMaskGen`.
 
     foreground : None or imgaug.augmenters.meta.Augmenter or iterable of imgaug.augmenters.meta.Augmenter, optional
         Augmenter(s) that make up the foreground branch.
@@ -2105,16 +2105,16 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
               converted into a ``Sequential`` and used as the augmenter.
 
     nb_sample_labels : None or tuple of int or list of int or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.blend.BoundingBoxesMaskGen`.
+        See :class:`~imgaug.augmenters.blend.BoundingBoxesMaskGen`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2181,7 +2181,7 @@ class IBatchwiseMaskGenerator(object):
 
     Child classes are supposed to receive a batch and generate an iterable
     of masks, one per row (i.e. image), matching the row shape (i.e. image
-    shape). This is used in :class:`imgaug.augmenters.blend.BlendAlphaMask`.
+    shape). This is used in :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     """
 
@@ -2196,7 +2196,7 @@ class IBatchwiseMaskGenerator(object):
         random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
             A seed or random number generator to use during the sampling
             process. If ``None``, the global RNG will be used.
-            See also :func:`imgaug.augmenters.meta.Augmenter.__init__`
+            See also :func:`~imgaug.augmenters.meta.Augmenter.__init__`
             for a similar parameter with more details.
 
         Returns
@@ -2247,7 +2247,7 @@ class StochasticParameterMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         shapes = batch.get_rowwise_shapes()
@@ -2315,7 +2315,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspaces_`.
+        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
@@ -2381,7 +2381,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
     from_colorspace : str, optional
         The source colorspace (of the input images).
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     """
 
@@ -2409,7 +2409,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         assert batch.images is not None, (
@@ -2584,7 +2584,7 @@ class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         random_state = iarandom.RNG(random_state)
@@ -2765,7 +2765,7 @@ class HorizontalLinearGradientMaskGen(_LinearGradientMaskGen):
 class VerticalLinearGradientMaskGen(_LinearGradientMaskGen):
     """Generator that produces vertical linear gradient masks.
 
-    See :class:`imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`
+    See :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`
     for details.
 
     Parameters
@@ -2910,7 +2910,7 @@ class RegularGridMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         random_state = iarandom.RNG(random_state)
@@ -3044,7 +3044,7 @@ class CheckerboardMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         random_state = iarandom.RNG(random_state)
@@ -3184,7 +3184,7 @@ class SegMapClassIdsMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         assert batch.segmentation_maps is not None, (
@@ -3340,7 +3340,7 @@ class BoundingBoxesMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         assert batch.bounding_boxes is not None, (
@@ -3440,7 +3440,7 @@ class InvertMaskGen(IBatchwiseMaskGenerator):
 
     def draw_masks(self, batch, random_state=None):
         """
-        See :func:`imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+        See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
         """
         random_state = iarandom.RNG(random_state)

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -388,7 +388,7 @@ class GaussianBlur(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.blur.blur_gaussian_(backend="auto")`.
+        See :func:`~imgaug.augmenters.blur.blur_gaussian_(backend="auto")`.
 
     Parameters
     ----------
@@ -407,13 +407,13 @@ class GaussianBlur(meta.Augmenter):
               from that parameter per ``N`` input images.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -456,7 +456,7 @@ class GaussianBlur(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.sigma]
 
 
@@ -515,13 +515,13 @@ class AverageBlur(meta.Augmenter):
               the kernel.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -657,7 +657,7 @@ class AverageBlur(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.k]
 
 
@@ -702,13 +702,13 @@ class MedianBlur(meta.Augmenter):
               by ``1``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -772,7 +772,7 @@ class MedianBlur(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.k]
 
 
@@ -854,13 +854,13 @@ class BilateralBlur(meta.Augmenter):
               the diameter for the n-th image. Expected to be discrete.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -920,7 +920,7 @@ class BilateralBlur(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.d, self.sigma_color, self.sigma_space]
 
 
@@ -977,19 +977,19 @@ class MotionBlur(iaa_convolutional.Convolve):
     order : int or iterable of int or imgaug.ALL or imgaug.parameters.StochasticParameter, optional
         Interpolation order to use when rotating the kernel according to
         `angle`.
-        See :func:`imgaug.augmenters.geometric.Affine.__init__`.
+        See :func:`~imgaug.augmenters.geometric.Affine.__init__`.
         Recommended to be ``0`` or ``1``, with ``0`` being faster, but less
         continuous/smooth as `angle` is changed, particularly around multiple
         of ``45`` degrees.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1082,7 +1082,7 @@ class MeanShiftBlur(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.blur.blur_mean_shift_`.
+        See :func:`~imgaug.augmenters.blur.blur_mean_shift_`.
 
     Parameters
     ----------
@@ -1111,13 +1111,13 @@ class MeanShiftBlur(meta.Augmenter):
               images.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1162,5 +1162,5 @@ class MeanShiftBlur(meta.Augmenter):
         )
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.spatial_window_radius, self.color_window_radius]

--- a/imgaug/augmenters/collections.py
+++ b/imgaug/augmenters/collections.py
@@ -70,7 +70,7 @@ class RandAugment(meta.Sequential):
     n : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or None, optional
         Parameter ``N`` in the paper, i.e. number of transformations to apply.
         The paper suggests ``N=2`` for ImageNet.
-        See also parameter ``n`` in :class:`imgaug.augmenters.meta.SomeOf`
+        See also parameter ``n`` in :class:`~imgaug.augmenters.meta.SomeOf`
         for more details.
 
         Note that horizontal flips (p=50%) and crops are always applied. This
@@ -99,7 +99,7 @@ class RandAugment(meta.Sequential):
     cval : number or tuple of number or list of number or imgaug.ALL or imgaug.parameters.StochasticParameter, optional
         The constant value to use when filling in newly created pixels.
         See parameter `fillcolor` in
-        :class:`imgaug.augmenters.pillike.Affine` for details.
+        :class:`~imgaug.augmenters.pillike.Affine` for details.
 
         The paper's repository uses an RGB value of ``125, 122, 113``.
         This implementation uses a single intensity value of ``128``, which
@@ -283,6 +283,6 @@ class RandAugment(meta.Sequential):
         ]
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         someof = self[1]
         return [someof.n, self._m, self._cval]

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -326,7 +326,7 @@ def change_colorspaces_(images, to_colorspaces, from_colorspaces=CSPACE_RGB):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -967,27 +967,27 @@ class WithColorspace(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspaces_`.
+        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
     to_colorspace : str
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     children : imgaug.augmenters.meta.Augmenter or list of imgaug.augmenters.meta.Augmenter or None, optional
         One or more augmenters to apply to converted images.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1047,11 +1047,11 @@ class WithColorspace(meta.Augmenter):
         return aug
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.channels]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
     def __str__(self):
@@ -1074,7 +1074,7 @@ class WithBrightnessChannels(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspaces_`.
+        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
@@ -1093,22 +1093,22 @@ class WithBrightnessChannels(meta.Augmenter):
             * If ``str``: Will always use this colorspace.
             * If ``list`` or ``str``: Will pick imagewise a random colorspace
               from this list.
-            * If :class:`imgaug.parameters.StochasticParameter`:
+            * If :class:`~imgaug.parameters.StochasticParameter`:
               A parameter that will be queried once per batch to generate
               all target colorspaces. Expected to return strings matching the
               ``CSPACE_*`` constants.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1223,11 +1223,11 @@ class WithBrightnessChannels(meta.Augmenter):
         return aug
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.to_colorspace, self.from_colorspace]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
     def __str__(self):
@@ -1254,21 +1254,21 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.WithBrightnessChannels`.
+        See :func:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     Parameters
     ----------
     mul : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.airthmetic.Multiply`.
+        See :class:`~imgaug.augmenters.airthmetic.Multiply`.
 
     add : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.airthmetic.Add`.
+        See :class:`~imgaug.augmenters.airthmetic.Add`.
 
     to_colorspace : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.color.WithBrightnessChannels`.
+        See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     from_colorspace : str, optional
-        See :class:`imgaug.augmenters.color.WithBrightnessChannels`.
+        See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     random_order : bool, optional
         Whether to apply the add and multiply operations in random
@@ -1276,13 +1276,13 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
         multiply and then add.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1354,27 +1354,27 @@ class MultiplyBrightness(MultiplyAndAddToBrightness):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.MultiplyAndAddToBrightness`.
+        See :func:`~imgaug.augmenters.color.MultiplyAndAddToBrightness`.
 
     Parameters
     ----------
     mul : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.airthmetic.Multiply`.
+        See :class:`~imgaug.augmenters.airthmetic.Multiply`.
 
     to_colorspace : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.color.WithBrightnessChannels`.
+        See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     from_colorspace : str, optional
-        See :class:`imgaug.augmenters.color.WithBrightnessChannels`.
+        See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1418,27 +1418,27 @@ class AddToBrightness(MultiplyAndAddToBrightness):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.MultiplyAndAddToBrightness`.
+        See :func:`~imgaug.augmenters.color.MultiplyAndAddToBrightness`.
 
     Parameters
     ----------
     add : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.airthmetic.Add`.
+        See :class:`~imgaug.augmenters.airthmetic.Add`.
 
     to_colorspace : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.color.WithBrightnessChannels`.
+        See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     from_colorspace : str, optional
-        See :class:`imgaug.augmenters.color.WithBrightnessChannels`.
+        See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1497,12 +1497,12 @@ class WithHueAndSaturation(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspaces_`.
+        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     children : imgaug.augmenters.meta.Augmenter or list of imgaug.augmenters.meta.Augmenter or None, optional
         One or more augmenters to apply to converted images.
@@ -1510,13 +1510,13 @@ class WithHueAndSaturation(meta.Augmenter):
         and have to modify these.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1634,11 +1634,11 @@ class WithHueAndSaturation(meta.Augmenter):
         return aug
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.from_colorspace]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
     def __str__(self):
@@ -1726,16 +1726,16 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
         are used instead of `mul`.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1875,16 +1875,16 @@ class MultiplyHue(MultiplyHueAndSaturation):
               parameter per image.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1936,16 +1936,16 @@ class MultiplySaturation(MultiplyHueAndSaturation):
               parameter per image.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1991,16 +1991,16 @@ class RemoveSaturation(MultiplySaturation):
               parameter per image.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2055,19 +2055,19 @@ def AddToHueAndSaturation(value=0, per_channel=False, from_colorspace="RGB",
     Parameters
     ----------
     value : int or tuple of int or list of int or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.arithmetic.Add.__init__()`.
+        See :func:`~imgaug.augmenters.arithmetic.Add.__init__()`.
 
     per_channel : bool or float, optional
-        See :func:`imgaug.augmenters.arithmetic.Add.__init__()`.
+        See :func:`~imgaug.augmenters.arithmetic.Add.__init__()`.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     channels : int or list of int or None, optional
-        See :func:`imgaug.augmenters.meta.WithChannels.__init__()`.
+        See :func:`~imgaug.augmenters.meta.WithChannels.__init__()`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2108,7 +2108,7 @@ class AddToHueAndSaturation(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -2170,16 +2170,16 @@ class AddToHueAndSaturation(meta.Augmenter):
         are used instead of `value`.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2336,7 +2336,7 @@ class AddToHueAndSaturation(meta.Augmenter):
         return image_hsv
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.value, self.value_hue, self.value_saturation,
                 self.per_channel, self.from_colorspace]
 
@@ -2432,16 +2432,16 @@ class AddToHue(AddToHueAndSaturation):
               parameter per image.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2497,16 +2497,16 @@ class AddToSaturation(AddToHueAndSaturation):
               parameter per image.
 
     from_colorspace : str, optional
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2548,7 +2548,7 @@ class ChangeColorspace(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -2586,13 +2586,13 @@ class ChangeColorspace(meta.Augmenter):
               parameter per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -2727,7 +2727,7 @@ class ChangeColorspace(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.to_colorspace, self.alpha]
 
 
@@ -2747,7 +2747,7 @@ class Grayscale(ChangeColorspace):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -2767,16 +2767,16 @@ class Grayscale(ChangeColorspace):
 
     from_colorspace : str, optional
         The source colorspace (of the input images).
-        See :func:`imgaug.augmenters.color.change_colorspace_`.
+        See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2865,7 +2865,7 @@ class ChangeColorTemperature(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.kelvin, self.from_colorspace]
 
 
@@ -2978,7 +2978,7 @@ class _AbstractColorQuantization(meta.Augmenter):
         """Apply the augmenter-specific quantization function to an image."""
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.counts,
                 self.from_colorspace,
                 self.to_colorspace,
@@ -3026,15 +3026,15 @@ class KMeansColorQuantization(_AbstractColorQuantization):
 
             minimum of (
                 ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`imgaug.augmenters.color.quantize_colors_kmeans`
+                :func:`~imgaug.augmenters.color.quantize_colors_kmeans`
             )
 
         if (image size > max_size)::
 
             minimum of (
                 ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`imgaug.augmenters.color.quantize_colors_kmeans`,
-                :func:`imgaug.imgaug.imresize_single_image`
+                :func:`~imgaug.augmenters.color.quantize_colors_kmeans`,
+                :func:`~imgaug.imgaug.imresize_single_image`
             )
 
     Parameters
@@ -3054,7 +3054,7 @@ class KMeansColorQuantization(_AbstractColorQuantization):
 
     to_colorspace : None or str or list of str or imgaug.parameters.StochasticParameter
         The colorspace in which to perform the quantization.
-        See :func:`imgaug.augmenters.color.change_colorspace_` for valid values.
+        See :func:`~imgaug.augmenters.color.change_colorspace_` for valid values.
         This will be ignored for grayscale input images.
 
             * If ``None`` the colorspace of input images will not be changed.
@@ -3080,16 +3080,16 @@ class KMeansColorQuantization(_AbstractColorQuantization):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3295,15 +3295,15 @@ class UniformColorQuantization(_AbstractColorQuantization):
 
             minimum of (
                 ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`imgaug.augmenters.color.quantize_uniform_`
+                :func:`~imgaug.augmenters.color.quantize_uniform_`
             )
 
         if (image size > max_size)::
 
             minimum of (
                 ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`imgaug.augmenters.color.quantize_uniform_`,
-                :func:`imgaug.imgaug.imresize_single_image`
+                :func:`~imgaug.augmenters.color.quantize_uniform_`,
+                :func:`~imgaug.imgaug.imresize_single_image`
             )
 
     Parameters
@@ -3321,7 +3321,7 @@ class UniformColorQuantization(_AbstractColorQuantization):
 
     to_colorspace : None or str or list of str or imgaug.parameters.StochasticParameter
         The colorspace in which to perform the quantization.
-        See :func:`imgaug.augmenters.color.change_colorspace_` for valid values.
+        See :func:`~imgaug.augmenters.color.change_colorspace_` for valid values.
         This will be ignored for grayscale input images.
 
             * If ``None`` the colorspace of input images will not be changed.
@@ -3347,16 +3347,16 @@ class UniformColorQuantization(_AbstractColorQuantization):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3440,15 +3440,15 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
 
             minimum of (
                 ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`imgaug.augmenters.color.quantize_colors_uniform`
+                :func:`~imgaug.augmenters.color.quantize_colors_uniform`
             )
 
         if (image size > max_size)::
 
             minimum of (
                 ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`imgaug.augmenters.color.quantize_colors_uniform`,
-                :func:`imgaug.imgaug.imresize_single_image`
+                :func:`~imgaug.augmenters.color.quantize_colors_uniform`,
+                :func:`~imgaug.imgaug.imresize_single_image`
             )
 
     Parameters
@@ -3466,7 +3466,7 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
 
     to_colorspace : None or str or list of str or imgaug.parameters.StochasticParameter
         The colorspace in which to perform the quantization.
-        See :func:`imgaug.augmenters.color.change_colorspace_` for valid values.
+        See :func:`~imgaug.augmenters.color.change_colorspace_` for valid values.
         This will be ignored for grayscale input images.
 
             * If ``None`` the colorspace of input images will not be changed.
@@ -3492,16 +3492,16 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3557,7 +3557,7 @@ class Posterize(UniformColorQuantizationToNBits):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.color.UniformColorQuantizationToNBits`.
+        See :class:`~imgaug.augmenters.color.UniformColorQuantizationToNBits`.
 
     """
 
@@ -3575,7 +3575,7 @@ def quantize_uniform(arr, nb_bins, to_bin_centers=True):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.quantize_uniform_`.
+        See :func:`~imgaug.augmenters.color.quantize_uniform_`.
 
     Parameters
     ----------
@@ -3754,7 +3754,7 @@ def quantize_uniform_to_n_bits(arr, nb_bits):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.quantize_uniform_to_n_bits_`.
+        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits_`.
 
     Parameters
     ----------
@@ -3789,7 +3789,7 @@ def quantize_uniform_to_n_bits_(arr, nb_bits):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.quantize_uniform_`.
+        See :func:`~imgaug.augmenters.color.quantize_uniform_`.
 
     Parameters
     ----------
@@ -3834,7 +3834,7 @@ def posterize(arr, nb_bits):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.quantize_uniform_to_n_bits`.
+        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -86,7 +86,7 @@ class _ContrastFuncWrapper(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return self.params1d
 
 
@@ -425,7 +425,7 @@ class GammaContrast(_ContrastFuncWrapper):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.contrast.adjust_contrast_gamma`.
+        See :func:`~imgaug.augmenters.contrast.adjust_contrast_gamma`.
 
     Parameters
     ----------
@@ -447,13 +447,13 @@ class GammaContrast(_ContrastFuncWrapper):
         be treated as ``True``, otherwise as ``False``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -498,7 +498,7 @@ class SigmoidContrast(_ContrastFuncWrapper):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.contrast.adjust_contrast_sigmoid`.
+        See :func:`~imgaug.augmenters.contrast.adjust_contrast_sigmoid`.
 
     Parameters
     ----------
@@ -534,13 +534,13 @@ class SigmoidContrast(_ContrastFuncWrapper):
         be treated as ``True``, otherwise as ``False``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -593,7 +593,7 @@ class LogContrast(_ContrastFuncWrapper):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.contrast.adjust_contrast_log`.
+        See :func:`~imgaug.augmenters.contrast.adjust_contrast_log`.
 
     Parameters
     ----------
@@ -617,13 +617,13 @@ class LogContrast(_ContrastFuncWrapper):
         be treated as ``True``, otherwise as ``False``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -665,7 +665,7 @@ class LinearContrast(_ContrastFuncWrapper):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.contrast.adjust_contrast_linear`.
+        See :func:`~imgaug.augmenters.contrast.adjust_contrast_linear`.
 
     Parameters
     ----------
@@ -689,13 +689,13 @@ class LinearContrast(_ContrastFuncWrapper):
         be treated as ``True``, otherwise as ``False``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -863,7 +863,7 @@ class _IntensityChannelBasedApplier(object):
         return result
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.from_colorspace, self.to_colorspace]
 
 
@@ -921,13 +921,13 @@ class AllChannelsCLAHE(meta.Augmenter):
         be treated as ``True``, otherwise as ``False``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1034,7 +1034,7 @@ class AllChannelsCLAHE(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.clip_limit, self.tile_grid_size_px,
                 self.tile_grid_size_px_min, self.per_channel]
 
@@ -1130,7 +1130,7 @@ class CLAHE(meta.Augmenter):
         be ignored and it will be assumed that the input is grayscale.
         If a fourth channel is present in an input image, it will be removed
         before the colorspace conversion and later re-added.
-        See also :func:`imgaug.augmenters.color.change_colorspace_` for
+        See also :func:`~imgaug.augmenters.color.change_colorspace_` for
         details.
 
     to_colorspace : {"Lab", "HLS", "HSV"}, optional
@@ -1141,13 +1141,13 @@ class CLAHE(meta.Augmenter):
         see ``imgaug.augmenters.contrast.AllChannelsCLAHE``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1248,7 +1248,7 @@ class CLAHE(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         ac_clahe = self.all_channel_clahe
         intb_applier = self.intensity_channel_based_applier
         return [
@@ -1291,13 +1291,13 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1347,7 +1347,7 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
 
 
@@ -1402,7 +1402,7 @@ class HistogramEqualization(meta.Augmenter):
         ignored and it will be assumed that the input is grayscale.
         If a fourth channel is present in an input image, it will be removed
         before the colorspace conversion and later re-added.
-        See also :func:`imgaug.augmenters.color.change_colorspace_` for
+        See also :func:`~imgaug.augmenters.color.change_colorspace_` for
         details.
 
     to_colorspace : {"Lab", "HLS", "HSV"}, optional
@@ -1414,13 +1414,13 @@ class HistogramEqualization(meta.Augmenter):
         ``imgaug.augmenters.contrast.AllChannelsHistogramEqualization``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1497,6 +1497,6 @@ class HistogramEqualization(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         icb_applier = self.intensity_channel_based_applier
         return icb_applier.get_parameters()

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -74,13 +74,13 @@ class Convolve(meta.Augmenter):
               channel.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -222,7 +222,7 @@ class Convolve(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.matrix, self.matrix_type]
 
 
@@ -263,13 +263,13 @@ class Sharpen(Convolve):
               parameter per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -370,13 +370,13 @@ class Emboss(Convolve):
               parameter per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -457,13 +457,13 @@ class EdgeDetect(Convolve):
               parameter per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -563,13 +563,13 @@ class DirectedEdgeDetect(Convolve):
               parameter per image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -992,13 +992,13 @@ class _SaveDebugImage(meta.Augmenter):
         supposed to be generated.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -1047,13 +1047,13 @@ class SaveDebugImageEveryNBatches(_SaveDebugImage):
         or the counter may be wrong in other ways.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -256,13 +256,13 @@ class Canny(meta.Augmenter):
         ``uint8`` colors.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -455,7 +455,7 @@ class Canny(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.alpha, self.hysteresis_thresholds, self.sobel_kernel_size,
                 self.colorizer]
 

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -813,7 +813,7 @@ class Fliplr(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.flip.fliplr`.
+        See :func:`~imgaug.augmenters.flip.fliplr`.
 
     Parameters
     ----------
@@ -821,13 +821,13 @@ class Fliplr(meta.Augmenter):
         Probability of each image to get flipped.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -898,7 +898,7 @@ class Fliplr(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p]
 
 
@@ -914,7 +914,7 @@ class Flipud(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.flip.flipud`.
+        See :func:`~imgaug.augmenters.flip.flipud`.
 
     Parameters
     ----------
@@ -922,13 +922,13 @@ class Flipud(meta.Augmenter):
         Probability of each image to get flipped.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1000,5 +1000,5 @@ class Flipud(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p]

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1048,7 +1048,7 @@ class Affine(meta.Augmenter):
         and scaling.
         Note also that activating this may lead to image sizes differing from
         the input image sizes. To avoid this, wrap ``Affine`` in
-        :class:`imgaug.augmenters.size.KeepSizeByResize`,
+        :class:`~imgaug.augmenters.size.KeepSizeByResize`,
         e.g. ``KeepSizeByResize(Affine(...))``.
 
     backend : str, optional
@@ -1063,13 +1063,13 @@ class Affine(meta.Augmenter):
         automatically fall back to order ``3``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1497,7 +1497,7 @@ class Affine(meta.Augmenter):
             order=order_samples)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [
             self.scale, self.translate, self.rotate, self.shear, self.order,
             self.cval, self.mode, self.backend, self.fit_output]
@@ -1510,7 +1510,7 @@ class ScaleX(Affine):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1534,13 +1534,13 @@ class ScaleX(Affine):
         See :class:`Affine`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1578,7 +1578,7 @@ class TranslateX(Affine):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1608,13 +1608,13 @@ class TranslateX(Affine):
         See :class:`Affine`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1661,7 +1661,7 @@ class TranslateY(Affine):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1691,13 +1691,13 @@ class TranslateY(Affine):
         See :class:`Affine`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1743,7 +1743,7 @@ class ScaleY(Affine):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1767,13 +1767,13 @@ class ScaleY(Affine):
         See :class:`Affine`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1811,7 +1811,7 @@ class Rotate(Affine):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1834,13 +1834,13 @@ class Rotate(Affine):
         See :class:`Affine`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1875,7 +1875,7 @@ class ShearX(Affine):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1899,13 +1899,13 @@ class ShearX(Affine):
         See :class:`Affine`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -1932,7 +1932,7 @@ class ShearY(Affine):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1956,13 +1956,13 @@ class ShearY(Affine):
         See :class:`Affine`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -2195,13 +2195,13 @@ class AffineCv2(meta.Augmenter):
               mentioned strings.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2660,7 +2660,7 @@ class AffineCv2(meta.Augmenter):
             bounding_boxes_on_images, random_state, parents, hooks)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.scale, self.translate, self.rotate, self.shear,
                 self.order, self.cval, self.mode]
 
@@ -2818,13 +2818,13 @@ class PiecewiseAffine(meta.Augmenter):
         Number of columns. Analogous to `nb_rows`.
 
     order : int or list of int or imgaug.ALL or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.geometric.Affine.__init__`.
+        See :func:`~imgaug.augmenters.geometric.Affine.__init__`.
 
     cval : int or float or tuple of float or imgaug.ALL or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.geometric.Affine.__init__`.
+        See :func:`~imgaug.augmenters.geometric.Affine.__init__`.
 
     mode : str or list of str or imgaug.ALL or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.geometric.Affine.__init__`.
+        See :func:`~imgaug.augmenters.geometric.Affine.__init__`.
 
     absolute_scale : bool, optional
         Take `scale` as an absolute value rather than a relative value.
@@ -2837,16 +2837,16 @@ class PiecewiseAffine(meta.Augmenter):
         If ``None``, no polygon recoverer will be used.
         If an object, then that object will be used and must provide a
         ``recover_from()`` method, similar to
-        :class:`imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
+        :class:`~imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3210,7 +3210,7 @@ class PiecewiseAffine(meta.Augmenter):
                 return matrix
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [
             self.scale, self.nb_rows, self.nb_cols, self.order, self.cval,
             self.mode, self.absolute_scale]
@@ -3269,7 +3269,7 @@ class PerspectiveTransform(meta.Augmenter):
 
             minimum of (
                 ``imgaug.augmenters.geometric.PerspectiveTransform(keep_size=False)``,
-                :func:`imgaug.imgaug.imresize_many_images`
+                :func:`~imgaug.imgaug.imresize_many_images`
             )
 
     Parameters
@@ -3355,16 +3355,16 @@ class PerspectiveTransform(meta.Augmenter):
         If ``None``, no polygon recoverer will be used.
         If an object, then that object will be used and must provide a
         ``recover_from()`` method, similar to
-        :class:`imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
+        :class:`~imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3839,7 +3839,7 @@ class PerspectiveTransform(meta.Augmenter):
         return matrix_expanded, max_width, max_height
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.jitter, self.keep_size, self.cval, self.mode,
                 self.fit_output]
 
@@ -4001,16 +4001,16 @@ class ElasticTransformation(meta.Augmenter):
         If ``None``, no polygon recoverer will be used.
         If an object, then that object will be used and must provide a
         ``recover_from()`` method, similar to
-        :class:`imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
+        :class:`~imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4328,7 +4328,7 @@ class ElasticTransformation(meta.Augmenter):
         return self._apply_to_cbaois_as_keypoints(bbsoi, func)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.alpha, self.sigma, self.order, self.cval, self.mode]
 
     @classmethod
@@ -4630,7 +4630,7 @@ class Rot90(meta.Augmenter):
 
             minimum of (
                 ``imgaug.augmenters.geometric.Rot90(keep_size=False)``,
-                :func:`imgaug.imgaug.imresize_many_images`
+                :func:`~imgaug.imgaug.imresize_many_images`
             )
 
     Parameters
@@ -4655,13 +4655,13 @@ class Rot90(meta.Augmenter):
         also cause the augmented image to look distorted.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4824,7 +4824,7 @@ class Rot90(meta.Augmenter):
         return result
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.k, self.keep_size]
 
 
@@ -4909,13 +4909,13 @@ class WithPolarWarping(meta.Augmenter):
         to polar representation.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -5459,11 +5459,11 @@ class WithPolarWarping(meta.Augmenter):
             return np.concatenate([rho, phi], axis=1)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
     def _to_deterministic(self):
@@ -5550,13 +5550,13 @@ class Jigsaw(meta.Augmenter):
         divisible by ``nb_rows`` and ``nb_cols``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -250,7 +250,7 @@ def apply_gaussian_noise(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -280,7 +280,7 @@ def apply_shot_noise(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -310,7 +310,7 @@ def apply_impulse_noise(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -340,7 +340,7 @@ def apply_speckle_noise(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -370,7 +370,7 @@ def apply_gaussian_blur(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -400,7 +400,7 @@ def apply_glass_blur(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -490,7 +490,7 @@ def apply_defocus_blur(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -520,7 +520,7 @@ def apply_motion_blur(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -550,7 +550,7 @@ def apply_zoom_blur(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -580,7 +580,7 @@ def apply_fog(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -610,7 +610,7 @@ def apply_frost(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -640,7 +640,7 @@ def apply_snow(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -670,7 +670,7 @@ def apply_spatter(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -700,7 +700,7 @@ def apply_contrast(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -730,7 +730,7 @@ def apply_brightness(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -760,7 +760,7 @@ def apply_saturate(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -790,7 +790,7 @@ def apply_jpeg_compression(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -820,7 +820,7 @@ def apply_pixelate(x, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -850,7 +850,7 @@ def apply_elastic_transform(image, severity=1, seed=None):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -912,7 +912,7 @@ def apply_elastic_transform(image, severity=1, seed=None):
 #
 #     dtype support::
 #
-#         See :func:`imgaug.augmenters.imgcorruptlike.apply_%s`.
+#         See :func:`~imgaug.augmenters.imgcorruptlike.apply_%s`.
 #
 #     Parameters
 #     ----------
@@ -921,13 +921,13 @@ def apply_elastic_transform(image, severity=1, seed=None):
 #         ``1 <= severity <= 5``.
 #
 #     name : None or str, optional
-#         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+#         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 #
 #     deterministic : bool, optional
-#         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+#         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 #
 #     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-#         See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+#         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 #
 #     Examples
 #     --------
@@ -973,7 +973,7 @@ class _ImgcorruptAugmenterBase(meta.Augmenter):
         return severities, seeds
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.severity]
 
 
@@ -988,7 +988,7 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_gaussian_noise`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_gaussian_noise`.
 
     Parameters
     ----------
@@ -997,13 +997,13 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1034,7 +1034,7 @@ class ShotNoise(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_shot_noise`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_shot_noise`.
 
     Parameters
     ----------
@@ -1043,13 +1043,13 @@ class ShotNoise(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1080,7 +1080,7 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_impulse_noise`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_impulse_noise`.
 
     Parameters
     ----------
@@ -1089,13 +1089,13 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1126,7 +1126,7 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_speckle_noise`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_speckle_noise`.
 
     Parameters
     ----------
@@ -1135,13 +1135,13 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1172,7 +1172,7 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_gaussian_blur`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_gaussian_blur`.
 
     Parameters
     ----------
@@ -1181,13 +1181,13 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1218,7 +1218,7 @@ class GlassBlur(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_glass_blur`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_glass_blur`.
 
     Parameters
     ----------
@@ -1227,13 +1227,13 @@ class GlassBlur(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1264,7 +1264,7 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_defocus_blur`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_defocus_blur`.
 
     Parameters
     ----------
@@ -1273,13 +1273,13 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1310,7 +1310,7 @@ class MotionBlur(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_motion_blur`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_motion_blur`.
 
     Parameters
     ----------
@@ -1319,13 +1319,13 @@ class MotionBlur(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1356,7 +1356,7 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_zoom_blur`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_zoom_blur`.
 
     Parameters
     ----------
@@ -1365,13 +1365,13 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1402,7 +1402,7 @@ class Fog(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_fog`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_fog`.
 
     Parameters
     ----------
@@ -1411,13 +1411,13 @@ class Fog(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1448,7 +1448,7 @@ class Frost(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_frost`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_frost`.
 
     Parameters
     ----------
@@ -1457,13 +1457,13 @@ class Frost(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1494,7 +1494,7 @@ class Snow(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_snow`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_snow`.
 
     Parameters
     ----------
@@ -1503,13 +1503,13 @@ class Snow(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1540,7 +1540,7 @@ class Spatter(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_spatter`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_spatter`.
 
     Parameters
     ----------
@@ -1549,13 +1549,13 @@ class Spatter(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1586,7 +1586,7 @@ class Contrast(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_contrast`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_contrast`.
 
     Parameters
     ----------
@@ -1595,13 +1595,13 @@ class Contrast(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1632,7 +1632,7 @@ class Brightness(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_brightness`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_brightness`.
 
     Parameters
     ----------
@@ -1641,13 +1641,13 @@ class Brightness(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1678,7 +1678,7 @@ class Saturate(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_saturate`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_saturate`.
 
     Parameters
     ----------
@@ -1687,13 +1687,13 @@ class Saturate(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1724,7 +1724,7 @@ class JpegCompression(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_jpeg_compression`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_jpeg_compression`.
 
     Parameters
     ----------
@@ -1733,13 +1733,13 @@ class JpegCompression(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1770,7 +1770,7 @@ class Pixelate(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_pixelate`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_pixelate`.
 
     Parameters
     ----------
@@ -1779,13 +1779,13 @@ class Pixelate(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1816,7 +1816,7 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
     dtype support::
 
         See
-        :func:`imgaug.augmenters.imgcorruptlike.apply_elastic_transform`.
+        :func:`~imgaug.augmenters.imgcorruptlike.apply_elastic_transform`.
 
     Parameters
     ----------
@@ -1825,13 +1825,13 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
         ``1 <= severity <= 5``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -246,7 +246,7 @@ class Augmenter(object):
         corresponding data (e.g. keypoints or segmentation maps) on these
         images. Usually, there is no need to set this variable by hand.
         Instead, instantiate the augmenter and then use
-        :func:`imgaug.augmenters.Augmenter.to_deterministic`.
+        :func:`~imgaug.augmenters.Augmenter.to_deterministic`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
         The RNG (random number generator) to use for this augmenter.
@@ -257,23 +257,23 @@ class Augmenter(object):
             * If ``None``: The global RNG is used (shared by all
               augmenters).
             * If ``int``: The value will be used as a seed for a new
-              :class:`imgaug.random.RNG` instance.
-            * If :class:`imgaug.random.RNG`: The ``RNG`` instance will be
+              :class:`~imgaug.random.RNG` instance.
+            * If :class:`~imgaug.random.RNG`: The ``RNG`` instance will be
               used without changes.
-            * If :class:`imgaug.random.Generator`: A new
-              :class:`imgaug.random.RNG` instance will be
+            * If :class:`~imgaug.random.Generator`: A new
+              :class:`~imgaug.random.RNG` instance will be
               created, containing that generator.
-            * If :class:`imgaug.random.bit_generator.BitGenerator`: Will
-              be wrapped in a :class:`imgaug.random.Generator`. Then
-              similar behaviour to :class:`imgaug.random.Generator`
+            * If :class:`~imgaug.random.bit_generator.BitGenerator`: Will
+              be wrapped in a :class:`~imgaug.random.Generator`. Then
+              similar behaviour to :class:`~imgaug.random.Generator`
               parameters.
-            * If :class:`imgaug.random.SeedSequence`: Will
+            * If :class:`~imgaug.random.SeedSequence`: Will
               be wrapped in a new bit generator and
-              :class:`imgaug.random.Generator`. Then
-              similar behaviour to :class:`imgaug.random.Generator`
+              :class:`~imgaug.random.Generator`. Then
+              similar behaviour to :class:`~imgaug.random.Generator`
               parameters.
-            * If :class:`imgaug.random.RandomState`: Similar behaviour to
-              :class:`imgaug.random.Generator`. Outdated in numpy 1.17+.
+            * If :class:`~imgaug.random.RandomState`: Similar behaviour to
+              :class:`~imgaug.random.Generator`. Outdated in numpy 1.17+.
 
         If a new bit generator has to be created, it will be an instance
         of :class:`numpy.random.SFC64`.
@@ -317,7 +317,7 @@ class Augmenter(object):
 
         This method also also supports augmentation on multiple cpu cores,
         activated via the `background` flag. If the `background` flag
-        is activated, an instance of :class:`imgaug.multicore.Pool` will
+        is activated, an instance of :class:`~imgaug.multicore.Pool` will
         be spawned using all available logical CPU cores and an
         ``output_buffer_size`` of ``C*10``, where ``C`` is the number of
         logical CPU cores. I.e. a maximum of ``C*10`` batches will be somewhere
@@ -644,10 +644,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_batch`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_batch`.
 
         hooks : imgaug.imgaug.HooksImages or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_batch`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_batch`.
 
         Returns
         ----------
@@ -733,7 +733,7 @@ class Augmenter(object):
             ``None``. It is set automatically for child augmenters.
 
         hooks : None or imgaug.imgaug.HooksImages, optional
-            :class:`imgaug.imgaug.HooksImages` object to dynamically
+            :class:`~imgaug.imgaug.HooksImages` object to dynamically
             interfere with the augmentation process.
 
         Returns
@@ -791,7 +791,7 @@ class Augmenter(object):
         .. note::
 
             This method exists mostly for legacy-support.
-            Overwriting :func:`imgaug.augmenters.meta.Augmenter._augment_batch`
+            Overwriting :func:`~imgaug.augmenters.meta.Augmenter._augment_batch`
             is now the preferred way of implementing custom augmentation
             routines.
 
@@ -811,10 +811,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_images`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_images`.
 
         hooks : imgaug.imgaug.HooksImages or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_images`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_images`.
 
         Returns
         ----------
@@ -840,7 +840,7 @@ class Augmenter(object):
             It is set automatically for child augmenters.
 
         hooks : None or imaug.imgaug.HooksHeatmaps, optional
-            :class:`imgaug.imgaug.HooksHeatmaps` object to dynamically
+            :class:`~imgaug.imgaug.HooksHeatmaps` object to dynamically
             interfere with the augmentation process.
 
         Returns
@@ -867,7 +867,7 @@ class Augmenter(object):
         .. note::
 
             This method exists mostly for legacy-support.
-            Overwriting :func:`imgaug.augmenters.meta.Augmenter._augment_batch`
+            Overwriting :func:`~imgaug.augmenters.meta.Augmenter._augment_batch`
             is now the preferred way of implementing custom augmentation
             routines.
 
@@ -877,10 +877,10 @@ class Augmenter(object):
             Heatmaps to augment. They may be changed in-place.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_heatmaps`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_heatmaps`.
 
         hooks : imgaug.imgaug.HooksHeatmaps or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_heatmaps`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_heatmaps`.
 
         Returns
         ----------
@@ -905,7 +905,7 @@ class Augmenter(object):
             ``None``. It is set automatically for child augmenters.
 
         hooks : None or imgaug.HooksHeatmaps, optional
-            :class:`imgaug.imgaug.HooksHeatmaps` object to dynamically
+            :class:`~imgaug.imgaug.HooksHeatmaps` object to dynamically
             interfere with the augmentation process.
 
         Returns
@@ -935,7 +935,7 @@ class Augmenter(object):
         .. note::
 
             This method exists mostly for legacy-support.
-            Overwriting :func:`imgaug.augmenters.meta.Augmenter._augment_batch`
+            Overwriting :func:`~imgaug.augmenters.meta.Augmenter._augment_batch`
             is now the preferred way of implementing custom augmentation
             routines.
 
@@ -946,11 +946,11 @@ class Augmenter(object):
 
         parents : list of imgaug.augmenters.meta.Augmenter
             See
-            :func:`imgaug.augmenters.meta.Augmenter.augment_segmentation_maps`.
+            :func:`~imgaug.augmenters.meta.Augmenter.augment_segmentation_maps`.
 
         hooks : imgaug.imgaug.HooksHeatmaps or None
             See
-            :func:`imgaug.augmenters.meta.Augmenter.augment_segmentation_maps`.
+            :func:`~imgaug.augmenters.meta.Augmenter.augment_segmentation_maps`.
 
         Returns
         ----------
@@ -1000,7 +1000,7 @@ class Augmenter(object):
         keypoints_on_images : imgaug.augmentables.kps.KeypointsOnImage or list of imgaug.augmentables.kps.KeypointsOnImage
             The keypoints/landmarks to augment.
             Either a single instance of
-            :class:`imgaug.augmentables.kps.KeypointsOnImage` or a list of
+            :class:`~imgaug.augmentables.kps.KeypointsOnImage` or a list of
             such instances. Each instance must contain the keypoints of a
             single image.
 
@@ -1010,7 +1010,7 @@ class Augmenter(object):
             ``None``. It is set automatically for child augmenters.
 
         hooks : None or imgaug.imgaug.HooksKeypoints, optional
-            :class:`imgaug.imgaug.HooksKeypoints` object to dynamically
+            :class:`~imgaug.imgaug.HooksKeypoints` object to dynamically
             interfere with the augmentation process.
 
         Returns
@@ -1040,7 +1040,7 @@ class Augmenter(object):
         .. note::
 
             This method exists mostly for legacy-support.
-            Overwriting :func:`imgaug.augmenters.meta.Augmenter._augment_batch`
+            Overwriting :func:`~imgaug.augmenters.meta.Augmenter._augment_batch`
             is now the preferred way of implementing custom augmentation
             routines.
 
@@ -1053,10 +1053,10 @@ class Augmenter(object):
             The random state to use for all sampling tasks during the augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_keypoints`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_keypoints`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_keypoints`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_keypoints`.
 
         Returns
         ----------
@@ -1109,7 +1109,7 @@ class Augmenter(object):
         bounding_boxes_on_images : imgaug.augmentables.bbs.BoundingBoxesOnImage or list of imgaug.augmentables.bbs.BoundingBoxesOnImage
             The bounding boxes to augment.
             Either a single instance of
-            :class:`imgaug.augmentables.bbs.BoundingBoxesOnImage` or a list of
+            :class:`~imgaug.augmentables.bbs.BoundingBoxesOnImage` or a list of
             such instances, with each one of them containing the bounding
             boxes of a single image.
 
@@ -1119,7 +1119,7 @@ class Augmenter(object):
             ``None``. It is set automatically for child augmenters.
 
         hooks : None or imgaug.imgaug.HooksKeypoints, optional
-            :class:`imgaug.imgaug.HooksKeypoints` object to dynamically
+            :class:`~imgaug.imgaug.HooksKeypoints` object to dynamically
             interfere with the augmentation process.
 
         Returns
@@ -1175,7 +1175,7 @@ class Augmenter(object):
         polygons_on_images : imgaug.augmentables.polys.PolygonsOnImage or list of imgaug.augmentables.polys.PolygonsOnImage
             The polygons to augment.
             Either a single instance of
-            :class:`imgaug.augmentables.polys.PolygonsOnImage` or a list of
+            :class:`~imgaug.augmentables.polys.PolygonsOnImage` or a list of
             such instances, with each one of them containing the polygons of
             a single image.
 
@@ -1185,7 +1185,7 @@ class Augmenter(object):
             ``None``. It is set automatically for child augmenters.
 
         hooks : None or imgaug.imgaug.HooksKeypoints, optional
-            :class:`imgaug.imgaug.HooksKeypoints` object to dynamically
+            :class:`~imgaug.imgaug.HooksKeypoints` object to dynamically
             interfere with the augmentation process.
 
         Returns
@@ -1244,7 +1244,7 @@ class Augmenter(object):
         line_strings_on_images : imgaug.augmentables.lines.LineStringsOnImage or list of imgaug.augmentables.lines.LineStringsOnImage
             The line strings to augment.
             Either a single instance of
-            :class:`imgaug.augmentables.lines.LineStringsOnImage` or a list of
+            :class:`~imgaug.augmentables.lines.LineStringsOnImage` or a list of
             such instances, with each one of them containing the line strings
             of a single image.
 
@@ -1254,7 +1254,7 @@ class Augmenter(object):
             It is set automatically for child augmenters.
 
         hooks : None or imgaug.imgaug.HooksKeypoints, optional
-            :class:`imgaug.imgaug.HooksKeypoints` object to dynamically
+            :class:`~imgaug.imgaug.HooksKeypoints` object to dynamically
             interfere with the augmentation process.
 
         Returns
@@ -1285,7 +1285,7 @@ class Augmenter(object):
         .. note::
 
             This method exists mostly for legacy-support.
-            Overwriting :func:`imgaug.augmenters.meta.Augmenter._augment_batch`
+            Overwriting :func:`~imgaug.augmenters.meta.Augmenter._augment_batch`
             is now the preferred way of implementing custom augmentation
             routines.
 
@@ -1299,10 +1299,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_bounding_boxes`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_bounding_boxes`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_bounding_boxes`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_bounding_boxes`.
 
         Returns
         -------
@@ -1327,7 +1327,7 @@ class Augmenter(object):
         .. note::
 
             This method exists mostly for legacy-support.
-            Overwriting :func:`imgaug.augmenters.meta.Augmenter._augment_batch`
+            Overwriting :func:`~imgaug.augmenters.meta.Augmenter._augment_batch`
             is now the preferred way of implementing custom augmentation
             routines.
 
@@ -1341,10 +1341,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         Returns
         -------
@@ -1370,7 +1370,7 @@ class Augmenter(object):
         .. note::
 
             This method exists mostly for legacy-support.
-            Overwriting :func:`imgaug.augmenters.meta.Augmenter._augment_batch`
+            Overwriting :func:`~imgaug.augmenters.meta.Augmenter._augment_batch`
             is now the preferred way of implementing custom augmentation
             routines.
 
@@ -1384,10 +1384,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_line_strings`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_line_strings`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_line_strings`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_line_strings`.
 
         Returns
         -------
@@ -1412,10 +1412,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         Returns
         -------
@@ -1436,7 +1436,7 @@ class Augmenter(object):
         .. warning::
 
             This method calls
-            :func:`imgaug.augmenters.meta.Augmenter._augment_keypoints` and
+            :func:`~imgaug.augmenters.meta.Augmenter._augment_keypoints` and
             expects it to do keypoint augmentation. The default for that
             method is to do nothing. It must therefore be overwritten,
             otherwise the polygon augmentation will also do nothing.
@@ -1451,10 +1451,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         recoverer : None or imgaug.augmentables.polys._ConcavePolygonRecoverer
             An instance used to repair invalid polygons after augmentation.
@@ -1491,10 +1491,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_polygons`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_polygons`.
 
         Returns
         -------
@@ -1523,10 +1523,10 @@ class Augmenter(object):
             augmentation.
 
         parents : list of imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_batch`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_batch`.
 
         hooks : imgaug.imgaug.HooksKeypoints or None
-            See :func:`imgaug.augmenters.meta.Augmenter.augment_batch`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.augment_batch`.
 
         Returns
         -------
@@ -1553,7 +1553,7 @@ class Augmenter(object):
 
         func : callable
             The function to apply. Receives a list of
-            :class:`imgaug.augmentables.kps.KeypointsOnImage` instances as its
+            :class:`~imgaug.augmentables.kps.KeypointsOnImage` instances as its
             only parameter.
 
         recoverer : None or imgaug.augmentables.polys._ConcavePolygonRecoverer
@@ -1611,7 +1611,7 @@ class Augmenter(object):
 
         func : callable
             The function to apply. Receives a list of
-            :class:`imgaug.augmentables.kps.KeypointsOnImage` instances as its
+            :class:`~imgaug.augmentables.kps.KeypointsOnImage` instances as its
             only parameter.
 
         Returns
@@ -1631,10 +1631,10 @@ class Augmenter(object):
         """Augment a batch.
 
         This method is a wrapper around
-        :class:`imgaug.augmentables.batches.UnnormalizedBatch` and
-        :func:`imgaug.augmenters.meta.Augmenter.augment_batch`. Hence, it
+        :class:`~imgaug.augmentables.batches.UnnormalizedBatch` and
+        :func:`~imgaug.augmenters.meta.Augmenter.augment_batch`. Hence, it
         supports the same datatypes as
-        :class:`imgaug.augmentables.batches.UnnormalizedBatch`.
+        :class:`~imgaug.augmentables.batches.UnnormalizedBatch`.
 
         If `return_batch` was set to ``False`` (the default), the method will
         return a tuple of augmentables. It will return the same types of
@@ -1661,7 +1661,7 @@ class Augmenter(object):
               tuple of images and something (like images + segmentation maps).
 
         If `return_batch` was set to ``True``, an instance of
-        :class:`imgaug.augmentables.batches.UnnormalizedBatch` will be
+        :class:`~imgaug.augmentables.batches.UnnormalizedBatch` will be
         returned. The output is the same for all python version and any
         number or combination of augmentables may be provided.
 
@@ -1691,7 +1691,7 @@ class Augmenter(object):
         heatmaps : None or (N,H,W,C) ndarray or imgaug.augmentables.heatmaps.HeatmapsOnImage or iterable of (H,W,C) ndarray or iterable of imgaug.augmentables.heatmaps.HeatmapsOnImage, optional
             The heatmaps to augment.
             If anything else than
-            :class:`imgaug.augmentables.heatmaps.HeatmapsOnImage`, then the
+            :class:`~imgaug.augmentables.heatmaps.HeatmapsOnImage`, then the
             number of heatmaps must match the number of images provided via
             parameter `images`. The number is contained either in ``N`` or the
             first iterable's size.
@@ -1699,7 +1699,7 @@ class Augmenter(object):
         segmentation_maps : None or (N,H,W) ndarray or imgaug.augmentables.segmaps.SegmentationMapsOnImage or iterable of (H,W) ndarray or iterable of imgaug.augmentables.segmaps.SegmentationMapsOnImage, optional
             The segmentation maps to augment.
             If anything else than
-            :class:`imgaug.augmentables.segmaps.SegmentationMapsOnImage`, then
+            :class:`~imgaug.augmentables.segmaps.SegmentationMapsOnImage`, then
             the number of segmaps must match the number of images provided via
             parameter `images`. The number is contained either in ``N`` or the
             first iterable's size.
@@ -1711,12 +1711,12 @@ class Augmenter(object):
             A single tuple represents a single coordinate on one image, an
             iterable of tuples the coordinates on one image and an iterable of
             iterable of tuples the coordinates on several images. Analogous if
-            :class:`imgaug.augmentables.kps.Keypoint` instances are used
+            :class:`~imgaug.augmentables.kps.Keypoint` instances are used
             instead of tuples.
             If an ndarray, then ``N`` denotes the number of images and ``K``
             the number of keypoints on each image.
             If anything else than
-            :class:`imgaug.augmentables.kps.KeypointsOnImage` is provided, then
+            :class:`~imgaug.augmentables.kps.KeypointsOnImage` is provided, then
             the number of keypoint groups must match the number of images
             provided via parameter `images`. The number is contained e.g. in
             ``N`` or in case of "iterable of iterable of tuples" in the first
@@ -1765,7 +1765,7 @@ class Augmenter(object):
 
         return_batch : bool, optional
             Whether to return an instance of
-            :class:`imgaug.augmentables.batches.UnnormalizedBatch`. If the
+            :class:`~imgaug.augmentables.batches.UnnormalizedBatch`. If the
             python version is below 3.6 and more than two augmentables were
             provided (e.g. images, keypoints and polygons), then this must be
             set to ``True``. Otherwise an error will be raised.
@@ -1831,7 +1831,7 @@ class Augmenter(object):
         rotations between ``-25`` deg and ``+25`` deg to them. The rotation
         values are sampled by image and aligned between all augmentables on
         the same image. The method finally returns an instance of
-        :class:`imgaug.augmentables.batches.UnnormalizedBatch` from which the
+        :class:`~imgaug.augmentables.batches.UnnormalizedBatch` from which the
         augmented data can be retrieved via ``batch_aug.images_aug``,
         ``batch_aug.keypoints_aug``, and ``batch_aug.bounding_boxes_aug``.
         In python 3.6+, `return_batch` can be kept at ``False`` and the
@@ -1943,7 +1943,7 @@ class Augmenter(object):
         return tuple(result)
 
     def __call__(self, *args, **kwargs):
-        """Alias for :func:`imgaug.augmenters.meta.Augmenter.augment`."""
+        """Alias for :func:`~imgaug.augmenters.meta.Augmenter.augment`."""
         return self.augment(*args, **kwargs)
 
     def pool(self, processes=None, maxtasksperchild=None, seed=None):
@@ -1952,7 +1952,7 @@ class Augmenter(object):
         Parameters
         ----------
         processes : None or int, optional
-            Same as in :func:`imgaug.multicore.Pool.__init__`.
+            Same as in :func:`~imgaug.multicore.Pool.__init__`.
             The number of background workers. If ``None``, the number of the
             machine's CPU cores will be used (this counts hyperthreads as CPU
             cores). If this is set to a negative value ``p``, then
@@ -1961,13 +1961,13 @@ class Augmenter(object):
             to e.g. reserve one core to feed batches to the GPU).
 
         maxtasksperchild : None or int, optional
-            Same as for :func:`imgaug.multicore.Pool.__init__`.
+            Same as for :func:`~imgaug.multicore.Pool.__init__`.
             The number of tasks done per worker process before the process
             is killed and restarted. If ``None``, worker processes will not
             be automatically restarted.
 
         seed : None or int, optional
-            Same as for :func:`imgaug.multicore.Pool.__init__`.
+            Same as for :func:`~imgaug.multicore.Pool.__init__`.
             The seed to use for child processes. If ``None``, a random seed
             will be used.
 
@@ -2129,7 +2129,7 @@ class Augmenter(object):
     def show_grid(self, images, rows, cols):
         """Augment images and plot the results as a single grid-like image.
 
-        This calls :func:`imgaug.augmenters.meta.Augmenter.draw_grid` and
+        This calls :func:`~imgaug.augmenters.meta.Augmenter.draw_grid` and
         simply shows the results. See that method for details.
 
         Parameters
@@ -2175,10 +2175,10 @@ class Augmenter(object):
         ----------
         n : None or int, optional
             Number of deterministic augmenters to return.
-            If ``None`` then only one :class:`imgaug.augmenters.meta.Augmenter`
+            If ``None`` then only one :class:`~imgaug.augmenters.meta.Augmenter`
             instance will be returned.
             If ``1`` or higher, a list containing ``n``
-            :class:`imgaug.augmenters.meta.Augmenter` instances will be
+            :class:`~imgaug.augmenters.meta.Augmenter` instances will be
             returned.
 
         Returns
@@ -2198,9 +2198,9 @@ class Augmenter(object):
         """Convert this augmenter from a stochastic to a deterministic one.
 
         Augmenter-specific implementation of
-        :func:`imgaug.augmenters.meta.to_deterministic`. This function is
+        :func:`~imgaug.augmenters.meta.to_deterministic`. This function is
         expected to return a single new deterministic
-        :class:`imgaug.augmenters.meta.Augmenter` instance of this augmenter.
+        :class:`~imgaug.augmenters.meta.Augmenter` instance of this augmenter.
 
         Returns
         -------
@@ -2227,7 +2227,7 @@ class Augmenter(object):
 
     @ia.deprecated("imgaug.augmenters.meta.Augmenter.seed_")
     def reseed(self, random_state=None, deterministic_too=False):
-        """Old name of :func:`imgaug.augmenters.meta.Augmenter.seed_`."""
+        """Old name of :func:`~imgaug.augmenters.meta.Augmenter.seed_`."""
         self.seed_(entropy=random_state, deterministic_too=deterministic_too)
 
     # TODO mark this as in-place
@@ -2244,13 +2244,13 @@ class Augmenter(object):
         If this augmenter or any child augmenter had a random number generator
         that pointed to the global random state, it will automatically be
         replaced with a local random state. This is similar to what
-        :func:`imgaug.augmenters.meta.Augmenter.localize_random_state`
+        :func:`~imgaug.augmenters.meta.Augmenter.localize_random_state`
         does.
 
         This method is useful when augmentations are run in the
         background (i.e. on multiple cores).
         It should be called before sending this
-        :class:`imgaug.augmenters.meta.Augmenter` instance to a
+        :class:`~imgaug.augmenters.meta.Augmenter` instance to a
         background worker or once within each worker with different seeds
         (i.e., if ``N`` workers are used, the function should be called
         ``N`` times). Otherwise, all background workers will
@@ -2315,7 +2315,7 @@ class Augmenter(object):
         ----------
         recursive : bool, optional
             See
-            :func:`imgaug.augmenters.meta.Augmenter.localize_random_state_`.
+            :func:`~imgaug.augmenters.meta.Augmenter.localize_random_state_`.
 
         Returns
         -------
@@ -2357,9 +2357,9 @@ class Augmenter(object):
               A and B would differ.)
 
         The case of determinism is handled automatically by
-        :func:`imgaug.augmenters.meta.Augmenter.to_deterministic`.
+        :func:`~imgaug.augmenters.meta.Augmenter.to_deterministic`.
         Only when you copy RNGs (via
-        :func:`imgaug.augmenters.meta.Augmenter.copy_random_state`),
+        :func:`~imgaug.augmenters.meta.Augmenter.copy_random_state`),
         you need to call this function first.
 
         Parameters
@@ -2389,19 +2389,19 @@ class Augmenter(object):
         Parameters
         ----------
         source : imgaug.augmenters.meta.Augmenter
-            See :func:`imgaug.augmenters.meta.Augmenter.copy_random_state_`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.copy_random_state_`.
 
         recursive : bool, optional
-            See :func:`imgaug.augmenters.meta.Augmenter.copy_random_state_`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.copy_random_state_`.
 
         matching : {'position', 'name'}, optional
-            See :func:`imgaug.augmenters.meta.Augmenter.copy_random_state_`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.copy_random_state_`.
 
         matching_tolerant : bool, optional
-            See :func:`imgaug.augmenters.meta.Augmenter.copy_random_state_`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.copy_random_state_`.
 
         copy_determinism : bool, optional
-            See :func:`imgaug.augmenters.meta.Augmenter.copy_random_state_`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.copy_random_state_`.
 
         Returns
         -------
@@ -2427,7 +2427,7 @@ class Augmenter(object):
 
             The source augmenters are not allowed to use the global RNG.
             Call
-            :func:`imgaug.augmenters.meta.Augmenter.localize_random_state_`
+            :func:`~imgaug.augmenters.meta.Augmenter.localize_random_state_`
             once on the source to localize all random states.
 
         Parameters
@@ -2435,7 +2435,7 @@ class Augmenter(object):
         source : imgaug.augmenters.meta.Augmenter
             The source augmenter(s) from where to copy the RNG(s).
             The source may have children (e.g. the source can be a
-            :class:`imgaug.augmenters.meta.Sequential`).
+            :class:`~imgaug.augmenters.meta.Sequential`).
 
         recursive : bool, optional
             Whether to copy the RNGs of the source augmenter *and*
@@ -2553,7 +2553,7 @@ class Augmenter(object):
         -------
         list
             List of parameters of arbitrary types (usually child class
-            of :class:`imgaug.parameters.StochasticParameter`, but not
+            of :class:`~imgaug.parameters.StochasticParameter`, but not
             guaranteed to be).
 
         """
@@ -2581,11 +2581,11 @@ class Augmenter(object):
         ``IfElse(condition, [A1, A2], [B1, B2, B3])`` returns
         ``[[A1, A2], [B1, B2, B3]]``
         for a call to
-        :func:`imgaug.augmenters.meta.Augmenter.get_children_lists` and
+        :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists` and
         ``A2`` is removed inplace from ``[A1, A2]``, then the children lists
         of ``IfElse(...)`` must also change to ``[A1], [B1, B2, B3]``. This
         is used in
-        :func:`imgaug.augmeneters.meta.Augmenter.remove_augmenters_`.
+        :func:`~imgaug.augmeneters.meta.Augmenter.remove_augmenters_`.
 
         Returns
         -------
@@ -2638,8 +2638,8 @@ class Augmenter(object):
         ----------
         func : callable
             A function that receives a
-            :class:`imgaug.augmenters.meta.Augmenter` instance and a list of
-            parent :class:`imgaug.augmenters.meta.Augmenter` instances and
+            :class:`~imgaug.augmenters.meta.Augmenter` instance and a list of
+            parent :class:`~imgaug.augmenters.meta.Augmenter` instances and
             must return ``True``, if that augmenter is valid match or
             ``False`` otherwise.
 
@@ -2701,7 +2701,7 @@ class Augmenter(object):
             Whether `name` parameter is a regular expression.
 
         flat : bool, optional
-            See :func:`imgaug.augmenters.meta.Augmenter.find_augmenters`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.find_augmenters`.
 
         Returns
         -------
@@ -2726,7 +2726,7 @@ class Augmenter(object):
             of these expressions is a match.
 
         flat : boolean, optional
-            See :func:`imgaug.augmenters.meta.Augmenter.find_augmenters`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.find_augmenters`.
 
         Returns
         -------
@@ -2772,7 +2772,7 @@ class Augmenter(object):
             If ``True`` and the condition (lambda function) leads to the
             removal of the topmost augmenter (the one this function is called
             on initially), then that topmost augmenter will be replaced by an
-            instance of :class:`imgaug.augmenters.meta.Noop` (i.e. an
+            instance of :class:`~imgaug.augmenters.meta.Noop` (i.e. an
             augmenter that doesn't change its inputs). If ``False``, ``None``
             will be returned in these cases.
             This can only be ``False`` if copy is set to ``True``.
@@ -2822,7 +2822,7 @@ class Augmenter(object):
 
     @ia.deprecated("remove_augmenters_")
     def remove_augmenters_inplace(self, func, parents=None):
-        """Old name for :func:`imgaug.meta.Augmenter.remove_augmenters_`."""
+        """Old name for :func:`~imgaug.meta.Augmenter.remove_augmenters_`."""
         self.remove_augmenters_(func=func, parents=parents)
 
     # TODO allow first arg to be string name, class type or func
@@ -2831,17 +2831,17 @@ class Augmenter(object):
         """Remove in-place children of this augmenter that match a condition.
 
         This is functionally identical to
-        :func:`imgaug.augmenters.meta.remove_augmenters` with
+        :func:`~imgaug.augmenters.meta.remove_augmenters` with
         ``copy=False``, except that it does not affect the topmost augmenter
         (the one on which this function is initially called on).
 
         Parameters
         ----------
         func : callable
-            See :func:`imgaug.augmenters.meta.Augmenter.remove_augmenters`.
+            See :func:`~imgaug.augmenters.meta.Augmenter.remove_augmenters`.
 
         parents : None or list of imgaug.augmenters.meta.Augmenter, optional
-            List of parent :class:`imgaug.augmenters.meta.Augmenter` instances
+            List of parent :class:`~imgaug.augmenters.meta.Augmenter` instances
             that lead to this augmenter. If ``None``, an empty list will be
             used. This parameter can usually be left empty and will be set
             automatically for children.
@@ -2926,7 +2926,7 @@ class Sequential(Augmenter, list):
 
     .. note::
 
-        You are *not* forced to use :class:`imgaug.augmenters.meta.Sequential`
+        You are *not* forced to use :class:`~imgaug.augmenters.meta.Sequential`
         in order to use other augmenters. Each augmenter can be used on its
         own, e.g the following defines an augmenter for horizontal flips and
         then augments a single image:
@@ -2963,13 +2963,13 @@ class Sequential(Augmenter, list):
         If ``True``, the order will be randomly sampled once per batch.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2982,7 +2982,7 @@ class Sequential(Augmenter, list):
     >>> ])
     >>> imgs_aug = seq.augment_images(imgs)
 
-    Create a :class:`imgaug.augmenters.meta.Sequential` that always first
+    Create a :class:`~imgaug.augmenters.meta.Sequential` that always first
     applies a horizontal flip augmenter and then a vertical flip augmenter.
     Each of these two augmenters has a ``50%`` probability of actually
     flipping the image.
@@ -2993,7 +2993,7 @@ class Sequential(Augmenter, list):
     >>> ], random_order=True)
     >>> imgs_aug = seq.augment_images(imgs)
 
-    Create a :class:`imgaug.augmenters.meta.Sequential` that sometimes first
+    Create a :class:`~imgaug.augmenters.meta.Sequential` that sometimes first
     applies a horizontal flip augmenter (followed by a vertical flip
     augmenter) and sometimes first a vertical flip augmenter (followed by a
     horizontal flip augmenter). Again, each of them has a ``50%`` probability
@@ -3052,7 +3052,7 @@ class Sequential(Augmenter, list):
         return seq
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.random_order]
 
     def add(self, augmenter):
@@ -3067,7 +3067,7 @@ class Sequential(Augmenter, list):
         self.append(augmenter)
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self]
 
     def __str__(self):
@@ -3084,14 +3084,14 @@ class Sequential(Augmenter, list):
 class SomeOf(Augmenter, list):
     """List augmenter that applies only some of its children to inputs.
 
-    This augmenter is similar to :class:`imgaug.augmenters.meta.Sequential`,
+    This augmenter is similar to :class:`~imgaug.augmenters.meta.Sequential`,
     but may apply only a fixed or random subset of its child augmenters to
     inputs. E.g. the augmenter could be initialized with a list of 20 child
     augmenters and then apply 5 randomly chosen child augmenters to images.
 
     The subset of augmenters to apply (and their order) is sampled once
     *per image*. If `random_order` is ``True``, the order will be sampled once
-    *per batch* (similar to :class:`imgaug.augmenters.meta.Sequential`).
+    *per batch* (similar to :class:`~imgaug.augmenters.meta.Sequential`).
 
     This augmenter currently does not support replacing (i.e. picking the same
     child multiple times) due to implementation difficulties in connection
@@ -3134,20 +3134,20 @@ class SomeOf(Augmenter, list):
     children : imgaug.augmenters.meta.Augmenter or list of imgaug.augmenters.meta.Augmenter or None, optional
         The augmenters to apply to images.
         If this is a list of augmenters, it will be converted to a
-        :class:`imgaug.augmenters.meta.Sequential`.
+        :class:`~imgaug.augmenters.meta.Sequential`.
 
     random_order : boolean, optional
         Whether to apply the child augmenters in random order.
         If ``True``, the order will be randomly sampled once per batch.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3322,7 +3322,7 @@ class SomeOf(Augmenter, list):
         return seq
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.n]
 
     def add(self, augmenter):
@@ -3337,7 +3337,7 @@ class SomeOf(Augmenter, list):
         self.append(augmenter)
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self]
 
     def __str__(self):
@@ -3364,13 +3364,13 @@ class OneOf(SomeOf):
         The choices of augmenters to apply.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3416,7 +3416,7 @@ class Sometimes(Augmenter):
     """Apply child augmenter(s) with a probability of `p`.
 
     Let ``C`` be one or more child augmenters given to
-    :class:`imgaug.augmenters.meta.Sometimes`.
+    :class:`~imgaug.augmenters.meta.Sometimes`.
     Let ``p`` be the fraction of images (or other data) to augment.
     Let ``I`` be the input images (or other data).
     Let ``N`` be the number of input images (or other entities).
@@ -3448,23 +3448,23 @@ class Sometimes(Augmenter):
     then_list : None or imgaug.augmenters.meta.Augmenter or list of imgaug.augmenters.meta.Augmenter, optional
         Augmenter(s) to apply to `p%` percent of all images.
         If this is a list of augmenters, it will be converted to a
-        :class:`imgaug.augmenters.meta.Sequential`.
+        :class:`~imgaug.augmenters.meta.Sequential`.
 
     else_list : None or imgaug.augmenters.meta.Augmenter or list of imgaug.augmenters.meta.Augmenter, optional
         Augmenter(s) to apply to ``(1-p)`` percent of all images.
         These augmenters will be applied only when the ones in `then_list`
         are *not* applied (either-or-relationship).
         If this is a list of augmenters, it will be converted to a
-        :class:`imgaug.augmenters.meta.Sequential`.
+        :class:`~imgaug.augmenters.meta.Sequential`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3537,11 +3537,11 @@ class Sometimes(Augmenter):
         return aug
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         result = []
         if self.then_list is not None:
             result.append(self.then_list)
@@ -3598,13 +3598,13 @@ class WithChannels(Augmenter):
         are extracted.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3771,11 +3771,11 @@ class WithChannels(Augmenter):
         return aug
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.channels]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
     def __str__(self):
@@ -3812,13 +3812,13 @@ class Identity(Augmenter):
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -3830,7 +3830,7 @@ class Identity(Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
 
 
@@ -3842,18 +3842,18 @@ class Noop(Identity):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.meta.Identity`.
+        See :class:`~imgaug.augmenters.meta.Identity`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -3893,7 +3893,7 @@ class Lambda(Augmenter):
 
         and return the changed images (may be transformed in-place).
         This is essentially the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_images`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_images`.
         If this is ``None`` instead of a function, the images will not be
         altered.
 
@@ -3905,7 +3905,7 @@ class Lambda(Augmenter):
 
         and return the changed heatmaps (may be transformed in-place).
         This is essentially the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_heatmaps`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_heatmaps`.
         If this is ``None`` instead of a function, the heatmaps will not be
         altered.
 
@@ -3917,7 +3917,7 @@ class Lambda(Augmenter):
 
         and return the changed segmaps (may be transformed in-place).
         This is essentially the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_segmentation_maps`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_segmentation_maps`.
         If this is ``None`` instead of a function, the segmentatio maps will
         not be altered.
 
@@ -3929,7 +3929,7 @@ class Lambda(Augmenter):
 
         and return the changed keypoints (may be transformed in-place).
         This is essentially the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_keypoints`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_keypoints`.
         If this is ``None`` instead of a function, the keypoints will not be
         altered.
 
@@ -3941,7 +3941,7 @@ class Lambda(Augmenter):
 
         and return the changed bounding boxes (may be transformed in-place).
         This is essentially the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_bounding_boxes`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_bounding_boxes`.
         If this is ``None`` instead of a function, the bounding boxes will not
         be altered.
         If this is the string ``"keypoints"`` instead of a function, the
@@ -3956,7 +3956,7 @@ class Lambda(Augmenter):
 
         and return the changed polygons (may be transformed in-place).
         This is essentially the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_polygons`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_polygons`.
         If this is ``None`` instead of a function, the polygons will not
         be altered.
         If this is the string ``"keypoints"`` instead of a function, the
@@ -3971,7 +3971,7 @@ class Lambda(Augmenter):
 
         and return the changed line strings (may be transformed in-place).
         This is essentially the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_line_strings`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_line_strings`.
         If this is ``None`` instead of a function, the line strings will not
         be altered.
         If this is the string ``"keypoints"`` instead of a function, the
@@ -3979,13 +3979,13 @@ class Lambda(Augmenter):
         corner vertices to keypoints and calling `func_keypoints`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4172,7 +4172,7 @@ class Lambda(Augmenter):
         return bounding_boxes_on_images
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
 
 
@@ -4212,7 +4212,7 @@ class AssertLambda(Lambda):
 
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_images`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_images`.
 
     func_heatmaps : None or callable, optional
         The function to call for each batch of heatmaps.
@@ -4222,7 +4222,7 @@ class AssertLambda(Lambda):
 
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_heatmaps`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_heatmaps`.
 
     func_segmentation_maps : None or callable, optional
         The function to call for each batch of segmentation maps.
@@ -4232,7 +4232,7 @@ class AssertLambda(Lambda):
 
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_segmentation_maps`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_segmentation_maps`.
 
     func_keypoints : None or callable, optional
         The function to call for each batch of keypoints.
@@ -4242,7 +4242,7 @@ class AssertLambda(Lambda):
 
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_keypoints`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_keypoints`.
 
     func_bounding_boxes : None or callable, optional
         The function to call for each batch of bounding boxes.
@@ -4252,7 +4252,7 @@ class AssertLambda(Lambda):
 
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_bounding_boxes`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_bounding_boxes`.
 
     func_polygons : None or callable, optional
         The function to call for each batch of polygons.
@@ -4262,7 +4262,7 @@ class AssertLambda(Lambda):
 
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_polygons`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_polygons`.
 
     func_line_strings : None or callable, optional
         The function to call for each batch of line strings.
@@ -4272,16 +4272,16 @@ class AssertLambda(Lambda):
 
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
-        :func:`imgaug.augmenters.meta.Augmenter._augment_line_strings`.
+        :func:`~imgaug.augmenters.meta.Augmenter._augment_line_strings`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -4350,7 +4350,7 @@ class AssertShape(Lambda):
         the ``tuple`` must match the number of dimensions, i.e. it must
         contain four entries for ``(N, H, W, C)``. If only a single entity
         is augmented, e.g. via
-        :func:`imgaug.augmenters.meta.Augmenter.augment_image`, then ``N`` is
+        :func:`~imgaug.augmenters.meta.Augmenter.augment_image`, then ``N`` is
         ``1`` in the input to this augmenter. Images that don't have
         a channel axis will automatically have one assigned, i.e. ``C`` is
         at least ``1``.
@@ -4373,49 +4373,49 @@ class AssertShape(Lambda):
     check_heatmaps : bool, optional
         Whether to validate input heatmaps via the given shape.
         The number of heatmaps will be verified as ``N``. For each
-        :class:`imgaug.augmentables.heatmaps.HeatmapsOnImage` instance
+        :class:`~imgaug.augmentables.heatmaps.HeatmapsOnImage` instance
         its array's height and width will be verified as ``H`` and ``W``,
         but not the channel count.
 
     check_segmentation_maps : bool, optional
         Whether to validate input segmentation maps via the given shape.
         The number of segmentation maps will be verified as ``N``. For each
-        :class:`imgaug.augmentables.segmaps.SegmentationMapOnImage` instance
+        :class:`~imgaug.augmentables.segmaps.SegmentationMapOnImage` instance
         its array's height and width will be verified as ``H`` and ``W``,
         but not the channel count.
 
     check_keypoints : bool, optional
         Whether to validate input keypoints via the given shape.
         This will check (a) the number of keypoints and (b) for each
-        :class:`imgaug.augmentables.kps.KeypointsOnImage` instance the
+        :class:`~imgaug.augmentables.kps.KeypointsOnImage` instance the
         ``.shape`` attribute, i.e. the shape of the corresponding image.
 
     check_bounding_boxes : bool, optional
         Whether to validate input bounding boxes via the given shape.
         This will check (a) the number of bounding boxes and (b) for each
-        :class:`imgaug.augmentables.bbs.BoundingBoxesOnImage` instance the
+        :class:`~imgaug.augmentables.bbs.BoundingBoxesOnImage` instance the
         ``.shape`` attribute, i.e. the shape of the corresponding image.
 
     check_polygons : bool, optional
         Whether to validate input polygons via the given shape.
         This will check (a) the number of polygons and (b) for each
-        :class:`imgaug.augmentables.polys.PolygonsOnImage` instance the
+        :class:`~imgaug.augmentables.polys.PolygonsOnImage` instance the
         ``.shape`` attribute, i.e. the shape of the corresponding image.
 
     check_line_strings : bool, optional
         Whether to validate input line strings via the given shape.
         This will check (a) the number of line strings and (b) for each
-        :class:`imgaug.augmentables.lines.LineStringsOnImage` instance the
+        :class:`~imgaug.augmentables.lines.LineStringsOnImage` instance the
         ``.shape`` attribute, i.e. the shape of the corresponding image.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4615,7 +4615,7 @@ class ChannelShuffle(Augmenter):
     p : float or imgaug.parameters.StochasticParameter, optional
         Probability of shuffling channels in any given image.
         May be a fixed probability as a ``float``, or a
-        :class:`imgaug.parameters.StochasticParameter` that returns ``0`` s
+        :class:`~imgaug.parameters.StochasticParameter` that returns ``0`` s
         and ``1`` s.
 
     channels : None or imgaug.ALL or list of int, optional
@@ -4627,13 +4627,13 @@ class ChannelShuffle(Augmenter):
         each image.)
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4684,7 +4684,7 @@ class ChannelShuffle(Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p, self.channels]
 
 
@@ -4788,13 +4788,13 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
         fraction.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4851,7 +4851,7 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.fraction]
 
 
@@ -4884,13 +4884,13 @@ class ClipCBAsToImagePlanes(Augmenter):
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4920,5 +4920,5 @@ class ClipCBAsToImagePlanes(Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []

--- a/imgaug/augmenters/overlay.py
+++ b/imgaug/augmenters/overlay.py
@@ -19,7 +19,7 @@ _DEPRECATION_COMMENT = (
 @ia.deprecated(alt_func="imgaug.augmenters.blend.blend_alpha()",
                comment=_DEPRECATION_COMMENT)
 def blend_alpha(*args, **kwargs):
-    """See :func:`imgaug.augmenters.blend.blend_alpha`."""
+    """See :func:`~imgaug.augmenters.blend.blend_alpha`."""
     # pylint: disable=invalid-name
     return blend.blend_alpha(*args, **kwargs)
 
@@ -27,7 +27,7 @@ def blend_alpha(*args, **kwargs):
 @ia.deprecated(alt_func="imgaug.augmenters.blend.BlendAlpha",
                comment=_DEPRECATION_COMMENT)
 def Alpha(*args, **kwargs):
-    """See :class:`imgaug.augmenters.blend.BlendAlpha`."""
+    """See :class:`~imgaug.augmenters.blend.BlendAlpha`."""
     # pylint: disable=invalid-name
     return blend.Alpha(*args, **kwargs)
 
@@ -35,7 +35,7 @@ def Alpha(*args, **kwargs):
 @ia.deprecated(alt_func="imgaug.augmenters.blend.BlendAlphaElementwise",
                comment=_DEPRECATION_COMMENT)
 def AlphaElementwise(*args, **kwargs):
-    """See :class:`imgaug.augmenters.blend.BlendAlphaElementwise`."""
+    """See :class:`~imgaug.augmenters.blend.BlendAlphaElementwise`."""
     # pylint: disable=invalid-name
     return blend.AlphaElementwise(*args, **kwargs)
 
@@ -43,7 +43,7 @@ def AlphaElementwise(*args, **kwargs):
 @ia.deprecated(alt_func="imgaug.augmenters.blend.BlendAlphaSimplexNoise",
                comment=_DEPRECATION_COMMENT)
 def SimplexNoiseAlpha(*args, **kwargs):
-    """See :class:`imgaug.augmenters.blend.BlendAlphaSimplexNoise`."""
+    """See :class:`~imgaug.augmenters.blend.BlendAlphaSimplexNoise`."""
     # pylint: disable=invalid-name
     return blend.SimplexNoiseAlpha(*args, **kwargs)
 
@@ -51,6 +51,6 @@ def SimplexNoiseAlpha(*args, **kwargs):
 @ia.deprecated(alt_func="imgaug.augmenters.blend.BlendAlphaFrequencyNoise",
                comment=_DEPRECATION_COMMENT)
 def FrequencyNoiseAlpha(*args, **kwargs):
-    """See :class:`imgaug.augmenters.blend.BlendAlphaFrequencyNoise`."""
+    """See :class:`~imgaug.augmenters.blend.BlendAlphaFrequencyNoise`."""
     # pylint: disable=invalid-name
     return blend.FrequencyNoiseAlpha(*args, **kwargs)

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -90,7 +90,7 @@ def solarize_(image, threshold=128):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)`.
+        See :func:`~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)`.
 
     Parameters
     ----------
@@ -119,7 +119,7 @@ def solarize(image, threshold=128):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)`.
+        See :func:`~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)`.
 
     Parameters
     ----------
@@ -147,7 +147,7 @@ def posterize_(image, bits):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.quantize_uniform_to_n_bits_.
+        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits_.
 
     Parameters
     ----------
@@ -175,7 +175,7 @@ def posterize(image, bits):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.color.quantize_uniform_to_n_bits`.
+        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits`.
 
     Parameters
     ----------
@@ -198,14 +198,14 @@ def posterize(image, bits):
 def equalize(image, mask=None):
     """Equalize the image histogram.
 
-    See :func:`imgaug.augmenters.pillike.equalize_` for details.
+    See :func:`~imgaug.augmenters.pillike.equalize_` for details.
 
     This function is identical in inputs and outputs to
     :func:`PIL.ImageOps.equalize`.
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pil.pil_equalize_`.
+        See :func:`~imgaug.augmenters.pil.pil_equalize_`.
 
     Parameters
     ----------
@@ -1223,24 +1223,24 @@ class Solarize(arithmetic.Invert):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.arithmetic.Invert`.
+        See :func:`~imgaug.augmenters.arithmetic.Invert`.
 
     Parameters
     ----------
     p : float or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.arithmetic.Invert`.
+        See :class:`~imgaug.augmenters.arithmetic.Invert`.
 
     threshold : None or number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.arithmetic.Invert`.
+        See :class:`~imgaug.augmenters.arithmetic.Invert`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1268,14 +1268,14 @@ class Posterize(colorlib.Posterize):
     This augmenter quantizes each array component to ``N`` bits.
 
     This class is currently an alias for
-    :class:`imgaug.augmenters.color.Posterize`, which again is an alias
-    for :class:`imgaug.augmenters.color.UniformColorQuantizationToNBits`,
+    :class:`~imgaug.augmenters.color.Posterize`, which again is an alias
+    for :class:`~imgaug.augmenters.color.UniformColorQuantizationToNBits`,
     i.e. all three classes are right now guarantueed to have the same
     outputs as PIL's function.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.color.Posterize`.
+        See :class:`~imgaug.augmenters.color.Posterize`.
 
     """
 
@@ -1287,18 +1287,18 @@ class Equalize(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.equalize_`.
+        See :func:`~imgaug.augmenters.pillike.equalize_`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1321,7 +1321,7 @@ class Equalize(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
 
 
@@ -1330,11 +1330,11 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
 
     This augmenter has identical outputs to :func:`PIL.ImageOps.autocontrast`.
 
-    See :func:`imgaug.augmenters.pillike.autocontrast` for more details.
+    See :func:`~imgaug.augmenters.pillike.autocontrast` for more details.
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.autocontrast`.
+        See :func:`~imgaug.augmenters.pillike.autocontrast`.
 
     Parameters
     ----------
@@ -1357,13 +1357,13 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
         be treated as ``True``, otherwise as ``False``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1429,7 +1429,7 @@ class _EnhanceBase(meta.Augmenter):
         return self.factor.draw_samples((nb_rows,), random_state=random_state)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.factor]
 
 
@@ -1440,7 +1440,7 @@ class EnhanceColor(_EnhanceBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.enhance_color`.
+        See :func:`~imgaug.augmenters.pillike.enhance_color`.
 
     Parameters
     ----------
@@ -1458,13 +1458,13 @@ class EnhanceColor(_EnhanceBase):
               parameter will be queried once to return ``(N,)`` samples.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1492,7 +1492,7 @@ class EnhanceContrast(_EnhanceBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.enhance_contrast`.
+        See :func:`~imgaug.augmenters.pillike.enhance_contrast`.
 
     Parameters
     ----------
@@ -1511,13 +1511,13 @@ class EnhanceContrast(_EnhanceBase):
               parameter will be queried once to return ``(N,)`` samples.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1546,7 +1546,7 @@ class EnhanceBrightness(_EnhanceBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.enhance_brightness`.
+        See :func:`~imgaug.augmenters.pillike.enhance_brightness`.
 
     Parameters
     ----------
@@ -1564,13 +1564,13 @@ class EnhanceBrightness(_EnhanceBase):
               parameter will be queried once to return ``(N,)`` samples.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1599,7 +1599,7 @@ class EnhanceSharpness(_EnhanceBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.enhance_sharpness`.
+        See :func:`~imgaug.augmenters.pillike.enhance_sharpness`.
 
     Parameters
     ----------
@@ -1617,13 +1617,13 @@ class EnhanceSharpness(_EnhanceBase):
               parameter will be queried once to return ``(N,)`` samples.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1661,7 +1661,7 @@ class _FilterBase(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
 
 
@@ -1673,18 +1673,18 @@ class FilterBlur(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_blur`.
+        See :func:`~imgaug.augmenters.pillike.filter_blur`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1709,18 +1709,18 @@ class FilterSmooth(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_smooth`.
+        See :func:`~imgaug.augmenters.pillike.filter_smooth`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1745,18 +1745,18 @@ class FilterSmoothMore(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_smooth_more`.
+        See :func:`~imgaug.augmenters.pillike.filter_smooth_more`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1783,18 +1783,18 @@ class FilterEdgeEnhance(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_edge_enhance`.
+        See :func:`~imgaug.augmenters.pillike.filter_edge_enhance`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1821,18 +1821,18 @@ class FilterEdgeEnhanceMore(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_edge_enhance_more`.
+        See :func:`~imgaug.augmenters.pillike.filter_edge_enhance_more`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1859,18 +1859,18 @@ class FilterFindEdges(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_find_edges`.
+        See :func:`~imgaug.augmenters.pillike.filter_find_edges`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1895,18 +1895,18 @@ class FilterContour(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_contour`.
+        See :func:`~imgaug.augmenters.pillike.filter_contour`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1932,18 +1932,18 @@ class FilterEmboss(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_emboss`.
+        See :func:`~imgaug.augmenters.pillike.filter_emboss`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1968,18 +1968,18 @@ class FilterSharpen(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_sharpen`.
+        See :func:`~imgaug.augmenters.pillike.filter_sharpen`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2004,18 +2004,18 @@ class FilterDetail(_FilterBase):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.filter_detail`.
+        See :func:`~imgaug.augmenters.pillike.filter_detail`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2044,7 +2044,7 @@ class Affine(geometric.Affine):
         This augmenter can currently only transform image-data.
         Batches containing heatmaps, segmentation maps and
         coordinate-based augmentables will be rejected with an error.
-        Use :class:`imgaug.augmenters.geometric.Affine` if you have to
+        Use :class:`~imgaug.augmenters.geometric.Affine` if you have to
         transform such inputs.
 
     .. note ::
@@ -2057,27 +2057,27 @@ class Affine(geometric.Affine):
 
     dtype support::
 
-        See :func:`imgaug.augmenters.pillike.warp_affine`.
+        See :func:`~imgaug.augmenters.pillike.warp_affine`.
 
     Parameters
     ----------
     scale : number or tuple of number or list of number or imgaug.parameters.StochasticParameter or dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter}, optional
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     translate_percent : None or number or tuple of number or list of number or imgaug.parameters.StochasticParameter or dict {"x": number/tuple/list/StochasticParameter, "y": number/tuple/list/StochasticParameter}, optional
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     translate_px : None or int or tuple of int or list of int or imgaug.parameters.StochasticParameter or dict {"x": int/tuple/list/StochasticParameter, "y": int/tuple/list/StochasticParameter}, optional
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     rotate : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     shear : number or tuple of number or list of number or imgaug.parameters.StochasticParameter or dict {"x": int/tuple/list/StochasticParameter, "y": int/tuple/list/StochasticParameter}, optional
-        See :class:`imgaug.augmenters.geometric.Affine`.
+        See :class:`~imgaug.augmenters.geometric.Affine`.
 
     fillcolor : number or tuple of number or list of number or imgaug.ALL or imgaug.parameters.StochasticParameter, optional
-        See parameter ``cval`` in :class:`imgaug.augmenters.geometric.Affine`.
+        See parameter ``cval`` in :class:`~imgaug.augmenters.geometric.Affine`.
 
     center : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         The center point of the affine transformation, given as relative
@@ -2087,17 +2087,17 @@ class Affine(geometric.Affine):
         Set this to ``(0.5, 0.5)`` or ``center-center`` to use the image
         center as the transformation center.
         See also paramerer ``position`` in
-        :class:`imgaug.augmenters.size.PadToFixedSize` for details
+        :class:`~imgaug.augmenters.size.PadToFixedSize` for details
         about valid datatypes of this parameter.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2121,7 +2121,7 @@ class Affine(geometric.Affine):
     Rotate an image by ``-20`` to ``20`` degress and fill up all newly
     created pixels with a random RGB color.
 
-    See the similar augmenter :class:`imgaug.augmenters.geometric.Affine`
+    See the similar augmenter :class:`~imgaug.augmenters.geometric.Affine`
     for more examples.
 
     """
@@ -2209,7 +2209,7 @@ class Affine(geometric.Affine):
         return samples
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [
             self.scale, self.translate, self.rotate, self.shear, self.cval,
             self.center]

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -178,7 +178,7 @@ class _AbstractPoolingBase(meta.Augmenter):
                                                   func)
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.kernel_size, self.keep_size]
 
 
@@ -209,7 +209,7 @@ class AveragePooling(_AbstractPoolingBase):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.avg_pool`.
+        See :func:`~imgaug.imgaug.avg_pool`.
 
     Attributes
     ----------
@@ -244,13 +244,13 @@ class AveragePooling(_AbstractPoolingBase):
         identical to the input shape.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -320,7 +320,7 @@ class MaxPooling(_AbstractPoolingBase):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.max_pool`.
+        See :func:`~imgaug.imgaug.max_pool`.
 
     Attributes
     ----------
@@ -355,13 +355,13 @@ class MaxPooling(_AbstractPoolingBase):
         identical to the input shape.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -433,7 +433,7 @@ class MinPooling(_AbstractPoolingBase):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pool`.
+        See :func:`~imgaug.imgaug.pool`.
 
     Attributes
     ----------
@@ -468,13 +468,13 @@ class MinPooling(_AbstractPoolingBase):
         identical to the input shape.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -546,7 +546,7 @@ class MedianPooling(_AbstractPoolingBase):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pool`.
+        See :func:`~imgaug.imgaug.pool`.
 
     Attributes
     ----------
@@ -581,13 +581,13 @@ class MedianPooling(_AbstractPoolingBase):
         identical to the input shape.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -39,7 +39,7 @@ def _ensure_image_max_size(image, max_size, interpolation):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.imresize_single_image`.
+        See :func:`~imgaug.imgaug.imresize_single_image`.
 
     Parameters
     ----------
@@ -50,7 +50,7 @@ def _ensure_image_max_size(image, max_size, interpolation):
         Maximum length of any side of the image.
 
     interpolation : string or int
-        See :func:`imgaug.imgaug.imresize_single_image`.
+        See :func:`~imgaug.imgaug.imresize_single_image`.
 
     """
     if max_size is not None:
@@ -104,7 +104,7 @@ class Superpixels(meta.Augmenter):
 
             minimum of (
                 ``imgaug.augmenters.segmentation.Superpixels(image size <= max_size)``,
-                :func:`imgaug.augmenters.segmentation._ensure_image_max_size`
+                :func:`~imgaug.augmenters.segmentation._ensure_image_max_size`
             )
 
     Parameters
@@ -165,16 +165,16 @@ class Superpixels(meta.Augmenter):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -308,7 +308,7 @@ class Superpixels(meta.Augmenter):
         return image_sp
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p_replace, self.n_segments, self.max_size,
                 self.interpolation]
 
@@ -476,7 +476,7 @@ class Voronoi(meta.Augmenter):
 
             minimum of (
                 ``imgaug.augmenters.segmentation.Voronoi(image size <= max_size)``,
-                :func:`imgaug.augmenters.segmentation._ensure_image_max_size`
+                :func:`~imgaug.augmenters.segmentation._ensure_image_max_size`
             )
 
     Parameters
@@ -526,16 +526,16 @@ class Voronoi(meta.Augmenter):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -632,7 +632,7 @@ class Voronoi(meta.Augmenter):
         return image_aug
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.points_sampler, self.p_replace, self.max_size,
                 self.interpolation]
 
@@ -641,8 +641,8 @@ class UniformVoronoi(Voronoi):
     """Uniformly sample Voronoi cells on images and average colors within them.
 
     This augmenter is a shortcut for the combination of
-    :class:`imgaug.augmenters.segmentation.Voronoi` with
-    :class:`imgaug.augmenters.segmentation.UniformPointsSampler`. Hence, it
+    :class:`~imgaug.augmenters.segmentation.Voronoi` with
+    :class:`~imgaug.augmenters.segmentation.UniformPointsSampler`. Hence, it
     generates a fixed amount of ``N`` random coordinates of voronoi cells on
     each image. The cell coordinates are sampled uniformly using the image
     height and width as maxima.
@@ -705,16 +705,16 @@ class UniformVoronoi(Voronoi):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -757,9 +757,9 @@ class RegularGridVoronoi(Voronoi):
     """Sample Voronoi cells from regular grids and color-average them.
 
     This augmenter is a shortcut for the combination of
-    :class:`imgaug.augmenters.segmentation.Voronoi`,
-    :class:`imgaug.augmenters.segmentation.RegularGridPointsSampler` and
-    :class:`imgaug.augmenters.segmentation.DropoutPointsSampler`. Hence, it
+    :class:`~imgaug.augmenters.segmentation.Voronoi`,
+    :class:`~imgaug.augmenters.segmentation.RegularGridPointsSampler` and
+    :class:`~imgaug.augmenters.segmentation.DropoutPointsSampler`. Hence, it
     generates a regular grid with ``R`` rows and ``C`` columns of coordinates
     on each image. Then, it drops ``p`` percent of the ``R*C`` coordinates
     to randomize the grid. Each image pixel then belongs to the voronoi
@@ -860,16 +860,16 @@ class RegularGridVoronoi(Voronoi):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -916,9 +916,9 @@ class RelativeRegularGridVoronoi(Voronoi):
     """Sample Voronoi cells from image-dependent grids and color-average them.
 
     This augmenter is a shortcut for the combination of
-    :class:`imgaug.augmenters.segmentation.Voronoi`,
-    :class:`imgaug.augmenters.segmentation.RegularGridPointsSampler` and
-    :class:`imgaug.augmenters.segmentation.DropoutPointsSampler`. Hence, it
+    :class:`~imgaug.augmenters.segmentation.Voronoi`,
+    :class:`~imgaug.augmenters.segmentation.RegularGridPointsSampler` and
+    :class:`~imgaug.augmenters.segmentation.DropoutPointsSampler`. Hence, it
     generates a regular grid with ``R`` rows and ``C`` columns of coordinates
     on each image. Then, it drops ``p`` percent of the ``R*C`` coordinates
     to randomize the grid. Each image pixel then belongs to the voronoi
@@ -1029,16 +1029,16 @@ class RelativeRegularGridVoronoi(Voronoi):
     interpolation : int or str, optional
         Interpolation method to use during downscaling when `max_size` is
         exceeded. Valid methods are the same as in
-        :func:`imgaug.imgaug.imresize_single_image`.
+        :func:`~imgaug.imgaug.imresize_single_image`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1092,7 +1092,7 @@ class IPointsSampler(object):
 
     Point samplers return coordinate arrays of shape ``Nx2``.
     These coordinates can be used in other augmenters, see e.g.
-    :class:`imgaug.augmenters.segmentation.Voronoi`.
+    :class:`~imgaug.augmenters.segmentation.Voronoi`.
 
     """
 
@@ -1113,7 +1113,7 @@ class IPointsSampler(object):
         random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState
             A random state to use for any probabilistic function required
             during the point sampling.
-            See :func:`imgaug.random.RNG` for details.
+            See :func:`~imgaug.random.RNG` for details.
 
         Returns
         -------

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -551,13 +551,13 @@ def pad_to_aspect_ratio(arr, aspect_ratio, mode="constant", cval=0,
                         return_pad_amounts=False):
     """Pad an image array on its sides so that it matches a target aspect ratio.
 
-    See :func:`imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
+    See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required padding amounts are distributed per
     image axis.
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pad`.
+        See :func:`~imgaug.imgaug.pad`.
 
     Parameters
     ----------
@@ -569,7 +569,7 @@ def pad_to_aspect_ratio(arr, aspect_ratio, mode="constant", cval=0,
         image having twice as much width as height.
 
     mode : str, optional
-        Padding mode to use. See :func:`imgaug.imgaug.pad` for details.
+        Padding mode to use. See :func:`~imgaug.imgaug.pad` for details.
 
     cval : number, optional
         Value to use for padding if `mode` is ``constant``.
@@ -617,13 +617,13 @@ def pad_to_multiples_of(arr, height_multiple, width_multiple, mode="constant",
                         cval=0, return_pad_amounts=False):
     """Pad an image array until its side lengths are multiples of given values.
 
-    See :func:`imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
+    See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required padding amounts are distributed per
     image axis.
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pad`.
+        See :func:`~imgaug.imgaug.pad`.
 
     Parameters
     ----------
@@ -641,7 +641,7 @@ def pad_to_multiples_of(arr, height_multiple, width_multiple, mode="constant",
         of this value.
 
     mode : str, optional
-        Padding mode to use. See :func:`imgaug.imgaug.pad` for details.
+        Padding mode to use. See :func:`~imgaug.imgaug.pad` for details.
 
     cval : number, optional
         Value to use for padding if `mode` is ``constant``.
@@ -827,7 +827,7 @@ def compute_paddings_to_reach_multiples_of(arr, height_multiple,
                                            width_multiple):
     """Compute pad amounts until img height/width are multiples of given values.
 
-    See :func:`imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
+    See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required padding amounts are distributed per
     image axis.
 
@@ -888,7 +888,7 @@ def compute_croppings_to_reach_multiples_of(arr, height_multiple,
                                             width_multiple):
     """Compute croppings to reach multiples of given heights/widths.
 
-    See :func:`imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
+    See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required cropping amounts are distributed per
     image axis.
 
@@ -953,7 +953,7 @@ def compute_paddings_to_reach_powers_of(arr, height_base, width_base,
     this function computes paddings that fulfill ``S' = B^E``, where ``E``
     is any exponent from the discrete interval ``[0 .. inf)``.
 
-    See :func:`imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
+    See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required padding amounts are distributed per
     image axis.
 
@@ -1022,7 +1022,7 @@ def compute_croppings_to_reach_powers_of(arr, height_base, width_base,
     this function computes croppings that fulfill ``S' = B^E``, where ``E``
     is any exponent from the discrete interval ``[0 .. inf)``.
 
-    See :func:`imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
+    See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required cropping amounts are distributed per
     image axis.
 
@@ -1103,7 +1103,7 @@ class Resize(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.imresize_many_images`.
+        See :func:`~imgaug.imgaug.imresize_many_images`.
 
     Parameters
     ----------
@@ -1159,13 +1159,13 @@ class Resize(meta.Augmenter):
               ``str``.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1490,7 +1490,7 @@ class Resize(meta.Augmenter):
         return h, w
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.size, self.interpolation, self.size_order]
 
 
@@ -1555,7 +1555,7 @@ class CropAndPad(meta.Augmenter):
 
             minimum of (
                 ``imgaug.augmenters.size.CropAndPad(keep_size=False)``,
-                :func:`imgaug.imgaug.imresize_many_images`
+                :func:`~imgaug.imgaug.imresize_many_images`
             )
 
     Parameters
@@ -1624,7 +1624,7 @@ class CropAndPad(meta.Augmenter):
         i.e. ``constant``, ``edge``, ``linear_ramp``, ``maximum``, ``median``,
         ``minimum``, ``reflect``, ``symmetric``, ``wrap``. The modes
         ``constant`` and ``linear_ramp`` use extra values, which are provided
-        by ``pad_cval`` when necessary. See :func:`imgaug.imgaug.pad` for
+        by ``pad_cval`` when necessary. See :func:`~imgaug.imgaug.pad` for
         more details.
 
             * If ``imgaug.ALL``, then a random mode from all available modes
@@ -1638,7 +1638,7 @@ class CropAndPad(meta.Augmenter):
     pad_cval : number or tuple of number list of number or imgaug.parameters.StochasticParameter, optional
         The constant value to use if the pad mode is ``constant`` or the end
         value to use if the mode is ``linear_ramp``.
-        See :func:`imgaug.imgaug.pad` for more details.
+        See :func:`~imgaug.imgaug.pad` for more details.
 
             * If ``number``, then that value will be used.
             * If a ``tuple`` of two ``number`` s and at least one of them is
@@ -1666,13 +1666,13 @@ class CropAndPad(meta.Augmenter):
         If ``True``, four values will be sampled independently, one per side.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2113,7 +2113,7 @@ class CropAndPad(meta.Augmenter):
         return result
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.all_sides, self.top, self.right, self.bottom, self.left,
                 self.pad_mode, self.pad_cval]
 
@@ -2192,7 +2192,7 @@ class Pad(CropAndPad):
         i.e. ``constant``, ``edge``, ``linear_ramp``, ``maximum``, ``median``,
         ``minimum``, ``reflect``, ``symmetric``, ``wrap``. The modes
         ``constant`` and ``linear_ramp`` use extra values, which are provided
-        by ``pad_cval`` when necessary. See :func:`imgaug.imgaug.pad` for
+        by ``pad_cval`` when necessary. See :func:`~imgaug.imgaug.pad` for
         more details.
 
             * If ``imgaug.ALL``, then a random mode from all available modes
@@ -2206,7 +2206,7 @@ class Pad(CropAndPad):
     pad_cval : number or tuple of number list of number or imgaug.parameters.StochasticParameter, optional
         The constant value to use if the pad mode is ``constant`` or the end
         value to use if the mode is ``linear_ramp``.
-        See :func:`imgaug.imgaug.pad` for more details.
+        See :func:`~imgaug.imgaug.pad` for more details.
 
             * If ``number``, then that value will be used.
             * If a ``tuple`` of two ``number`` s and at least one of them is
@@ -2234,13 +2234,13 @@ class Pad(CropAndPad):
         If ``True``, four values will be sampled independently, one per side.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2431,13 +2431,13 @@ class Crop(CropAndPad):
         If ``True``, four values will be sampled independently, one per side.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2536,7 +2536,7 @@ class PadToFixedSize(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pad`.
+        See :func:`~imgaug.imgaug.pad`.
 
     Parameters
     ----------
@@ -2549,10 +2549,10 @@ class PadToFixedSize(meta.Augmenter):
         If ``None``, image heights will not be altered.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.CropAndPad.__init__`.
+        See :func:`~imgaug.augmenters.size.CropAndPad.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.CropAndPad.__init__`.
+        See :func:`~imgaug.augmenters.size.CropAndPad.__init__`.
 
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         Sets the center point of the padding, which determines how the
@@ -2597,13 +2597,13 @@ class PadToFixedSize(meta.Augmenter):
               second for ``y`` coordinates.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2814,7 +2814,7 @@ class PadToFixedSize(meta.Augmenter):
         return pad_top, pad_right, pad_bottom, pad_left
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.size[0], self.size[1], self.pad_mode, self.pad_cval,
                 self.position]
 
@@ -2822,14 +2822,14 @@ class PadToFixedSize(meta.Augmenter):
 class CenterPadToFixedSize(PadToFixedSize):
     """Pad images equally on all sides up to given minimum heights/widths.
 
-    This is an alias for :class:`imgaug.augmenters.size.PadToFixedSize`
+    This is an alias for :class:`~imgaug.augmenters.size.PadToFixedSize`
     with ``position="center"``. It spreads the pad amounts equally over
-    all image sides, while :class:`imgaug.augmenters.size.PadToFixedSize`
+    all image sides, while :class:`~imgaug.augmenters.size.PadToFixedSize`
     by defaults spreads them randomly.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -2846,13 +2846,13 @@ class CenterPadToFixedSize(PadToFixedSize):
         See :func:`PadToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -2958,13 +2958,13 @@ class CropToFixedSize(meta.Augmenter):
               second for ``y`` coordinates.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3128,14 +3128,14 @@ class CropToFixedSize(meta.Augmenter):
         return [self.size] * nb_images, offset_xs, offset_ys
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.size[0], self.size[1], self.position]
 
 
 class CenterCropToFixedSize(CropToFixedSize):
     """Take a crop from the center of each image.
 
-    This is an alias for :class:`imgaug.augmenters.size.CropToFixedSize` with
+    This is an alias for :class:`~imgaug.augmenters.size.CropToFixedSize` with
     ``position="center"``.
 
     .. note::
@@ -3147,7 +3147,7 @@ class CenterCropToFixedSize(CropToFixedSize):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3158,13 +3158,13 @@ class CenterCropToFixedSize(CropToFixedSize):
         See :func:`CropToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3195,7 +3195,7 @@ class CropToMultiplesOf(CropToFixedSize):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3213,13 +3213,13 @@ class CropToMultiplesOf(CropToFixedSize):
         See :func:`CropToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3268,22 +3268,22 @@ class CropToMultiplesOf(CropToFixedSize):
         return sizes, offset_xs, offset_ys
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_multiple, self.height_multiple, self.position]
 
 
 class CenterCropToMultiplesOf(CropToMultiplesOf):
     """Crop images equally on all sides until H/W are multiples of given values.
 
-    This is the same as :class:`imgaug.augmenters.size.CropToMultiplesOf`,
+    This is the same as :class:`~imgaug.augmenters.size.CropToMultiplesOf`,
     but uses ``position="center"`` by default, which spreads the crop amounts
     equally over all image sides, while
-    :class:`imgaug.augmenters.size.CropToMultiplesOf` by default spreads
+    :class:`~imgaug.augmenters.size.CropToMultiplesOf` by default spreads
     them randomly.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3294,13 +3294,13 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
         See :func:`CropToMultiplesOf.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3329,7 +3329,7 @@ class PadToMultiplesOf(PadToFixedSize):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3344,22 +3344,22 @@ class PadToMultiplesOf(PadToFixedSize):
         If ``None``, image heights will not be altered.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`PadToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3411,7 +3411,7 @@ class PadToMultiplesOf(PadToFixedSize):
         return sizes, pad_xs, pad_ys, pad_modes, pad_cvals
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_multiple, self.height_multiple,
                 self.pad_mode, self.pad_cval,
                 self.position]
@@ -3420,15 +3420,15 @@ class PadToMultiplesOf(PadToFixedSize):
 class CenterPadToMultiplesOf(PadToMultiplesOf):
     """Pad images equally on all sides until H/W are multiples of given values.
 
-    This is the same as :class:`imgaug.augmenters.size.PadToMultiplesOf`, but
+    This is the same as :class:`~imgaug.augmenters.size.PadToMultiplesOf`, but
     uses ``position="center"`` by default, which spreads the pad amounts
     equally over all image sides, while
-    :class:`imgaug.augmenters.size.PadToMultiplesOf` by default spreads them
+    :class:`~imgaug.augmenters.size.PadToMultiplesOf` by default spreads them
     randomly.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3439,19 +3439,19 @@ class CenterPadToMultiplesOf(PadToMultiplesOf):
         See :func:`PadToMultiplesOf.__init__`.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToMultiplesOf.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToMultiplesOf.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToMultiplesOf.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToMultiplesOf.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3495,7 +3495,7 @@ class CropToPowersOf(CropToFixedSize):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3515,13 +3515,13 @@ class CropToPowersOf(CropToFixedSize):
         See :func:`CropToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3570,22 +3570,22 @@ class CropToPowersOf(CropToFixedSize):
         return sizes, offset_xs, offset_ys
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_base, self.height_base, self.position]
 
 
 class CenterCropToPowersOf(CropToPowersOf):
     """Crop images equally on all sides until H/W is a power of a base.
 
-    This is the same as :class:`imgaug.augmenters.size.CropToPowersOf`, but
+    This is the same as :class:`~imgaug.augmenters.size.CropToPowersOf`, but
     uses ``position="center"`` by default, which spreads the crop amounts
     equally over all image sides, while
-    :class:`imgaug.augmenters.size.CropToPowersOf` by default spreads them
+    :class:`~imgaug.augmenters.size.CropToPowersOf` by default spreads them
     randomly.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3596,13 +3596,13 @@ class CenterCropToPowersOf(CropToPowersOf):
         See :func:`CropToPowersOf.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3634,7 +3634,7 @@ class PadToPowersOf(PadToFixedSize):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3651,22 +3651,22 @@ class PadToPowersOf(PadToFixedSize):
         If ``None``, image heights will not be altered.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`PadToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3718,7 +3718,7 @@ class PadToPowersOf(PadToFixedSize):
         return sizes, pad_xs, pad_ys, pad_modes, pad_cvals
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_base, self.height_base,
                 self.pad_mode, self.pad_cval,
                 self.position]
@@ -3727,14 +3727,14 @@ class PadToPowersOf(PadToFixedSize):
 class CenterPadToPowersOf(PadToPowersOf):
     """Pad images equally on all sides until H/W is a power of a base.
 
-    This is the same as :class:`imgaug.augmenters.size.PadToPowersOf`, but uses
+    This is the same as :class:`~imgaug.augmenters.size.PadToPowersOf`, but uses
     ``position="center"`` by default, which spreads the pad amounts equally
-    over all image sides, while :class:`imgaug.augmenters.size.PadToPowersOf`
+    over all image sides, while :class:`~imgaug.augmenters.size.PadToPowersOf`
     by default spreads them randomly.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3745,19 +3745,19 @@ class CenterPadToPowersOf(PadToPowersOf):
         See :func:`PadToPowersOf.__init__`.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToPowersOf.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToPowersOf.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToPowersOf.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToPowersOf.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3793,7 +3793,7 @@ class CropToAspectRatio(CropToFixedSize):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3805,13 +3805,13 @@ class CropToAspectRatio(CropToFixedSize):
         See :func:`CropToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3862,22 +3862,22 @@ class CropToAspectRatio(CropToFixedSize):
         return sizes, offset_xs, offset_ys
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.aspect_ratio, self.position]
 
 
 class CenterCropToAspectRatio(CropToAspectRatio):
     """Crop images equally on all sides until they reach an aspect ratio.
 
-    This is the same as :class:`imgaug.augmenters.size.CropToAspectRatio`, but
+    This is the same as :class:`~imgaug.augmenters.size.CropToAspectRatio`, but
     uses ``position="center"`` by default, which spreads the crop amounts
     equally over all image sides, while
-    :class:`imgaug.augmenters.size.CropToAspectRatio` by default spreads
+    :class:`~imgaug.augmenters.size.CropToAspectRatio` by default spreads
     them randomly.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3885,13 +3885,13 @@ class CenterCropToAspectRatio(CropToAspectRatio):
         See :func:`CropToAspectRatio.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3921,7 +3921,7 @@ class PadToAspectRatio(PadToFixedSize):
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3933,19 +3933,19 @@ class PadToAspectRatio(PadToFixedSize):
         See :func:`PadToFixedSize.__init__`.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -3995,7 +3995,7 @@ class PadToAspectRatio(PadToFixedSize):
         return sizes, pad_xs, pad_ys, pad_modes, pad_cvals
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.aspect_ratio, self.pad_mode, self.pad_cval,
                 self.position]
 
@@ -4003,15 +4003,15 @@ class PadToAspectRatio(PadToFixedSize):
 class CenterPadToAspectRatio(PadToAspectRatio):
     """Pad images equally on all sides until H/W matches an aspect ratio.
 
-    This is the same as :class:`imgaug.augmenters.size.PadToAspectRatio`, but
+    This is the same as :class:`~imgaug.augmenters.size.PadToAspectRatio`, but
     uses ``position="center"`` by default, which spreads the pad amounts
     equally over all image sides, while
-    :class:`imgaug.augmenters.size.PadToAspectRatio` by default spreads them
+    :class:`~imgaug.augmenters.size.PadToAspectRatio` by default spreads them
     randomly.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -4019,19 +4019,19 @@ class CenterPadToAspectRatio(PadToAspectRatio):
         See :func:`PadToAspectRatio.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToAspectRatio.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToAspectRatio.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToAspectRatio.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToAspectRatio.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4057,14 +4057,14 @@ class CenterPadToAspectRatio(PadToAspectRatio):
 class CropToSquare(CropToAspectRatio):
     """Crop images until their width and height are identical.
 
-    This is identical to :class:`imgaug.augmenters.size.CropToAspectRatio`
+    This is identical to :class:`~imgaug.augmenters.size.CropToAspectRatio`
     with ``aspect_ratio=1.0``.
 
     Images with axis sizes of ``0`` will not be altered.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -4072,13 +4072,13 @@ class CropToSquare(CropToAspectRatio):
         See :func:`CropToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4102,33 +4102,33 @@ class CropToSquare(CropToAspectRatio):
 class CenterCropToSquare(CropToSquare):
     """Crop images equally on all sides until their height/width are identical.
 
-    In contrast to :class:`imgaug.augmenters.size.CropToSquare`, this
+    In contrast to :class:`~imgaug.augmenters.size.CropToSquare`, this
     augmenter always tries to spread the columns/rows to remove equally over
     both sides of the respective axis to be cropped.
-    :class:`imgaug.augmenters.size.CropToAspectRatio` by default spreads the
+    :class:`~imgaug.augmenters.size.CropToAspectRatio` by default spreads the
     croppings randomly.
 
-    This augmenter is identical to :class:`imgaug.augmenters.size.CropToSquare`
+    This augmenter is identical to :class:`~imgaug.augmenters.size.CropToSquare`
     with ``position="center"``, and thereby the same as
-    :class:`imgaug.augmenters.size.CropToAspectRatio` with
+    :class:`~imgaug.augmenters.size.CropToAspectRatio` with
     ``aspect_ratio=1.0, position="center"``.
 
     Images with axis sizes of ``0`` will not be altered.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.CropToFixedSize`.
+        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4152,11 +4152,11 @@ class PadToSquare(PadToAspectRatio):
     """Pad images until their height and width are identical.
 
     This augmenter is identical to
-    :class:`imgaug.augmenters.size.PadToAspectRatio` with ``aspect_ratio=1.0``.
+    :class:`~imgaug.augmenters.size.PadToAspectRatio` with ``aspect_ratio=1.0``.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -4164,19 +4164,19 @@ class PadToSquare(PadToAspectRatio):
         See :func:`PadToFixedSize.__init__`.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToFixedSize.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4201,33 +4201,33 @@ class PadToSquare(PadToAspectRatio):
 class CenterPadToSquare(PadToSquare):
     """Pad images equally on all sides until their height & width are identical.
 
-    This is the same as :class:`imgaug.augmenters.size.PadToSquare`, but uses
+    This is the same as :class:`~imgaug.augmenters.size.PadToSquare`, but uses
     ``position="center"`` by default, which spreads the pad amounts equally
-    over all image sides, while :class:`imgaug.augmenters.size.PadToSquare`
+    over all image sides, while :class:`~imgaug.augmenters.size.PadToSquare`
     by default spreads them randomly. This augmenter is thus also identical to
-    :class:`imgaug.augmenters.size.PadToAspectRatio` with
+    :class:`~imgaug.augmenters.size.PadToAspectRatio` with
     ``aspect_ratio=1.0, position="center"``.
 
     dtype support::
 
-        See :class:`imgaug.augmenters.size.PadToFixedSize`.
+        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     pad_mode : imgaug.ALL or str or list of str or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToAspectRatio.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToAspectRatio.__init__`.
 
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
-        See :func:`imgaug.augmenters.size.PadToAspectRatio.__init__`.
+        See :func:`~imgaug.augmenters.size.PadToAspectRatio.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4260,7 +4260,7 @@ class KeepSizeByResize(meta.Augmenter):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.imresize_many_images`.
+        See :func:`~imgaug.imgaug.imresize_many_images`.
 
     Parameters
     ----------
@@ -4270,7 +4270,7 @@ class KeepSizeByResize(meta.Augmenter):
 
     interpolation : KeepSizeByResize.NO_RESIZE or {'nearest', 'linear', 'area', 'cubic'} or {cv2.INTER_NEAREST, cv2.INTER_LINEAR, cv2.INTER_AREA, cv2.INTER_CUBIC} or list of str or list of int or StochasticParameter, optional
         The interpolation mode to use when resizing images.
-        Can take any value that :func:`imgaug.imgaug.imresize_single_image`
+        Can take any value that :func:`~imgaug.imgaug.imresize_single_image`
         accepts, e.g. ``cubic``.
 
             * If this is ``KeepSizeByResize.NO_RESIZE`` then images will not
@@ -4305,13 +4305,13 @@ class KeepSizeByResize(meta.Augmenter):
         majority of all cases.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -4557,11 +4557,11 @@ class KeepSizeByResize(meta.Augmenter):
         return aug
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.interpolation, self.interpolation_heatmaps]
 
     def get_children_lists(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_children_lists`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
     def __str__(self):

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -78,16 +78,16 @@ class FastSnowyLandscape(meta.Augmenter):
 
     from_colorspace : str, optional
         The source colorspace of the input images.
-        See :func:`imgaug.augmenters.color.ChangeColorspace.__init__`.
+        See :func:`~imgaug.augmenters.color.ChangeColorspace.__init__`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -175,7 +175,7 @@ class FastSnowyLandscape(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.lightness_threshold, self.lightness_multiplier]
 
 
@@ -206,7 +206,7 @@ class CloudLayer(meta.Augmenter):
         - (2) Note that random values are usually sampled as ``int64`` or
               ``float64``, which ``float128`` images would exceed. Note also
               that random values might have to upscaled, which is done
-              via :func:`imgaug.imgaug.imresize_many_images` and has its own
+              via :func:`~imgaug.imgaug.imresize_many_images` and has its own
               limited dtype support (includes however floats up to ``64bit``).
 
     Parameters
@@ -227,7 +227,7 @@ class CloudLayer(meta.Augmenter):
         Exponent of the frequency noise used to add fine intensity to the
         mean intensity.
         Recommended to be in the interval ``[-2.5, -1.5]``.
-        See :func:`imgaug.parameters.FrequencyNoise.__init__` for details.
+        See :func:`~imgaug.parameters.FrequencyNoise.__init__` for details.
 
     intensity_coarse_scale : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
         Standard deviation of the gaussian distribution used to add more
@@ -276,14 +276,14 @@ class CloudLayer(meta.Augmenter):
         Controls the image size at which the alpha mask is sampled.
         Lower values will lead to coarser alpha masks and hence larger
         clouds (and empty areas).
-        See :func:`imgaug.parameters.FrequencyNoise.__init__` for details.
+        See :func:`~imgaug.parameters.FrequencyNoise.__init__` for details.
 
     alpha_freq_exponent : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
         Exponent of the frequency noise used to sample the alpha mask.
         Similarly to `alpha_size_max_px`, lower values will lead to coarser
         alpha patterns.
         Recommended to be in the interval ``[-4.0, -1.5]``.
-        See :func:`imgaug.parameters.FrequencyNoise.__init__` for details.
+        See :func:`~imgaug.parameters.FrequencyNoise.__init__` for details.
 
     sparsity : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
         Exponent applied late to the alpha mask. Lower values will lead to
@@ -315,13 +315,13 @@ class CloudLayer(meta.Augmenter):
               per image from that parameter.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -357,7 +357,7 @@ class CloudLayer(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.intensity_mean,
                 self.alpha_min,
                 self.alpha_multiplier,
@@ -479,7 +479,7 @@ class Clouds(meta.SomeOf):
     """
     Add clouds to images.
 
-    This is a wrapper around :class:`imgaug.augmenters.weather.CloudLayer`.
+    This is a wrapper around :class:`~imgaug.augmenters.weather.CloudLayer`.
     It executes 1 to 2 layers per image, leading to varying densities and
     frequency patterns of clouds.
 
@@ -510,13 +510,13 @@ class Clouds(meta.SomeOf):
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -567,7 +567,7 @@ class Clouds(meta.SomeOf):
 class Fog(CloudLayer):
     """Add fog to images.
 
-    This is a wrapper around :class:`imgaug.augmenters.weather.CloudLayer`.
+    This is a wrapper around :class:`~imgaug.augmenters.weather.CloudLayer`.
     It executes a single layer per image with a configuration leading to
     fairly dense clouds with low-frequency patterns.
 
@@ -598,13 +598,13 @@ class Fog(CloudLayer):
     Parameters
     ----------
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -727,7 +727,7 @@ class SnowflakesLayer(meta.Augmenter):
         Angle in degrees of motion blur applied to the snowflakes, where
         ``0.0`` is motion blur that points straight upwards.
         Recommended to be in the interval ``[-30, 30]``.
-        See also :func:`imgaug.augmenters.blur.MotionBlur.__init__`.
+        See also :func:`~imgaug.augmenters.blur.MotionBlur.__init__`.
 
             * If a ``number``, then that value will always be used.
             * If a ``tuple`` ``(a, b)``, then a value will be uniformly sampled
@@ -784,13 +784,13 @@ class SnowflakesLayer(meta.Augmenter):
         values for very small or large images.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -832,7 +832,7 @@ class SnowflakesLayer(meta.Augmenter):
         return batch
 
     def get_parameters(self):
-        """See :func:`imgaug.augmenters.meta.Augmenter.get_parameters`."""
+        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.density,
                 self.density_uniformity,
                 self.flake_size,
@@ -975,7 +975,7 @@ class Snowflakes(meta.SomeOf):
     """Add falling snowflakes to images.
 
     This is a wrapper around
-    :class:`imgaug.augmenters.weather.SnowflakesLayer`. It executes 1 to 3
+    :class:`~imgaug.augmenters.weather.SnowflakesLayer`. It executes 1 to 3
     layers per image.
 
     dtype support::
@@ -1070,7 +1070,7 @@ class Snowflakes(meta.SomeOf):
         Angle in degrees of motion blur applied to the snowflakes, where
         ``0.0`` is motion blur that points straight upwards.
         Recommended to be in the interval ``[-30, 30]``.
-        See also :func:`imgaug.augmenters.blur.MotionBlur.__init__`.
+        See also :func:`~imgaug.augmenters.blur.MotionBlur.__init__`.
 
             * If a ``number``, then that value will always be used.
             * If a ``tuple`` ``(a, b)``, then a value will be uniformly sampled
@@ -1105,13 +1105,13 @@ class Snowflakes(meta.SomeOf):
               per image from that parameter.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------
@@ -1178,39 +1178,39 @@ class RainLayer(SnowflakesLayer):
     Parameters
     ----------
     density : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
-        Same as in :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        Same as in :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     density_uniformity : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
-        Same as in :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        Same as in :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     drop_size : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
         Same as `flake_size` in
-        :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     drop_size_uniformity : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
         Same as `flake_size_uniformity` in
-        :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     angle : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
-        Same as in :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        Same as in :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     speed : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
-        Same as in :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        Same as in :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     blur_sigma_fraction : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
-        Same as in :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        Same as in :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     blur_sigma_limits : tuple of float, optional
-        Same as in :class:`imgaug.augmenters.weather.SnowflakesLayer`.
+        Same as in :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     """
 
@@ -1260,7 +1260,7 @@ class Rain(meta.SomeOf):
     """Add falling snowflakes to images.
 
     This is a wrapper around
-    :class:`imgaug.augmenters.weather.RainLayer`. It executes 1 to 3
+    :class:`~imgaug.augmenters.weather.RainLayer`. It executes 1 to 3
     layers per image.
 
     .. note::
@@ -1295,19 +1295,19 @@ class Rain(meta.SomeOf):
     Parameters
     ----------
     drop_size : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
-        See :class:`imgaug.augmenters.weather.RainLayer`.
+        See :class:`~imgaug.augmenters.weather.RainLayer`.
 
     speed : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
-        See :class:`imgaug.augmenters.weather.RainLayer`.
+        See :class:`~imgaug.augmenters.weather.RainLayer`.
 
     name : None or str, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     deterministic : bool, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`imgaug.augmenters.meta.Augmenter.__init__`.
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
     Examples
     --------

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -477,7 +477,7 @@ def seed(entropy=None, seedval=None):
 
         This function is not yet marked as deprecated, but might be in the
         future. The preferred way to seed `imgaug` is via
-        :func:`imgaug.random.seed`.
+        :func:`~imgaug.random.seed`.
 
     Parameters
     ----------
@@ -513,7 +513,7 @@ def normalize_random_state(random_state):
     Parameters
     ----------
     random_state : None or int or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.bit_generator.SeedSequence or numpy.random.RandomState
-        See :func:`imgaug.random.normalize_generator`.
+        See :func:`~imgaug.random.normalize_generator`.
 
     Returns
     -------
@@ -684,9 +684,9 @@ def _quokka_normalize_extract(extract):
               the image.
             * If a ``tuple``, then expected to contain four ``number`` s
               denoting ``(x1, y1, x2, y2)``.
-            * If a :class:`imgaug.augmentables.bbs.BoundingBox`, then that
+            * If a :class:`~imgaug.augmentables.bbs.BoundingBox`, then that
               bounding box's area will be extracted from the image.
-            * If a :class:`imgaug.augmentables.bbs.BoundingBoxesOnImage`,
+            * If a :class:`~imgaug.augmentables.bbs.BoundingBoxesOnImage`,
               then expected to contain exactly one bounding box and a shape
               matching the full image dimensions (i.e. ``(643, 960, *)``).
               Then the one bounding box will be used similar to
@@ -809,7 +809,7 @@ def quokka(size=None, extract=None):
     ----------
     size : None or float or tuple of int, optional
         Size of the output image. Input into
-        :func:`imgaug.imgaug.imresize_single_image`. Usually expected to be a
+        :func:`~imgaug.imgaug.imresize_single_image`. Usually expected to be a
         ``tuple`` ``(H, W)``, where ``H`` is the desired height and ``W`` is
         the width. If ``None``, then the image will not be resized.
 
@@ -822,9 +822,9 @@ def quokka(size=None, extract=None):
               the image.
             * If a ``tuple``, then expected to contain four ``number`` s
               denoting ``(x1, y1, x2, y2)``.
-            * If a :class:`imgaug.augmentables.bbs.BoundingBox`, then that
+            * If a :class:`~imgaug.augmentables.bbs.BoundingBox`, then that
               bounding box's area will be extracted from the image.
-            * If a :class:`imgaug.augmentables.bbs.BoundingBoxesOnImage`,
+            * If a :class:`~imgaug.augmentables.bbs.BoundingBoxesOnImage`,
               then expected to contain exactly one bounding box and a shape
               matching the full image dimensions (i.e. ``(643, 960, *)``).
               Then the one bounding box will be used similar to
@@ -853,7 +853,7 @@ def quokka_square(size=None):
     ----------
     size : None or float or tuple of int, optional
         Size of the output image. Input into
-        :func:`imgaug.imgaug.imresize_single_image`. Usually expected to be a
+        :func:`~imgaug.imgaug.imresize_single_image`. Usually expected to be a
         ``tuple`` ``(H, W)``, where ``H`` is the desired height and ``W`` is
         the width. If ``None``, then the image will not be resized.
 
@@ -872,10 +872,10 @@ def quokka_heatmap(size=None, extract=None):
     Parameters
     ----------
     size : None or float or tuple of int, optional
-        See :func:`imgaug.imgaug.quokka`.
+        See :func:`~imgaug.imgaug.quokka`.
 
     extract : None or 'square' or tuple of number or imgaug.augmentables.bbs.BoundingBox or imgaug.augmentables.bbs.BoundingBoxesOnImage
-        See :func:`imgaug.imgaug.quokka`.
+        See :func:`~imgaug.imgaug.quokka`.
 
     Returns
     -------
@@ -912,10 +912,10 @@ def quokka_segmentation_map(size=None, extract=None):
     Parameters
     ----------
     size : None or float or tuple of int, optional
-        See :func:`imgaug.imgaug.quokka`.
+        See :func:`~imgaug.imgaug.quokka`.
 
     extract : None or 'square' or tuple of number or imgaug.augmentables.bbs.BoundingBox or imgaug.augmentables.bbs.BoundingBoxesOnImage
-        See :func:`imgaug.imgaug.quokka`.
+        See :func:`~imgaug.imgaug.quokka`.
 
     Returns
     -------
@@ -971,7 +971,7 @@ def quokka_keypoints(size=None, extract=None):
         relative size changes, ``int`` s to absolute sizes in pixels.
 
     extract : None or 'square' or tuple of number or imgaug.augmentables.bbs.BoundingBox or imgaug.augmentables.bbs.BoundingBoxesOnImage
-        Subarea to extract from the image. See :func:`imgaug.imgaug.quokka`.
+        Subarea to extract from the image. See :func:`~imgaug.imgaug.quokka`.
 
     Returns
     -------
@@ -1017,7 +1017,7 @@ def quokka_bounding_boxes(size=None, extract=None):
         to absolute sizes in pixels.
 
     extract : None or 'square' or tuple of number or imgaug.augmentables.bbs.BoundingBox or imgaug.augmentables.bbs.BoundingBoxesOnImage
-        Subarea to extract from the image. See :func:`imgaug.imgaug.quokka`.
+        Subarea to extract from the image. See :func:`~imgaug.imgaug.quokka`.
 
     Returns
     -------
@@ -1071,7 +1071,7 @@ def quokka_polygons(size=None, extract=None):
         ``int`` s to absolute sizes in pixels.
 
     extract : None or 'square' or tuple of number or imgaug.augmentables.bbs.BoundingBox or imgaug.augmentables.bbs.BoundingBoxesOnImage
-        Subarea to extract from the image. See :func:`imgaug.imgaug.quokka`.
+        Subarea to extract from the image. See :func:`~imgaug.imgaug.quokka`.
 
     Returns
     -------
@@ -1585,7 +1585,7 @@ def imresize_single_image(image, sizes, interpolation=None):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.imresize_many_images`.
+        See :func:`~imgaug.imgaug.imresize_many_images`.
 
     Parameters
     ----------
@@ -1594,10 +1594,10 @@ def imresize_single_image(image, sizes, interpolation=None):
         Usually recommended to be of dtype ``uint8``.
 
     sizes : float or iterable of int or iterable of float
-        See :func:`imgaug.imgaug.imresize_many_images`.
+        See :func:`~imgaug.imgaug.imresize_many_images`.
 
     interpolation : None or str or int, optional
-        See :func:`imgaug.imgaug.imresize_many_images`.
+        See :func:`~imgaug.imgaug.imresize_many_images`.
 
     Returns
     -------
@@ -1668,7 +1668,7 @@ def pool(arr, block_size, func, pad_mode="constant", pad_cval=0,
 
     pad_mode : str, optional
         Padding mode to use if the array cannot be divided by `block_size`
-        without remainder. See :func:`imgaug.imgaug.pad` for details.
+        without remainder. See :func:`~imgaug.imgaug.pad` for details.
 
     pad_cval : number, optional
         Value to use for padding if `mode` is ``constant``.
@@ -1754,30 +1754,30 @@ def avg_pool(arr, block_size, pad_mode="reflect", pad_cval=128,
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pool`.
+        See :func:`~imgaug.imgaug.pool`.
 
     Parameters
     ----------
     arr : (H,W) ndarray or (H,W,C) ndarray
         Image-like array to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     block_size : int or tuple of int or tuple of int
         Size of each block of values to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     pad_mode : str, optional
         Padding mode to use if the array cannot be divided by `block_size`
         without remainder.
-        See :func:`imgaug.imgaug.pad` for details.
+        See :func:`~imgaug.imgaug.pad` for details.
 
     pad_cval : number, optional
         Padding value.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     preserve_dtype : bool, optional
         Whether to preserve the input array dtype.
-        See  :func:`imgaug.imgaug.pool` for details.
+        See  :func:`~imgaug.imgaug.pool` for details.
 
     cval : None or number, optional
         Deprecated. Old name for `pad_cval`.
@@ -1801,30 +1801,30 @@ def max_pool(arr, block_size, pad_mode="edge", pad_cval=0,
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pool`.
+        See :func:`~imgaug.imgaug.pool`.
 
     Parameters
     ----------
     arr : (H,W) ndarray or (H,W,C) ndarray
         Image-like array to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     block_size : int or tuple of int or tuple of int
         Size of each block of values to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     pad_mode : str, optional
         Padding mode to use if the array cannot be divided by `block_size`
         without remainder.
-        See :func:`imgaug.imgaug.pad` for details.
+        See :func:`~imgaug.imgaug.pad` for details.
 
     pad_cval : number, optional
         Padding value.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     preserve_dtype : bool, optional
         Whether to preserve the input array dtype.
-        See  :func:`imgaug.imgaug.pool` for details.
+        See  :func:`~imgaug.imgaug.pool` for details.
 
     cval : None or number, optional
         Deprecated. Old name for `pad_cval`.
@@ -1848,30 +1848,30 @@ def min_pool(arr, block_size, pad_mode="edge", pad_cval=255,
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pool`.
+        See :func:`~imgaug.imgaug.pool`.
 
     Parameters
     ----------
     arr : (H,W) ndarray or (H,W,C) ndarray
         Image-like array to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     block_size : int or tuple of int or tuple of int
         Size of each block of values to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     pad_mode : str, optional
         Padding mode to use if the array cannot be divided by `block_size`
         without remainder.
-        See :func:`imgaug.imgaug.pad` for details.
+        See :func:`~imgaug.imgaug.pad` for details.
 
     pad_cval : number, optional
         Padding value.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     preserve_dtype : bool, optional
         Whether to preserve the input array dtype.
-        See  :func:`imgaug.imgaug.pool` for details.
+        See  :func:`~imgaug.imgaug.pool` for details.
 
     Returns
     -------
@@ -1892,30 +1892,30 @@ def median_pool(arr, block_size, pad_mode="reflect", pad_cval=128,
 
     dtype support::
 
-        See :func:`imgaug.imgaug.pool`.
+        See :func:`~imgaug.imgaug.pool`.
 
     Parameters
     ----------
     arr : (H,W) ndarray or (H,W,C) ndarray
         Image-like array to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     block_size : int or tuple of int or tuple of int
         Size of each block of values to pool.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     pad_mode : str, optional
         Padding mode to use if the array cannot be divided by `block_size`
         without remainder.
-        See :func:`imgaug.imgaug.pad` for details.
+        See :func:`~imgaug.imgaug.pad` for details.
 
     pad_cval : number, optional
         Padding value.
-        See :func:`imgaug.imgaug.pool` for details.
+        See :func:`~imgaug.imgaug.pool` for details.
 
     preserve_dtype : bool, optional
         Whether to preserve the input array dtype.
-        See  :func:`imgaug.imgaug.pool` for details.
+        See  :func:`~imgaug.imgaug.pool` for details.
 
     Returns
     -------
@@ -2037,25 +2037,25 @@ def draw_grid(images, rows=None, cols=None):
 def show_grid(images, rows=None, cols=None):
     """Combine multiple images into a single image and plot the result.
 
-    This will show a window of the results of :func:`imgaug.imgaug.draw_grid`.
+    This will show a window of the results of :func:`~imgaug.imgaug.draw_grid`.
 
     dtype support::
 
         minimum of (
-            :func:`imgaug.imgaug.draw_grid`,
-            :func:`imgaug.imgaug.imshow`
+            :func:`~imgaug.imgaug.draw_grid`,
+            :func:`~imgaug.imgaug.imshow`
         )
 
     Parameters
     ----------
     images : (N,H,W,3) ndarray or iterable of (H,W,3) array
-        See :func:`imgaug.imgaug.draw_grid`.
+        See :func:`~imgaug.imgaug.draw_grid`.
 
     rows : None or int, optional
-        See :func:`imgaug.imgaug.draw_grid`.
+        See :func:`~imgaug.imgaug.draw_grid`.
 
     cols : None or int, optional
-        See :func:`imgaug.imgaug.draw_grid`.
+        See :func:`~imgaug.imgaug.draw_grid`.
 
     """
     grid = draw_grid(images, rows=rows, cols=cols)
@@ -2148,15 +2148,15 @@ def apply_lut(image, table):
 
     dtype support::
 
-        See :func:`imgaug.imgaug.apply_lut_`.
+        See :func:`~imgaug.imgaug.apply_lut_`.
 
     Parameters
     ----------
     image : ndarray
-        See :func:`imgaug.imgaug.apply_lut_`.
+        See :func:`~imgaug.imgaug.apply_lut_`.
 
     table : ndarray or list of ndarray
-        See :func:`imgaug.imgaug.apply_lut_`.
+        See :func:`~imgaug.imgaug.apply_lut_`.
 
     Returns
     -------

--- a/imgaug/multicore.py
+++ b/imgaug/multicore.py
@@ -421,8 +421,8 @@ class Pool(object):
         Wait for the workers to exit.
 
         This may only be called after first calling
-        :func:`imgaug.multicore.Pool.close` or
-        :func:`imgaug.multicore.Pool.terminate`.
+        :func:`~imgaug.multicore.Pool.close` or
+        :func:`~imgaug.multicore.Pool.terminate`.
 
         """
         if self._pool is not None:

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -374,7 +374,7 @@ class StochasticParameter(object):
         random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
             A seed or random number generator to use during the sampling
             process. If ``None``, the global RNG will be used.
-            See also :func:`imgaug.augmenters.meta.Augmenter.__init__`
+            See also :func:`~imgaug.augmenters.meta.Augmenter.__init__`
             for a similar parameter with more details.
 
         Returns
@@ -396,7 +396,7 @@ class StochasticParameter(object):
         random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
             A seed or random number generator to use during the sampling
             process. If ``None``, the global RNG will be used.
-            See also :func:`imgaug.augmenters.meta.Augmenter.__init__`
+            See also :func:`~imgaug.augmenters.meta.Augmenter.__init__`
             for a similar parameter with more details.
 
         Returns
@@ -574,7 +574,7 @@ class StochasticParameter(object):
             Number of points to sample. This is always expected to have at
             least two values. The first defines the number of sampling runs,
             the second (and further) dimensions define the size assigned
-            to each :func:`imgaug.parameters.StochasticParameter.draw_samples`
+            to each :func:`~imgaug.parameters.StochasticParameter.draw_samples`
             call. E.g. ``(10, 20, 15)`` will lead to ``10`` calls of
             ``draw_samples(size=(20, 15))``. The results will be merged to a
             single 1d array.
@@ -1497,7 +1497,7 @@ class FromLowerResolution(StochasticParameter):
         Upsampling/interpolation method to use. This is used after the sampling
         is finished and the low resolution plane has to be upsampled to the
         requested `size` in ``draw_samples(size, ...)``. The method may be
-        the same as in :func:`imgaug.imgaug.imresize_many_images`. Usually
+        the same as in :func:`~imgaug.imgaug.imresize_many_images`. Usually
         ``nearest`` or ``linear`` are good choices. ``nearest`` will result
         in rectangles with sharp edges and ``linear`` in rectangles with
         blurry and round edges. The method may be provided as a
@@ -2745,13 +2745,13 @@ class Sigmoid(StochasticParameter):
         Parameters
         ----------
         other_param : imgaug.parameters.StochasticParameter
-            See :func:`imgaug.parameters.Sigmoid.__init__`.
+            See :func:`~imgaug.parameters.Sigmoid.__init__`.
 
         threshold : number or tuple of number or iterable of number or imgaug.parameters.StochasticParameter, optional
-            See :func:`imgaug.parameters.Sigmoid.__init__`.
+            See :func:`~imgaug.parameters.Sigmoid.__init__`.
 
         activated : bool or number, optional
-            See :func:`imgaug.parameters.Sigmoid.__init__`.
+            See :func:`~imgaug.parameters.Sigmoid.__init__`.
 
         Returns
         -------
@@ -2826,7 +2826,7 @@ class SimplexNoise(StochasticParameter):
         After generating the noise maps in low resolution environments, they
         have to be upscaled to the originally requested shape (i.e. usually
         the image size). This parameter controls the interpolation method to
-        use. See also :func:`imgaug.imgaug.imresize_many_images` for a
+        use. See also :func:`~imgaug.imgaug.imresize_many_images` for a
         description of possible values.
 
             * If ``imgaug.ALL``, then either ``nearest`` or ``linear`` or
@@ -3032,7 +3032,7 @@ class FrequencyNoise(StochasticParameter):
         After generating the noise maps in low resolution environments, they
         have to be upscaled to the originally requested shape (i.e. usually
         the image size). This parameter controls the interpolation method to
-        use. See also :func:`imgaug.imgaug.imresize_many_images` for a
+        use. See also :func:`~imgaug.imgaug.imresize_many_images` for a
         description of possible values.
 
             * If ``imgaug.ALL``, then either ``nearest`` or ``linear`` or

--- a/imgaug/random.py
+++ b/imgaug/random.py
@@ -1,7 +1,7 @@
 """Classes and functions related to pseudo-random number generation.
 
 This module deals with the generation of pseudo-random numbers.
-It provides the :class:`imgaug.random.RNG` class, which is the primary
+It provides the :class:`~imgaug.random.RNG` class, which is the primary
 random number generator in ``imgaug``. It also provides various utility
 functions related random number generation, such as copying random number
 generators or setting their state.
@@ -22,8 +22,8 @@ Definitions
   Note that outside of this module, the term "random state" often roughly
   translates to "any random number generator with numpy-like interface
   in a given state", i.e. it can then include instances of
-  :class:`numpy.random.Generator` or :class:`imgaug.random.RNG`.
-- *RNG*: An instance of :class:`imgaug.random.RNG`.
+  :class:`numpy.random.Generator` or :class:`~imgaug.random.RNG`.
+- *RNG*: An instance of :class:`~imgaug.random.RNG`.
 
 Examples
 --------
@@ -102,7 +102,7 @@ class RNG(object):
     * :func:`numpy.random.RandomState.get_state`
     * :func:`numpy.random.RandomState.set_state`
 
-    In :func:`imgaug.random.RNG.choice`, the `axis` argument is not yet
+    In :func:`~imgaug.random.RNG.choice`, the `axis` argument is not yet
     supported.
 
     Parameters
@@ -357,7 +357,7 @@ class RNG(object):
             This simply samples one or more random values. This means that
             a call of this method will not completely change the outputs of
             the next called sampling method. To achieve more drastic output
-            changes, call :func:`imgaug.random.RNG.derive_rng_`.
+            changes, call :func:`~imgaug.random.RNG.derive_rng_`.
 
         Returns
         -------
@@ -397,7 +397,7 @@ class RNG(object):
         """Create a list containing `n` times this RNG.
 
         This method was mainly introduced as a replacement for previous
-        calls of :func:`imgaug.random.RNG.derive_rngs_`. These calls
+        calls of :func:`~imgaug.random.RNG.derive_rngs_`. These calls
         turned out to be very slow in numpy 1.17+ and were hence replaced
         by simple duplication (except for the cases where child RNGs
         absolutely *had* to be created).
@@ -932,7 +932,7 @@ def normalize_generator_(generator):
     Parameters
     ----------
     generator : None or int or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState
-        See :func:`imgaug.random.normalize_generator`.
+        See :func:`~imgaug.random.normalize_generator`.
 
     Returns
     -------
@@ -1351,7 +1351,7 @@ def set_generator_state_(generator, state):
     state : tuple or dict
         The new state of the generator.
         Should correspond to the output of
-        :func:`imgaug.random.get_generator_state`.
+        :func:`~imgaug.random.get_generator_state`.
 
     """
     if isinstance(generator, np.random.RandomState):
@@ -1438,7 +1438,7 @@ def advance_generator_(generator):
         This simply samples one or more random values. This means that
         a call of this method will not completely change the outputs of
         the next called sampling method. To achieve more drastic output
-        changes, call :func:`imgaug.random.derive_generator_`.
+        changes, call :func:`~imgaug.random.derive_generator_`.
 
     Parameters
     ----------

--- a/imgaug/validation.py
+++ b/imgaug/validation.py
@@ -56,10 +56,10 @@ def assert_is_iterable_of(iterable_var, classes):
     Parameters
     ----------
     iterable_var : iterable
-        See :func:`imgaug.validation.is_iterable_of`.
+        See :func:`~imgaug.validation.is_iterable_of`.
 
     classes : type or iterable of type
-        See :func:`imgaug.validation.is_iterable_of`.
+        See :func:`~imgaug.validation.is_iterable_of`.
 
     """
     valid = is_iterable_of(iterable_var, classes)


### PR DESCRIPTION
This patch adds a tilde symbol to absolute
`:class:` and `:func:` links in docstrings.
The symbol was previously missing.