### PR TITLE
Unify OpenCV Input Normalization

### DIFF
--- a/changelogs/master/refactored/20200111_opencv_normalization.md
+++ b/changelogs/master/refactored/20200111_opencv_normalization.md
@@ -1,0 +1,4 @@
+# Unified OpenCV Input Normalization #565
+
+* Refactored various augmenters to use the same normalization for OpenCV
+  inputs. This probably fixes some previously undiscovered bugs.

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -26,6 +26,7 @@ import six
 import cv2
 
 import imgaug as ia
+from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from .. import parameters as iap
 from .. import dtypes as iadt
@@ -2545,7 +2546,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
         ])
 
         alphas = cv2.GaussianBlur(
-            alphas[np.newaxis, :],
+            _normalize_cv2_input_arr_(alphas[np.newaxis, :]),
             ksize=(ksize_x, ksize_y),
             sigmaX=sigma, sigmaY=sigma,
             borderType=cv2.BORDER_REPLICATE

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -21,6 +21,7 @@ import skimage.exposure as ski_exposure
 import cv2
 
 import imgaug as ia
+from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from . import color as color_lib
 from .. import parameters as iap
@@ -1020,7 +1021,9 @@ class AllChannelsCLAHE(meta.Augmenter):
                         clipLimit=clip_limit_i[c_param],
                         tileGridSize=(tgs_px_w_i[c_param], tgs_px_h_i[c_param])
                     )
-                    channel_warped = clahe.apply(image[..., c])
+                    channel_warped = clahe.apply(
+                        _normalize_cv2_input_arr_(image[..., c])
+                    )
                     image_warped.append(channel_warped)
                 else:
                     image_warped.append(image[..., c])
@@ -1338,8 +1341,9 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
             if image.size == 0:
                 continue
 
-            image_warped = [cv2.equalizeHist(image[..., c])
-                            for c in sm.xrange(image.shape[2])]
+            image_warped = [
+                cv2.equalizeHist(_normalize_cv2_input_arr_(image[..., c]))
+                for c in sm.xrange(image.shape[2])]
             image_warped = np.array(image_warped, dtype=image_warped[0].dtype)
             image_warped = image_warped.transpose((1, 2, 0))
 

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -21,6 +21,7 @@ import cv2
 import six.moves as sm
 
 import imgaug as ia
+from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from .. import parameters as iap
 from .. import dtypes as iadt
@@ -207,7 +208,7 @@ class Convolve(meta.Augmenter):
                     # ndimage.convolve caused problems here cv2.filter2D()
                     # always returns same output dtype as input dtype
                     image_aug[..., channel] = cv2.filter2D(
-                        image_aug[..., channel],
+                        _normalize_cv2_input_arr_(image_aug[..., channel]),
                         -1,
                         matrices[channel]
                     )

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -19,6 +19,7 @@ import cv2
 import six
 
 import imgaug as ia
+from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from . import blend
 from .. import parameters as iap
@@ -437,7 +438,7 @@ class Canny(meta.Augmenter):
             has_zero_sized_axes = (0 in image.shape[0:2])
             if alpha > 0 and sobel > 1 and not has_zero_sized_axes:
                 image_canny = cv2.Canny(
-                    image[:, :, 0:3],
+                    _normalize_cv2_input_arr_(image[:, :, 0:3]),
                     threshold1=hthreshs[0],
                     threshold2=hthreshs[1],
                     apertureSize=sobel,

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -56,6 +56,7 @@ import PIL.ImageEnhance
 import PIL.ImageFilter
 
 import imgaug as ia
+from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from . import arithmetic
 from . import color as colorlib
@@ -305,7 +306,8 @@ def _equalize_no_pil_(image, mask=None):
             image_c = image[:, :, np.newaxis]
         else:
             image_c = image[:, :, c_idx:c_idx+1]
-        histo = cv2.calcHist([image_c], [0], mask, [256], [0, 256])
+        histo = cv2.calcHist(
+            [_normalize_cv2_input_arr_(image_c)], [0], mask, [256], [0, 256])
         if len(histo.nonzero()[0]) <= 1:
             lut[0, :, c_idx] = np.arange(256).astype(np.int32)
             continue
@@ -430,7 +432,8 @@ def _autocontrast_no_pil(image, cutoff, ignore):  # noqa: C901
             image_c = image[:, :, np.newaxis]
         else:
             image_c = image[:, :, c_idx:c_idx+1]
-        h = cv2.calcHist([image_c], [0], None, [256], [0, 256])
+        h = cv2.calcHist(
+            [_normalize_cv2_input_arr_(image_c)], [0], None, [256], [0, 256])
         if ignore is not None:
             h[ignore] = 0
 

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -39,6 +39,7 @@ import numpy as np
 import cv2
 
 import imgaug as ia
+from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from .. import parameters as iap
 
@@ -494,7 +495,8 @@ def pad(arr, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
                     cval = tuple([cval] * arr.shape[2])
 
                 arr_pad = cv2.copyMakeBorder(
-                    arr, top=top, bottom=bottom, left=left, right=right,
+                    _normalize_cv2_input_arr_(arr),
+                    top=top, bottom=bottom, left=left, right=right,
                     borderType=mapping_mode_np_to_cv2[mode], value=cval)
                 if arr.ndim == 3 and arr_pad.ndim == 2:
                     arr_pad = arr_pad[..., np.newaxis]
@@ -506,7 +508,8 @@ def pad(arr, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
                     arr_c = arr[..., channel_start_idx:channel_start_idx+4]
                     cval_c = cval[channel_start_idx:channel_start_idx+4]
                     arr_pad_c = cv2.copyMakeBorder(
-                        arr_c, top=top, bottom=bottom, left=left, right=right,
+                        _normalize_cv2_input_arr_(arr_c),
+                        top=top, bottom=bottom, left=left, right=right,
                         borderType=mapping_mode_np_to_cv2[mode], value=cval_c)
                     arr_pad_c = np.atleast_3d(arr_pad_c)
                     result.append(arr_pad_c)

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -2143,6 +2143,16 @@ def do_assert(condition, message="Assertion failed."):
         raise AssertionError(str(message))
 
 
+def _normalize_cv2_input_arr_(arr):
+    flags = arr.flags
+    if not flags["OWNDATA"]:
+        arr = np.copy(arr)
+        flags = arr.flags
+    if not flags["C_CONTIGUOUS"]:
+        arr = np.ascontiguousarray(arr)
+    return arr
+
+
 def apply_lut(image, table):
     """Map an input image to a new one using a lookup table.
 
@@ -2215,11 +2225,7 @@ def apply_lut_(image, table):
     if 0 in image_shape_orig:
         return image
 
-    flags = image.flags
-    if not flags["OWNDATA"]:
-        image = np.copy(image)
-    if not flags["C_CONTIGUOUS"]:
-        image = np.ascontiguousarray(image)
+    image = _normalize_cv2_input_arr_(image)
 
     # [(256,), (256,), ...] => (256, C)
     if isinstance(table, list):


### PR DESCRIPTION
Refactor various augmenters to use the same
normalization for OpenCV inputs. This probably
fixes some previously undiscovered bugs.