### PR TITLE
Improve batchwise augmentation backend

### DIFF
--- a/changelogs/master/20191003_reworked_aug_methods.md
+++ b/changelogs/master/20191003_reworked_aug_methods.md
@@ -1,4 +1,4 @@
-# Reworked Augmentation Methods #451
+# Reworked Augmentation Methods #451 #566
 
 * Added method `to_normalized_batch()` to `imgaug.augmentables.batches.Batch`
   to have the same interface in `Batch` and `UnnormalizedBatch`.
@@ -12,85 +12,89 @@
   `imgaug.augmentables.batches.Batch`.
 * Added method `fill_from_batch_in_augmentation_()` to
   `imgaug.augmentables.batches.Batch`.
+* Added method `fill_from_augmented_normalized_batch_()` to
+  `imgaug.augmentables.batches.UnnormalizedBatch`.
 * Added class `imgaug.augmentables.batches.BatchInAugmentation`.
-* Added method `_augment_batch()` in `imgaug.augmenters.meta.Augmenter`.
-  This method is now called from `augment_batch()`.
+* Added method `_augment_batch_()` in `imgaug.augmenters.meta.Augmenter`.
+  This method is now called from `augment_batch_()`.
 * Changed `augment_images()` in `imgaug.augmenters.meta.Augmenter` to be
-  a thin wrapper around `augment_batch()`.
+  a thin wrapper around `augment_batch_()`.
 * Changed `augment_heatmaps()` in `imgaug.augmenters.meta.Augmenter` to be
-  a thin wrapper around `augment_batch()`.
+  a thin wrapper around `augment_batch_()`.
 * Changed `augment_segmentation_maps()` in `imgaug.augmenters.meta.Augmenter`
-  to be a thin wrapper around `augment_batch()`.
+  to be a thin wrapper around `augment_batch_()`.
 * Changed `augment_keypoints()` in `imgaug.augmenters.meta.Augmenter` to be
-  a thin wrapper around `augment_batch()`.
+  a thin wrapper around `augment_batch_()`.
 * Changed `augment_bounding_boxes()` in `imgaug.augmenters.meta.Augmenter` to be
-  a thin wrapper around `augment_batch()`.
+  a thin wrapper around `augment_batch_()`.
 * Changed `augment_polygons()` in `imgaug.augmenters.meta.Augmenter` to be
-  a thin wrapper around `augment_batch()`.
+  a thin wrapper around `augment_batch_()`.
 * Changed `augment_line_strings()` in `imgaug.augmenters.meta.Augmenter` to be
-  a thin wrapper around `augment_batch()`.
+  a thin wrapper around `augment_batch_()`.
 * Changed `augment_image()`, `augment_images()`, `augment_heatmaps()`,
   `augment_segmentation_maps()`, `augment_keypoints()`,
   `augment_bounding_boxes()`, `augment_polygons()` and `augment_line_strings()`
   to return `None` inputs without change. Previously they resulted in an
   exception. This is more consistent with the behaviour in the other
   `augment_*` methods.
-* [breaking] Added parameter `parents` to
-  `imgaug.augmenters.meta.Augmenter.augment_batch()`. This breaks if one relied
-  on the order of arguments for that methods.
+* Added method `imgaug.augmenters.meta.Augmenter.augment_batch_()`,
+  similar to `augment_batch()`, but explicitly works in-place and has a
+  `parent` parameter.
+* Deprecated `imgaug.augmenters.meta.Augmenter.augment_batch()`.
+  Use `.augment_batch_()` instead.
 * Changed `augment_images()` to no longer be abstract. It defaults
   to not changing the input images.
-* Refactored `Sequential` to use single `_augment_batch()` method.
-* Refactored `SomeOf` to use single `_augment_batch()` method.
-* Refactored `Sometimes` to use single `_augment_batch()` method.
+* Refactored `Sequential` to use single `_augment_batch_()` method.
+* Refactored `SomeOf` to use single `_augment_batch_()` method.
+* Refactored `Sometimes` to use single `_augment_batch_()` method.
 * Refactored `AveragePooling`, `MaxPooling`, `MinPooling`, `MedianPooling`
-  to use single `_augment_batch()` method.
-* Refactored `ElasticTransformation` to use single `_augment_batch()` method.
-* Refactored `Alpha` to use single `_augment_batch()` method.
-* Refactored `AlphaElementwise` to use single `_augment_batch()` method.
-* Refactored `WithColorspace` to use single `_augment_batch()` method.
-* Refactored `WithHueAndSaturation` to use single `_augment_batch()` method.
-* Refactored `Fliplr` to use single `_augment_batch()` method.
-* Refactored `Flipud` to use single `_augment_batch()` method.
-* Refactored `Affine` to use single `_augment_batch()` method.
-* Refactored `Rot90` to use single `_augment_batch()` method.
-* Refactored `Resize` to use single `_augment_batch()` method.
-* Refactored `CropAndPad` to use single `_augment_batch()` method.
-* Refactored `PadToFixedSize` to use single `_augment_batch()` method.
-* Refactored `CropToFixedSize` to use single `_augment_batch()` method.
-* Refactored `KeepSizeByResize` to use single `_augment_batch()` method.
-* Refactored `PiecewiseAffine` to use single `_augment_batch()` method.
-* Refactored `PerspectiveTransform` to use single `_augment_batch()` method.
-* Refactored `WithChannels` to use single `_augment_batch()` method.
-* Refactored `Add` to use single `_augment_batch()` method.
-* Refactored `AddElementwise` to use single `_augment_batch()` method.
-* Refactored `Multiply` to use single `_augment_batch()` method.
-* Refactored `MultiplyElementwise` to use single `_augment_batch()` method.
-* Refactored `ReplaceElementwise` to use single `_augment_batch()` method.
-* Refactored `Invert` to use single `_augment_batch()` method.
-* Refactored `JpegCompression` to use single `_augment_batch()` method.
-* Refactored `GaussianBlur` to use single `_augment_batch()` method.
-* Refactored `AverageBlur` to use single `_augment_batch()` method.
-* Refactored `MedianBlur` to use single `_augment_batch()` method.
-* Refactored `BilateralBlur` to use single `_augment_batch()` method.
-* Refactored `AddToHueAndSaturation` to use single `_augment_batch()` method.
-* Refactored `ChangeColorspace` to use single `_augment_batch()` method.
-* Refactored `_AbstractColorQuantization` to use single `_augment_batch()`
+  to use single `_augment_batch_()` method.
+* Refactored `ElasticTransformation` to use single `_augment_batch_()` method.
+* Refactored `Alpha` to use single `_augment_batch_()` method.
+* Refactored `AlphaElementwise` to use single `_augment_batch_()` method.
+* Refactored `WithColorspace` to use single `_augment_batch_()` method.
+* Refactored `WithHueAndSaturation` to use single `_augment_batch_()` method.
+* Refactored `Fliplr` to use single `_augment_batch_()` method.
+* Refactored `Flipud` to use single `_augment_batch_()` method.
+* Refactored `Affine` to use single `_augment_batch_()` method.
+* Refactored `Rot90` to use single `_augment_batch_()` method.
+* Refactored `Resize` to use single `_augment_batch_()` method.
+* Refactored `CropAndPad` to use single `_augment_batch_()` method.
+* Refactored `PadToFixedSize` to use single `_augment_batch_()` method.
+* Refactored `CropToFixedSize` to use single `_augment_batch_()` method.
+* Refactored `KeepSizeByResize` to use single `_augment_batch_()` method.
+* Refactored `PiecewiseAffine` to use single `_augment_batch_()` method.
+* Refactored `PerspectiveTransform` to use single `_augment_batch_()` method.
+* Refactored `WithChannels` to use single `_augment_batch_()` method.
+* Refactored `Add` to use single `_augment_batch_()` method.
+* Refactored `AddElementwise` to use single `_augment_batch_()` method.
+* Refactored `Multiply` to use single `_augment_batch_()` method.
+* Refactored `MultiplyElementwise` to use single `_augment_batch_()` method.
+* Refactored `ReplaceElementwise` to use single `_augment_batch_()` method.
+* Refactored `Invert` to use single `_augment_batch_()` method.
+* Refactored `JpegCompression` to use single `_augment_batch_()` method.
+* Refactored `GaussianBlur` to use single `_augment_batch_()` method.
+* Refactored `AverageBlur` to use single `_augment_batch_()` method.
+* Refactored `MedianBlur` to use single `_augment_batch_()` method.
+* Refactored `BilateralBlur` to use single `_augment_batch_()` method.
+* Refactored `AddToHueAndSaturation` to use single `_augment_batch_()` method.
+* Refactored `ChangeColorspace` to use single `_augment_batch_()` method.
+* Refactored `_AbstractColorQuantization` to use single `_augment_batch_()`
   method.
-* Refactored `_ContrastFuncWrapper` to use single `_augment_batch()` method.
-* Refactored `AllChannelsCLAHE` to use single `_augment_batch()` method.
-* Refactored `CLAHE` to use single `_augment_batch()` method.
-* Refactored `AllChannelsHistogramEqualization` to use single `_augment_batch()`
-  method.
-* Refactored `HistogramEqualization` to use single `_augment_batch()` method.
-* Refactored `Convolve` to use single `_augment_batch()` method.
-* Refactored `Canny` to use single `_augment_batch()` method.
-* Refactored `ChannelShuffle` to use single `_augment_batch()` method.
-* Refactored `Superpixels` to use single `_augment_batch()` method.
-* Refactored `Voronoi` to use single `_augment_batch()` method.
-* Refactored `FastSnowyLandscape` to use single `_augment_batch()` method.
-* Refactored `CloudLayer` to use single `_augment_batch()` method.
-* Refactored `SnowflakesLayer` to use single `_augment_batch()` method.
+* Refactored `_ContrastFuncWrapper` to use single `_augment_batch_()` method.
+* Refactored `AllChannelsCLAHE` to use single `_augment_batch_()` method.
+* Refactored `CLAHE` to use single `_augment_batch_()` method.
+* Refactored `AllChannelsHistogramEqualization` to use single
+  `_augment_batch_()` method.
+* Refactored `HistogramEqualization` to use single `_augment_batch_()` method.
+* Refactored `Convolve` to use single `_augment_batch_()` method.
+* Refactored `Canny` to use single `_augment_batch_()` method.
+* Refactored `ChannelShuffle` to use single `_augment_batch_()` method.
+* Refactored `Superpixels` to use single `_augment_batch_()` method.
+* Refactored `Voronoi` to use single `_augment_batch_()` method.
+* Refactored `FastSnowyLandscape` to use single `_augment_batch_()` method.
+* Refactored `CloudLayer` to use single `_augment_batch_()` method.
+* Refactored `SnowflakesLayer` to use single `_augment_batch_()` method.
 * Added validation of input arguments to `KeypointsOnImage.from_xy_array()`.
 * Improved validation of input arguments to
   `BoundingBoxesOnImage.from_xyxy_array()`.
@@ -118,3 +122,4 @@
 * Added method `imgaug.augmentables.bbs.BoundingBoxesOnImages.from_point_soups()`.
 * Changed `imgaug.augmentables.BoundingBoxesOnImage.from_xyxy_array()` to also
   accept `(N, 2, 2)` arrays instead of only `(N, 4)`.
+* Added context `imgaug.testutils.TemporaryDirectory`.

--- a/imgaug/augmentables/batches.py
+++ b/imgaug/augmentables/batches.py
@@ -213,6 +213,45 @@ class UnnormalizedBatch(object):
             data=self.data
         )
 
+    def fill_from_augmented_normalized_batch_(self, batch_aug_norm):
+        """
+        Fill this batch with (normalized) augmentation results in-place.
+
+        This method receives a (normalized) Batch instance, takes all
+        ``*_aug`` attributes out if it and assigns them to this
+        batch *in unnormalized form*. Hence, the datatypes of all ``*_aug``
+        attributes will match the datatypes of the ``*_unaug`` attributes.
+
+        Parameters
+        ----------
+        batch_aug_norm: imgaug.augmentables.batches.Batch
+            Batch after normalization and augmentation.
+
+        Returns
+        -------
+        imgaug.augmentables.batches.UnnormalizedBatch
+            This instance itself.
+            All ``*_unaug`` attributes are unchanged.
+            All ``*_aug`` attributes are taken from `batch_normalized`,
+            converted to unnormalized form.
+
+        """
+        self.images_aug = nlib.invert_normalize_images(
+            batch_aug_norm.images_aug, self.images_unaug)
+        self.heatmaps_aug = nlib.invert_normalize_heatmaps(
+            batch_aug_norm.heatmaps_aug, self.heatmaps_unaug)
+        self.segmentation_maps_aug = nlib.invert_normalize_segmentation_maps(
+            batch_aug_norm.segmentation_maps_aug, self.segmentation_maps_unaug)
+        self.keypoints_aug = nlib.invert_normalize_keypoints(
+            batch_aug_norm.keypoints_aug, self.keypoints_unaug)
+        self.bounding_boxes_aug = nlib.invert_normalize_bounding_boxes(
+            batch_aug_norm.bounding_boxes_aug, self.bounding_boxes_unaug)
+        self.polygons_aug = nlib.invert_normalize_polygons(
+            batch_aug_norm.polygons_aug, self.polygons_unaug)
+        self.line_strings_aug = nlib.invert_normalize_line_strings(
+            batch_aug_norm.line_strings_aug, self.line_strings_unaug)
+        return self
+
     def fill_from_augmented_normalized_batch(self, batch_aug_norm):
         """
         Fill this batch with (normalized) augmentation results.
@@ -232,7 +271,7 @@ class UnnormalizedBatch(object):
         imgaug.augmentables.batches.UnnormalizedBatch
             New UnnormalizedBatch instance. All ``*_unaug`` attributes are
             taken from the old UnnormalizedBatch (without deepcopying them)
-            and all ``*_aug`` attributes are taken from `batch_normalized`
+            and all ``*_aug`` attributes are taken from `batch_normalized`,
             converted to unnormalized form.
 
         """

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -1523,7 +1523,7 @@ class Add(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(
             per_channel, "per_channel")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -1658,7 +1658,7 @@ class AddElementwise(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(
             per_channel, "per_channel")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -2088,7 +2088,7 @@ class Multiply(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(
             per_channel, "per_channel")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -2221,7 +2221,7 @@ class MultiplyElementwise(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(per_channel,
                                                         "per_channel")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -2480,7 +2480,7 @@ class Cutout(meta.Augmenter):
                 type(fill_mode).__name__))
         return iap.Choice(fill_mode)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -2984,7 +2984,7 @@ class Dropout2d(meta.Augmenter):
         self._heatmaps_cval = 0.0
         self._segmentation_maps_cval = 0
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         imagewise_drop_channel_ids, all_dropped_ids = self._draw_samples(
             batch, random_state)
 
@@ -3154,7 +3154,7 @@ class TotalDropout(meta.Augmenter):
         self._heatmaps_cval = 0.0
         self._segmentation_maps_cval = 0
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         drop_mask = self._draw_samples(batch, random_state)
         drop_ids = None
 
@@ -3317,7 +3317,7 @@ class ReplaceElementwise(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(per_channel,
                                                         "per_channel")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -4188,7 +4188,7 @@ class Invert(meta.Augmenter):
         self.invert_above_threshold = iap.handle_probability_param(
             invert_above_threshold, "invert_above_threshold")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -4467,7 +4467,7 @@ class JpegCompression(meta.Augmenter):
             compression, "compression",
             value_range=(0, 100), tuple_to_uniform=True, list_to_choice=True)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 

--- a/imgaug/augmenters/artistic.py
+++ b/imgaug/augmenters/artistic.py
@@ -335,7 +335,7 @@ class Cartoon(meta.Augmenter):
             tuple_to_uniform=True, list_to_choice=True)
         self.from_colorspace = from_colorspace
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             samples = self._draw_samples(batch, random_state)
             for i, image in enumerate(batch.images):

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -222,7 +222,7 @@ def _generate_branch_outputs(augmenter, batch, hooks, parents):
         outputs_fg = outputs_fg.deepcopy()
         with outputs_fg.propagation_hooks_ctx(augmenter, hooks, parents):
             if augmenter.foreground is not None:
-                outputs_fg = augmenter.foreground.augment_batch(
+                outputs_fg = augmenter.foreground.augment_batch_(
                     outputs_fg,
                     parents=parents_extended,
                     hooks=hooks
@@ -232,7 +232,7 @@ def _generate_branch_outputs(augmenter, batch, hooks, parents):
     if augmenter.background is not None:
         outputs_bg = outputs_bg.deepcopy()
         with outputs_bg.propagation_hooks_ctx(augmenter, hooks, parents):
-            outputs_bg = augmenter.background.augment_batch(
+            outputs_bg = augmenter.background.augment_batch_(
                 outputs_bg,
                 parents=parents_extended,
                 hooks=hooks
@@ -406,7 +406,7 @@ class BlendAlpha(meta.Augmenter):
 
         self.epsilon = 1e-2
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         batch_fg, batch_bg = _generate_branch_outputs(
             self, batch, hooks, parents)
 
@@ -602,7 +602,7 @@ class BlendAlphaMask(meta.Augmenter):
 
         self.epsilon = 1e-2
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         batch_fg, batch_bg = _generate_branch_outputs(
             self, batch, hooks, parents)
 

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -443,7 +443,7 @@ class GaussianBlur(meta.Augmenter):
         # apply the blur
         self.eps = 1e-3
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -593,7 +593,7 @@ class AverageBlur(meta.Augmenter):
                 "Expected int, tuple/list with 2 entries or "
                 "StochasticParameter. Got %s." % (type(k),))
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -746,7 +746,7 @@ class MedianBlur(meta.Augmenter):
                 "Expected all values in iterable k to be odd, but at least "
                 "one was not. Add or subtract 1 to/from that value.")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -896,7 +896,7 @@ class BilateralBlur(meta.Augmenter):
             sigma_space, "sigma_space", value_range=(1, None),
             tuple_to_uniform=True, list_to_choice=True)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=invalid-name
         if batch.images is None:
             return batch
@@ -1147,7 +1147,7 @@ class MeanShiftBlur(meta.Augmenter):
             value_range=(0.01, None), tuple_to_uniform=True,
             list_to_choice=True)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             samples = self._draw_samples(batch, random_state)
             for i, image in enumerate(batch.images):

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -1013,7 +1013,7 @@ class WithColorspace(meta.Augmenter):
         self.from_colorspace = from_colorspace
         self.children = meta.handle_children_list(children, self.name, "then")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             # TODO this did not fail in the tests when there was only one
             #      `if` with all three steps in it
@@ -1023,7 +1023,7 @@ class WithColorspace(meta.Augmenter):
                     to_colorspaces=self.to_colorspace,
                     from_colorspaces=self.from_colorspace)
 
-            batch = self.children.augment_batch(
+            batch = self.children.augment_batch_(
                 batch,
                 parents=parents + [self],
                 hooks=hooks
@@ -1164,7 +1164,7 @@ class WithBrightnessChannels(meta.Augmenter):
             valid_values=self._VALID_COLORSPACES)
         self.from_colorspace = from_colorspace
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             images_cvt = None
             to_colorspaces = None
@@ -1181,7 +1181,7 @@ class WithBrightnessChannels(meta.Augmenter):
 
                 batch.images = brightness_channels
 
-            batch = self.children.augment_batch(
+            batch = self.children.augment_batch_(
                 batch, parents=parents + [self], hooks=hooks)
 
             if batch.images is not None:
@@ -1557,12 +1557,12 @@ class WithHueAndSaturation(meta.Augmenter):
         # for Add or Multiply
         self._internal_dtype = np.int16
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             images_hs, images_hsv = self._images_to_hsv_(batch.images)
             batch.images = images_hs
 
-            batch = self.children.augment_batch(
+            batch = self.children.augment_batch_(
                 batch, parents=parents + [self], hooks=hooks)
 
             batch.images = self._hs_to_images_(batch.images, images_hsv)
@@ -2250,7 +2250,7 @@ class AddToHueAndSaturation(meta.Augmenter):
 
         return samples_hue, samples_saturation
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -2698,7 +2698,7 @@ class ChangeColorspace(meta.Augmenter):
             (n_augmentables,), random_state=rss[1])
         return alphas, to_colorspaces
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -2850,7 +2850,7 @@ class ChangeColorTemperature(meta.Augmenter):
             list_to_choice=True)
         self.from_colorspace = from_colorspace
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             nb_rows = batch.nb_rows
             kelvins = self.kelvin.draw_samples((nb_rows,),
@@ -2902,7 +2902,7 @@ class _AbstractColorQuantization(meta.Augmenter):
 
         return counts
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -42,7 +42,7 @@ class _ContrastFuncWrapper(meta.Augmenter):
         self.dtypes_allowed = dtypes_allowed
         self.dtypes_disallowed = dtypes_disallowed
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -968,7 +968,7 @@ class AllChannelsCLAHE(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(per_channel,
                                                         "per_channel")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -1219,7 +1219,7 @@ class CLAHE(meta.Augmenter):
         self.intensity_channel_based_applier = _IntensityChannelBasedApplier(
             from_colorspace, to_colorspace, name=name)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -1240,7 +1240,7 @@ class CLAHE(meta.Augmenter):
             # pylint: disable=protected-access
             # TODO would .augment_batch() be sufficient here?
             batch_imgs = iabatches.BatchInAugmentation(images=images_normalized)
-            return self.all_channel_clahe._augment_batch(
+            return self.all_channel_clahe._augment_batch_(
                 batch_imgs, random_state_derived, parents + [self],
                 hooks
             ).images
@@ -1321,7 +1321,7 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
         super(AllChannelsHistogramEqualization, self).__init__(
             name=name, deterministic=deterministic, random_state=random_state)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -1469,7 +1469,7 @@ class HistogramEqualization(meta.Augmenter):
         self.intensity_channel_based_applier = _IntensityChannelBasedApplier(
             from_colorspace, to_colorspace, name=name)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -1490,7 +1490,7 @@ class HistogramEqualization(meta.Augmenter):
             # pylint: disable=protected-access
             # TODO would .augment_batch() be sufficient here
             batch_imgs = iabatches.BatchInAugmentation(images=images_normalized)
-            return self.all_channel_histogram_equalization._augment_batch(
+            return self.all_channel_histogram_equalization._augment_batch_(
                 batch_imgs, random_state_derived, parents + [self],
                 hooks
             ).images

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -135,7 +135,7 @@ class Convolve(meta.Augmenter):
                 "StochasticParameter. Got %s." % (
                     type(matrix),))
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -1009,7 +1009,7 @@ class _SaveDebugImage(meta.Augmenter):
         self.destination = destination
         self.schedule = schedule
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         save = self.schedule.on_batch(batch)
         self.destination.on_batch(batch)
 

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -403,7 +403,7 @@ class Canny(meta.Augmenter):
 
         return alpha_samples, hthresh_samples, sobel_samples
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -863,7 +863,7 @@ class Fliplr(meta.Augmenter):
             name=name, deterministic=deterministic, random_state=random_state)
         self.p = iap.handle_probability_param(p, "p")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self.p.draw_samples((batch.nb_rows,),
                                       random_state=random_state)
         for i, sample in enumerate(samples):
@@ -963,7 +963,7 @@ class Flipud(meta.Augmenter):
             name=name, deterministic=deterministic, random_state=random_state)
         self.p = iap.handle_probability_param(p, "p")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self.p.draw_samples((batch.nb_rows,),
                                       random_state=random_state)
         for i, sample in enumerate(samples):

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1296,7 +1296,7 @@ class Affine(meta.Augmenter):
                 list_to_choice=True
             ), param_type
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self._draw_samples(batch.nb_rows, random_state)
 
         if batch.images is not None:
@@ -2903,7 +2903,7 @@ class PiecewiseAffine(meta.Augmenter):
         self._cval_heatmaps = 0
         self._cval_segmentation_maps = 0
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self._draw_samples(batch.nb_rows, random_state)
 
         if batch.images is not None:
@@ -3468,7 +3468,7 @@ class PerspectiveTransform(meta.Augmenter):
             "of int/strings or StochasticParameter, got %s." % (
                 type(mode),))
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         samples_images = self._draw_samples(batch.get_rowwise_shapes(),
                                             random_state.copy())
 
@@ -3596,7 +3596,7 @@ class PerspectiveTransform(meta.Augmenter):
         # estimate max_heights/max_widths for the underlying images
         # this is only necessary if keep_size is False as then the underlying
         # image sizes change and we need to update them here
-        # TODO this was re-used from before _augment_batch() -- reoptimize
+        # TODO this was re-used from before _augment_batch_() -- reoptimize
         if self.keep_size:
             max_heights_imgs = samples.max_heights
             max_widths_imgs = samples.max_widths
@@ -4122,7 +4122,7 @@ class ElasticTransformation(meta.Augmenter):
         return _ElasticTransformationSamplingResult(
             rss[0:-5], alphas, sigmas, orders, cvals, modes)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=invalid-name
         if batch.images is not None:
             iadt.gate_dtypes(
@@ -4714,7 +4714,7 @@ class Rot90(meta.Augmenter):
     def _draw_samples(self, nb_images, random_state):
         return self.k.draw_samples((nb_images,), random_state=random_state)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=invalid-name
         ks = self._draw_samples(batch.nb_rows, random_state)
 
@@ -4952,7 +4952,7 @@ class WithPolarWarping(meta.Augmenter):
             name=name, deterministic=deterministic, random_state=random_state)
         self.children = meta.handle_children_list(children, self.name, "then")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             iadt.gate_dtypes(
                 batch.images,
@@ -4975,9 +4975,9 @@ class WithPolarWarping(meta.Augmenter):
                 setattr(batch, column.attr_name, col_aug)
                 inv_data[column.name] = inv_data_col
 
-            batch = self.children.augment_batch(batch,
-                                                parents=parents + [self],
-                                                hooks=hooks)
+            batch = self.children.augment_batch_(batch,
+                                                 parents=parents + [self],
+                                                 hooks=hooks)
             for column in batch.columns:
                 func = getattr(self, "_invert_warp_%s_" % (column.name,))
                 col_unaug = func(column.value, inv_data[column.name])
@@ -5601,7 +5601,7 @@ class Jigsaw(meta.Augmenter):
             tuple_to_uniform=True, list_to_choice=True, allow_floats=False)
         self.allow_pad = allow_pad
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self._draw_samples(batch, random_state)
 
         # We resize here heatmaps/segmaps early to the image size in order to
@@ -5627,8 +5627,8 @@ class Jigsaw(meta.Augmenter):
                     width_multiple=samples.nb_cols[i],
                     height_multiple=samples.nb_rows[i])
                 row = batch.subselect_rows_by_indices([i])
-                row = padder.augment_batch(row, parents=parents + [self],
-                                           hooks=hooks)
+                row = padder.augment_batch_(row, parents=parents + [self],
+                                            hooks=hooks)
                 batch = batch.invert_subselect_rows_by_indices_([i], row)
 
         if batch.images is not None:

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -953,7 +953,7 @@ class _ImgcorruptAugmenterBase(meta.Augmenter):
             severity, "severity", value_range=(1, 5), tuple_to_uniform=True,
             list_to_choice=True, allow_floats=False)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -1316,7 +1316,7 @@ class Equalize(meta.Augmenter):
         super(Equalize, self).__init__(
             name=name, deterministic=deterministic, random_state=random_state)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=no-self-use
         if batch.images:
             for image in batch.images:
@@ -1418,7 +1418,7 @@ class _EnhanceBase(meta.Augmenter):
             factor, "factor", value_range=factor_value_range,
             tuple_to_uniform=True, list_to_choice=True)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -1654,7 +1654,7 @@ class _FilterBase(meta.Augmenter):
             name=name, deterministic=deterministic, random_state=random_state)
         self.func = func
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -2150,14 +2150,14 @@ class Affine(geometric.Affine):
         # TODO move that func to iap
         self.center = sizelib._handle_position_parameter(center)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         cols = batch.get_column_names()
         assert len(cols) == 0 or (len(cols) == 1 and "images" in cols), (
             "PILAffine can currently only process image data. Got a batch "
             "containing: %s. Use imgaug.augmenters.geometric.Affine for "
             "batches containing non-image data." % (", ".join(cols),))
 
-        return super(Affine, self)._augment_batch(
+        return super(Affine, self)._augment_batch_(
             batch, random_state, parents, hooks)
 
     def _augment_images_by_samples(self, images, samples,

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -76,7 +76,7 @@ class _AbstractPoolingBase(meta.Augmenter):
             np.clip(kernel_sizes_w, 1, None)
         )
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None and self.keep_size:
             return batch
 

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -211,7 +211,7 @@ class Superpixels(meta.Augmenter):
         self.max_size = max_size
         self.interpolation = interpolation
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -589,7 +589,7 @@ class Voronoi(meta.Augmenter):
         self.max_size = max_size
         self.interpolation = interpolation
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -1345,7 +1345,7 @@ class Resize(meta.Augmenter):
                 "got %s." % (type(interpolation),))
         return interpolation
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         nb_rows = batch.nb_rows
         samples = self._draw_samples(nb_rows, random_state)
 
@@ -1914,7 +1914,7 @@ class CropAndPad(meta.Augmenter):
                 "StochasticParameter, got type %s." % (type(percent),))
         return all_sides, top, right, bottom, left
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         shapes = batch.get_rowwise_shapes()
         samples = self._draw_samples(random_state, shapes)
 
@@ -2672,7 +2672,7 @@ class PadToFixedSize(meta.Augmenter):
         self._pad_cval_heatmaps = 0.0
         self._pad_cval_segmentation_maps = 0
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         # Providing the whole batch to _draw_samples() would not be necessary
         # for this augmenter. The number of rows would be sufficient. This
         # formulation however enables derived augmenters to use rowwise shapes
@@ -3010,7 +3010,7 @@ class CropToFixedSize(meta.Augmenter):
         # (0.0, 1.0) crops left and bottom, (1.0, 0.0) crops right and top.
         self.position = _handle_position_parameter(position)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         # Providing the whole batch to _draw_samples() would not be necessary
         # for this augmenter. The number of rows would be sufficient. This
         # formulation however enables derived augmenters to use rowwise shapes
@@ -4396,7 +4396,7 @@ class KeepSizeByResize(meta.Augmenter):
         self.interpolation_segmaps = _validate_param(interpolation_segmaps,
                                                      True)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             images_were_array = None
             if batch.images is not None:
@@ -4405,7 +4405,7 @@ class KeepSizeByResize(meta.Augmenter):
 
             samples = self._draw_samples(batch.nb_rows, random_state)
 
-            batch = self.children.augment_batch(
+            batch = self.children.augment_batch_(
                 batch, parents=parents + [self], hooks=hooks)
 
             if batch.images is not None:

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -148,7 +148,7 @@ class FastSnowyLandscape(meta.Augmenter):
             (nb_augmentables,), rss[0])
         return thresh_samples, lmul_samples
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -345,7 +345,7 @@ class CloudLayer(meta.Augmenter):
         self.density_multiplier = iap.handle_continuous_param(
             density_multiplier, "density_multiplier")
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 
@@ -820,7 +820,7 @@ class SnowflakesLayer(meta.Augmenter):
         # (height, width), same for all images
         self.gate_noise_size = (8, 8)
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
 

--- a/imgaug/multicore.py
+++ b/imgaug/multicore.py
@@ -512,7 +512,7 @@ def _Pool_worker(batch_idx, batch):
     if Pool._WORKER_SEED_START is not None:
         seed = Pool._WORKER_SEED_START + batch_idx
         _reseed_global_local(seed, augseq)
-    result = augseq.augment_batch(batch)
+    result = augseq.augment_batch_(batch)
     return result
 
 
@@ -878,7 +878,7 @@ class BackgroundAugmenter(object):
                     # loading queue is finished
                     queue_source.put(pickle.dumps(None, protocol=-1))
                 else:
-                    batch_aug = augseq.augment_batch(batch)
+                    batch_aug = augseq.augment_batch_(batch)
 
                     # send augmented batch to output queue
                     batch_str = pickle.dumps(batch_aug, protocol=-1)

--- a/imgaug/testutils.py
+++ b/imgaug/testutils.py
@@ -8,6 +8,8 @@ from __future__ import print_function, division, absolute_import
 import random
 import copy
 import warnings
+import tempfile
+import shutil
 
 import numpy as np
 import six.moves as sm
@@ -169,3 +171,23 @@ def wrap_shift_deprecation(func, *args, **kwargs):
         )
 
         return result
+
+
+class TemporaryDirectory(object):
+    """Create a context for a temporary directory.
+
+    The directory is automatically removed at the end of the context.
+    This context is available in ``tmpfile.TemporaryDirectory``, but only
+    from 3.2+.
+
+    """
+
+    def __init__(self, suffix="", prefix="tmp", dir=None):
+        # pylint: disable=redefined-builtin
+        self.name = tempfile.mkdtemp(suffix, prefix, dir)
+
+    def __enter__(self):
+        return self.name
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        shutil.rmtree(self.name)

--- a/test/augmenters/test_color.py
+++ b/test/augmenters/test_color.py
@@ -359,7 +359,7 @@ class _BatchCapturingDummyAugmenter(iaa.Augmenter):
         super(_BatchCapturingDummyAugmenter, self).__init__()
         self.last_batch = None
 
-    def _augment_batch(self, batch, random_state, parents, hooks):
+    def _augment_batch_(self, batch, random_state, parents, hooks):
         self.last_batch = copylib.deepcopy(batch.deepcopy())
         return batch
 
@@ -808,7 +808,7 @@ class TestWithHueAndSaturation(unittest.TestCase):
                 super(_DummyAugmenter, self).__init__()
                 self.call_count = 0
 
-            def _augment_batch(self, batch, random_state, parents, hooks):
+            def _augment_batch_(self, batch, random_state, parents, hooks):
                 assert batch.images[0].dtype.name == "int16"
                 self.call_count += 1
                 return batch
@@ -905,7 +905,7 @@ class TestWithHueAndSaturation(unittest.TestCase):
                 super(_DummyAugmenter, self).__init__()
                 self.call_count = 0
 
-            def _augment_batch(self, batch, random_state, parents, hooks):
+            def _augment_batch_(self, batch, random_state, parents, hooks):
                 self.call_count += 1
                 return batch
 
@@ -931,7 +931,7 @@ class TestWithHueAndSaturation(unittest.TestCase):
                 super(_DummyAugmenter, self).__init__()
                 self.call_count = 0
 
-            def _augment_batch(self, batch, random_state, parents, hooks):
+            def _augment_batch_(self, batch, random_state, parents, hooks):
                 self.call_count += 1
                 return batch
 

--- a/test/augmenters/test_contrast.py
+++ b/test/augmenters/test_contrast.py
@@ -1309,7 +1309,7 @@ class TestCLAHE(unittest.TestCase):
         mock_cs.side_effect = _side_effect
 
         mock_all_channel_clahe = ArgCopyingMagicMock()
-        mock_all_channel_clahe._augment_batch.return_value = mocked_batch
+        mock_all_channel_clahe._augment_batch_.return_value = mocked_batch
 
         clahe = iaa.CLAHE(
             clip_limit=1,
@@ -1323,7 +1323,7 @@ class TestCLAHE(unittest.TestCase):
         assert np.array_equal(img_aug, img+2)
 
         assert mock_cs.call_count == 0
-        assert mock_all_channel_clahe._augment_batch.call_count == 1
+        assert mock_all_channel_clahe._augment_batch_.call_count == 1
 
     @classmethod
     def _test_single_image_3d_rgb_to_x(cls, to_colorspace, channel_idx):
@@ -1352,7 +1352,7 @@ class TestCLAHE(unittest.TestCase):
             mock_cs.side_effect = side_effect_change_colorspace
 
             mock_all_channel_clahe = ArgCopyingMagicMock()
-            mock_all_channel_clahe._augment_batch.side_effect = \
+            mock_all_channel_clahe._augment_batch_.side_effect = \
                 side_effect_all_channel_clahe
 
             clahe = iaa.CLAHE(
@@ -1371,7 +1371,7 @@ class TestCLAHE(unittest.TestCase):
             assert np.array_equal(img3d_aug, expected3)
 
             assert mock_cs.call_count == 2
-            assert mock_all_channel_clahe._augment_batch.call_count == 1
+            assert mock_all_channel_clahe._augment_batch_.call_count == 1
 
             # indices: call 0, args, arg 0
             assert np.array_equal(mock_cs.call_args_list[0][0][0], img3d)
@@ -1427,7 +1427,7 @@ class TestCLAHE(unittest.TestCase):
         mock_cs.side_effect = side_effect_change_colorspace
 
         mock_all_channel_clahe = ArgCopyingMagicMock()
-        mock_all_channel_clahe._augment_batch.side_effect = \
+        mock_all_channel_clahe._augment_batch_.side_effect = \
             side_effect_all_channel_clahe
 
         clahe = iaa.CLAHE(
@@ -1447,7 +1447,7 @@ class TestCLAHE(unittest.TestCase):
         assert np.array_equal(img4d_aug, expected4)
 
         assert mock_cs.call_count == 2
-        assert mock_all_channel_clahe._augment_batch.call_count == 1
+        assert mock_all_channel_clahe._augment_batch_.call_count == 1
 
         # indices: call 0, args, arg 0
         assert np.array_equal(mock_cs.call_args_list[0][0][0], img4d[..., 0:3])
@@ -1489,7 +1489,7 @@ class TestCLAHE(unittest.TestCase):
         mock_cs.side_effect = side_effect_change_colorspace
 
         mock_all_channel_clahe = ArgCopyingMagicMock()
-        mock_all_channel_clahe._augment_batch.side_effect = \
+        mock_all_channel_clahe._augment_batch_.side_effect = \
             side_effect_all_channel_clahe
 
         clahe = iaa.CLAHE(
@@ -1515,12 +1515,12 @@ class TestCLAHE(unittest.TestCase):
         assert np.array_equal(img5d_aug, img5d + 2)
 
         assert mock_cs.call_count == 0
-        assert mock_all_channel_clahe._augment_batch.call_count == 1
+        assert mock_all_channel_clahe._augment_batch_.call_count == 1
 
         # indices: call 0, args, arg 0, image 0 in list of images
         assert np.array_equal(
             mock_all_channel_clahe
-            ._augment_batch
+            ._augment_batch_
             .call_args_list[0][0][0]
             .images[0],
             img5d
@@ -1559,7 +1559,7 @@ class TestCLAHE(unittest.TestCase):
             mock_cs.side_effect = side_effect_change_colorspace
 
             mock_all_channel_clahe = ArgCopyingMagicMock()
-            mock_all_channel_clahe._augment_batch.side_effect = \
+            mock_all_channel_clahe._augment_batch_.side_effect = \
                 side_effect_all_channel_clahe
 
             clahe = iaa.CLAHE(
@@ -1576,19 +1576,19 @@ class TestCLAHE(unittest.TestCase):
             assert mock_cs.call_count == (n_3d_imgs*2 if with_3d_images else 0)
             assert (
                 mock_all_channel_clahe
-                ._augment_batch
+                ._augment_batch_
                 .call_count == 1)
 
             # indices: call 0, args, arg 0
             assert isinstance(
                 mock_all_channel_clahe
-                ._augment_batch
+                ._augment_batch_
                 .call_args_list[0][0][0],
                 iabatches.BatchInAugmentation)
 
             assert (
                 len(mock_all_channel_clahe
-                    ._augment_batch
+                    ._augment_batch_
                     .call_args_list[0][0][0]
                     .images)
                 == 5 if with_3d_images else 2)
@@ -1598,7 +1598,7 @@ class TestCLAHE(unittest.TestCase):
                 expected = imgs[i][..., np.newaxis]
                 assert np.array_equal(
                     mock_all_channel_clahe
-                    ._augment_batch
+                    ._augment_batch_
                     .call_args_list[0][0][0]
                     .images[i],
                     expected
@@ -1669,7 +1669,7 @@ class TestCLAHE(unittest.TestCase):
             mock_cs.side_effect = side_effect_change_colorspace
 
             mock_all_channel_clahe = ArgCopyingMagicMock()
-            mock_all_channel_clahe._augment_batch.side_effect = \
+            mock_all_channel_clahe._augment_batch_.side_effect = \
                 side_effect_all_channel_clahe
 
             clahe = iaa.CLAHE(
@@ -1688,21 +1688,21 @@ class TestCLAHE(unittest.TestCase):
                                           else 0)
             assert (
                 mock_all_channel_clahe
-                ._augment_batch
+                ._augment_batch_
                 .call_count
                 == 1)
 
             # indices: call 0, args, arg 0
             assert isinstance(
                 mock_all_channel_clahe
-                ._augment_batch
+                ._augment_batch_
                 .call_args_list[0][0][0],
                 iabatches.BatchInAugmentation)
 
             assert (
                 len(
                     mock_all_channel_clahe
-                    ._augment_batch
+                    ._augment_batch_
                     .call_args_list[0][0][0]
                     .images)
                 == nb_images)
@@ -1717,7 +1717,7 @@ class TestCLAHE(unittest.TestCase):
 
                     assert np.array_equal(
                         mock_all_channel_clahe
-                        ._augment_batch
+                        ._augment_batch_
                         .call_args_list[0][0][0]
                         .images[i],
                         expected

--- a/test/test_multicore.py
+++ b/test/test_multicore.py
@@ -747,21 +747,21 @@ class Test_Pool_worker(unittest.TestCase):
 
     def test_without_seed_start(self):
         augseq = mock.MagicMock()
-        augseq.augment_batch.return_value = "augmented_batch"
+        augseq.augment_batch_.return_value = "augmented_batch_"
         image = np.zeros((1, 1, 3), dtype=np.uint8)
         batch = UnnormalizedBatch(images=[image])
 
         multicore.Pool._WORKER_AUGSEQ = augseq
         result = multicore._Pool_worker(1, batch)
 
-        assert result == "augmented_batch"
-        assert augseq.augment_batch.call_count == 1
-        augseq.augment_batch.assert_called_once_with(batch)
+        assert result == "augmented_batch_"
+        assert augseq.augment_batch_.call_count == 1
+        augseq.augment_batch_.assert_called_once_with(batch)
 
     @mock.patch("imgaug.random.seed")
     def test_with_seed_start(self, mock_ia_seed):
         augseq = mock.MagicMock()
-        augseq.augment_batch.return_value = "augmented_batch"
+        augseq.augment_batch_.return_value = "augmented_batch_"
         image = np.zeros((1, 1, 3), dtype=np.uint8)
         batch = UnnormalizedBatch(images=[image])
         batch_idx = 1
@@ -784,9 +784,9 @@ class Test_Pool_worker(unittest.TestCase):
             % (iarandom.SEED_MAX_VALUE - iarandom.SEED_MIN_VALUE)
         )
 
-        assert result == "augmented_batch"
-        assert augseq.augment_batch.call_count == 1
-        augseq.augment_batch.assert_called_once_with(batch)
+        assert result == "augmented_batch_"
+        assert augseq.augment_batch_.call_count == 1
+        augseq.augment_batch_.assert_called_once_with(batch)
         mock_ia_seed.assert_called_once_with(seed_global_expected)
         augseq.seed_.assert_called_once_with(seed_local_expected)
 


### PR DESCRIPTION
This patch is a follow-up to #451. It makes the original patch no longer breaking, improves naming of methods and adds some tests.
List of changes:
* Rename `augment_batch()` to `augment_batch_()`.
* Rename `_augment_batch()` to `_augment_batch_()`.
* Re-add `augment_batch()` and mark it as deprecated.
* Add `UnnormalizedBatch.fill_from_normalized_batch_()` and use it in `augment_batch_()`.
* Add context `testutils.TemporaryDirectory`.
* Add a few tests for `augment_batch_()`.
* Add tests for augmenting images loaded via functions from popular libraries.