### PR TITLE
Simplify standard parameters of augmenters

### DIFF
--- a/changelogs/master/changed/20200112_simplified_augmenter_args.md
+++ b/changelogs/master/changed/20200112_simplified_augmenter_args.md
@@ -1,0 +1,31 @@
+# Simplified Standard Parameters of Augmenters #567
+
+Changed the standard parameters shared by all augmenters to a
+reduced and more self-explanatory set. Previously, all augmenters
+shared the parameters `name`, `random_state` and `deterministic`.
+The new parameters are `seed` and `name`.
+
+`deterministic` was removed as it was hardly ever used and because
+it caused frequently confusion with regards to its meaning. The
+parameter is still accepted but will now produce a deprecation
+warning. Use `<augmenter>.to_deterministic()` instead.
+(Reminder: `to_deterministic()` is necessary if you want to get
+the same samples in consecutive augmentation calls. It is *not*
+necessary if you want your generated samples to be dependent on
+an initial seed or random state as that is *always* the case
+anyways. You only have to manually set the seed, either
+augmenter-specific via the `seed` parameter or global via
+`imgaug.random.seed()` (affects only augmenters without their
+own seed).)
+
+`random_state` was renamed to `seed` as providing a seed value
+is the more common use case compared to providing a random state.
+Many users also seemed to be unaware that `random_state` accepted
+seed values. The new name should make this more clear.
+The old parameter `random_state` is still accepted, but will
+likely be deprecated in the future.
+
+**[breaking]** This patch breaks if one relied on the order of
+`name` and `random_state` instead of their names. These parameters
+are now in inverted order, i.e. `(..., seed=None, name=None, ...)`
+as seeds are much more commonly used than names.

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -1476,14 +1476,14 @@ class Add(meta.Augmenter):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1513,9 +1513,8 @@ class Add(meta.Augmenter):
     """
 
     def __init__(self, value=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
-        super(Add, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+                 seed=None, name=None, **old_kwargs):
+        super(Add, self).__init__(seed=seed, name=name, **old_kwargs)
 
         self.value = iap.handle_continuous_param(
             value, "value", value_range=None, tuple_to_uniform=True,
@@ -1612,14 +1611,14 @@ class AddElementwise(meta.Augmenter):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1648,9 +1647,9 @@ class AddElementwise(meta.Augmenter):
     """
 
     def __init__(self, value=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(AddElementwise, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.value = iap.handle_continuous_param(
             value, "value", value_range=None, tuple_to_uniform=True,
@@ -1739,14 +1738,14 @@ class AdditiveGaussianNoise(AddElementwise):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1775,7 +1774,7 @@ class AdditiveGaussianNoise(AddElementwise):
 
     """
     def __init__(self, loc=0, scale=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         loc2 = iap.handle_continuous_param(
             loc, "loc", value_range=None, tuple_to_uniform=True,
             list_to_choice=True)
@@ -1786,8 +1785,8 @@ class AdditiveGaussianNoise(AddElementwise):
         value = iap.Normal(loc=loc2, scale=scale2)
 
         super(AdditiveGaussianNoise, self).__init__(
-            value, per_channel=per_channel, name=name,
-            deterministic=deterministic, random_state=random_state)
+            value, per_channel=per_channel,
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO rename to AddLaplaceNoise?
@@ -1851,14 +1850,14 @@ class AdditiveLaplaceNoise(AddElementwise):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1887,7 +1886,7 @@ class AdditiveLaplaceNoise(AddElementwise):
 
     """
     def __init__(self, loc=0, scale=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         loc2 = iap.handle_continuous_param(
             loc, "loc", value_range=None, tuple_to_uniform=True,
             list_to_choice=True)
@@ -1900,9 +1899,7 @@ class AdditiveLaplaceNoise(AddElementwise):
         super(AdditiveLaplaceNoise, self).__init__(
             value,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO rename to AddPoissonNoise?
@@ -1952,14 +1949,14 @@ class AdditivePoissonNoise(AddElementwise):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1994,7 +1991,7 @@ class AdditivePoissonNoise(AddElementwise):
 
     """
     def __init__(self, lam=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         lam2 = iap.handle_continuous_param(
             lam, "lam",
             value_range=(0, None), tuple_to_uniform=True, list_to_choice=True)
@@ -2004,9 +2001,7 @@ class AdditivePoissonNoise(AddElementwise):
         super(AdditivePoissonNoise, self).__init__(
             value,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Multiply(meta.Augmenter):
@@ -2043,14 +2038,14 @@ class Multiply(meta.Augmenter):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2078,9 +2073,9 @@ class Multiply(meta.Augmenter):
     """
 
     def __init__(self, mul=1.0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Multiply, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.mul = iap.handle_continuous_param(
             mul, "mul", value_range=None, tuple_to_uniform=True,
@@ -2175,14 +2170,14 @@ class MultiplyElementwise(meta.Augmenter):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2211,9 +2206,9 @@ class MultiplyElementwise(meta.Augmenter):
     """
 
     def __init__(self, mul=1.0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(MultiplyElementwise, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.mul = iap.handle_continuous_param(
             mul, "mul",
@@ -2446,12 +2441,12 @@ class Cutout(meta.Augmenter):
                  fill_mode="constant",
                  cval=128,
                  fill_per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         from .size import _handle_position_parameter  # TODO move to iap
         from .geometric import _handle_cval_arg  # TODO move to iap
 
         super(Cutout, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.nb_iterations = iap.handle_discrete_param(
             nb_iterations, "nb_iterations", value_range=(0, None),
             tuple_to_uniform=True, list_to_choice=True, allow_floats=False)
@@ -2636,14 +2631,14 @@ class Dropout(MultiplyElementwise):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2669,15 +2664,13 @@ class Dropout(MultiplyElementwise):
 
     """
     def __init__(self, p=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         p_param = _handle_dropout_probability_param(p, "p")
 
         super(Dropout, self).__init__(
             p_param,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 def _handle_dropout_probability_param(p, name):
@@ -2816,14 +2809,14 @@ class CoarseDropout(MultiplyElementwise):
         less than ``2``, otherwise one may end up with a ``1x1`` low resolution
         mask, leading easily to the whole image being dropped.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2862,7 +2855,7 @@ class CoarseDropout(MultiplyElementwise):
     """
     def __init__(self, p=0, size_px=None, size_percent=None, per_channel=False,
                  min_size=4,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         p_param = _handle_dropout_probability_param(p, "p")
 
         if size_px is not None:
@@ -2879,9 +2872,7 @@ class CoarseDropout(MultiplyElementwise):
         super(CoarseDropout, self).__init__(
             p_param,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Dropout2d(meta.Augmenter):
@@ -2939,14 +2930,14 @@ class Dropout2d(meta.Augmenter):
         will not be dropped, even if ``p=1.0``. Set to ``0`` to allow dropping
         all channels.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2966,10 +2957,10 @@ class Dropout2d(meta.Augmenter):
 
     """
 
-    def __init__(self, p, nb_keep_channels=1, name=None, deterministic=False,
-                 random_state=None):
+    def __init__(self, p, nb_keep_channels=1,
+                 seed=None, name=None, **old_kwargs):
         super(Dropout2d, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.p = _handle_dropout_probability_param(p, "p")
         self.nb_keep_channels = max(nb_keep_channels, 0)
 
@@ -3115,14 +3106,14 @@ class TotalDropout(meta.Augmenter):
               parameter, you can usually do ``imgaug.parameters.Binomial(1-p)``
               to convert parameter `p` to a 0/1 representation.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3138,9 +3129,9 @@ class TotalDropout(meta.Augmenter):
 
     """
 
-    def __init__(self, p, name=None, deterministic=False, random_state=None):
+    def __init__(self, p, seed=None, name=None, **old_kwargs):
         super(TotalDropout, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.p = _handle_dropout_probability_param(p, "p")
 
         self._drop_images = True
@@ -3256,14 +3247,14 @@ class ReplaceElementwise(meta.Augmenter):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3306,9 +3297,9 @@ class ReplaceElementwise(meta.Augmenter):
     """
 
     def __init__(self, mask, replacement, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ReplaceElementwise, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.mask = iap.handle_probability_param(
             mask, "mask", tuple_to_uniform=True, list_to_choice=True)
@@ -3400,14 +3391,14 @@ class SaltAndPepper(ReplaceElementwise):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3424,14 +3415,12 @@ class SaltAndPepper(ReplaceElementwise):
 
     """
     def __init__(self, p=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(SaltAndPepper, self).__init__(
             mask=p,
             replacement=iap.Beta(0.5, 0.5) * 255,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
+            seed=seed, name=name, **old_kwargs
         )
 
 
@@ -3461,14 +3450,14 @@ class ImpulseNoise(SaltAndPepper):
               sampled from that parameter per image. Any value ``>0.5`` in
               that mask will be replaced with impulse noise noise.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3478,13 +3467,11 @@ class ImpulseNoise(SaltAndPepper):
     Replace ``10%`` of all pixels with impulse noise.
 
     """
-    def __init__(self, p=0, name=None, deterministic=False, random_state=None):
+    def __init__(self, p=0, seed=None, name=None, **old_kwargs):
         super(ImpulseNoise, self).__init__(
             p=p,
             per_channel=True,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CoarseSaltAndPepper(ReplaceElementwise):
@@ -3575,14 +3562,14 @@ class CoarseSaltAndPepper(ReplaceElementwise):
         less than ``2``, otherwise one may end up with a ``1x1`` low resolution
         mask, leading easily to the whole image being replaced.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3610,7 +3597,7 @@ class CoarseSaltAndPepper(ReplaceElementwise):
     """
     def __init__(self, p=0, size_px=None, size_percent=None,
                  per_channel=False, min_size=4,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         mask = iap.handle_probability_param(
             p, "p", tuple_to_uniform=True, list_to_choice=True)
 
@@ -3629,9 +3616,7 @@ class CoarseSaltAndPepper(ReplaceElementwise):
             mask=mask_low,
             replacement=replacement,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
+            seed=seed, name=name, **old_kwargs
         )
 
 
@@ -3672,14 +3657,14 @@ class Salt(ReplaceElementwise):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3691,7 +3676,7 @@ class Salt(ReplaceElementwise):
     """
 
     def __init__(self, p=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         replacement01 = iap.ForceSign(
             iap.Beta(0.5, 0.5) - 0.5,
             positive=True,
@@ -3704,9 +3689,7 @@ class Salt(ReplaceElementwise):
             mask=p,
             replacement=replacement,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CoarseSalt(ReplaceElementwise):
@@ -3789,14 +3772,14 @@ class CoarseSalt(ReplaceElementwise):
         less than ``2``, otherwise one may end up with a ``1x1`` low resolution
         mask, leading easily to the whole image being replaced.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3813,7 +3796,7 @@ class CoarseSalt(ReplaceElementwise):
 
     def __init__(self, p=0, size_px=None, size_percent=None, per_channel=False,
                  min_size=4,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         mask = iap.handle_probability_param(
             p, "p", tuple_to_uniform=True, list_to_choice=True)
 
@@ -3837,9 +3820,7 @@ class CoarseSalt(ReplaceElementwise):
             mask=mask_low,
             replacement=replacement,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Pepper(ReplaceElementwise):
@@ -3882,14 +3863,14 @@ class Pepper(ReplaceElementwise):
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3901,7 +3882,7 @@ class Pepper(ReplaceElementwise):
     """
 
     def __init__(self, p=0, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         replacement01 = iap.ForceSign(
             iap.Beta(0.5, 0.5) - 0.5,
             positive=False,
@@ -3913,9 +3894,7 @@ class Pepper(ReplaceElementwise):
             mask=p,
             replacement=replacement,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
+            seed=seed, name=name, **old_kwargs
         )
 
 
@@ -3997,14 +3976,14 @@ class CoarsePepper(ReplaceElementwise):
         otherwise one may end up with a ``1x1`` low resolution mask, leading
         easily to the whole image being replaced.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4021,7 +4000,7 @@ class CoarsePepper(ReplaceElementwise):
 
     def __init__(self, p=0, size_px=None, size_percent=None, per_channel=False,
                  min_size=4,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         mask = iap.handle_probability_param(
             p, "p", tuple_to_uniform=True, list_to_choice=True)
 
@@ -4045,9 +4024,7 @@ class CoarsePepper(ReplaceElementwise):
             mask=mask_low,
             replacement=replacement,
             per_channel=per_channel,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
+            seed=seed, name=name, **old_kwargs
         )
 
 
@@ -4121,14 +4098,14 @@ class Invert(meta.Augmenter):
         ``N`` and interpreted as ``True`` if ``>0.5``.
         If `threshold` is ``None`` this parameter has no effect.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4168,9 +4145,9 @@ class Invert(meta.Augmenter):
 
     def __init__(self, p=0, per_channel=False, min_value=None, max_value=None,
                  threshold=None, invert_above_threshold=0.5,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Invert, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         # TODO allow list and tuple for p
         self.p = iap.handle_probability_param(p, "p")
@@ -4296,14 +4273,14 @@ class Solarize(Invert):
     invert_above_threshold : bool or float or imgaug.parameters.StochasticParameter, optional
         See :class:`Invert`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4317,18 +4294,18 @@ class Solarize(Invert):
     """
     def __init__(self, p, per_channel=False, min_value=None, max_value=None,
                  threshold=(128-64, 128+64), invert_above_threshold=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Solarize, self).__init__(
             p=p, per_channel=per_channel,
             min_value=min_value, max_value=max_value,
             threshold=threshold, invert_above_threshold=invert_above_threshold,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO remove from examples
 @ia.deprecated("imgaug.contrast.LinearContrast")
 def ContrastNormalization(alpha=1.0, per_channel=False,
-                          name=None, deterministic=False, random_state=None):
+                          seed=None, name=None, **old_kwargs):
     """
     Change the contrast of images.
 
@@ -4362,14 +4339,14 @@ def ContrastNormalization(alpha=1.0, per_channel=False,
         with values between ``0.0`` and ``1.0``, where values ``>0.5`` will
         lead to per-channel behaviour (i.e. same as ``True``).
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4393,7 +4370,7 @@ def ContrastNormalization(alpha=1.0, per_channel=False,
     from . import contrast as contrast_lib
     return contrast_lib.LinearContrast(
         alpha=alpha, per_channel=per_channel,
-        name=name, deterministic=deterministic, random_state=random_state)
+        seed=seed, name=name, **old_kwargs)
 
 
 # TODO try adding per channel somehow
@@ -4436,14 +4413,14 @@ class JpegCompression(meta.Augmenter):
               from that parameter per ``N`` input images, each representing the
               compression for the ``n``-th image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4457,9 +4434,9 @@ class JpegCompression(meta.Augmenter):
 
     """
     def __init__(self, compression=50,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(JpegCompression, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         # will be converted to int during augmentation, which is why we allow
         # floats here

--- a/imgaug/augmenters/artistic.py
+++ b/imgaug/augmenters/artistic.py
@@ -291,14 +291,14 @@ class Cartoon(meta.Augmenter):
         The source colorspace. Use one of ``imgaug.augmenters.color.CSPACE_*``.
         Defaults to ``RGB``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -317,9 +317,9 @@ class Cartoon(meta.Augmenter):
     def __init__(self, blur_ksize=(1, 5), segmentation_size=(0.8, 1.2),
                  saturation=(1.5, 2.5), edge_prevalence=(0.9, 1.1),
                  from_colorspace=colorlib.CSPACE_RGB,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Cartoon, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.blur_ksize = iap.handle_continuous_param(
             blur_ksize, "blur_ksize", value_range=(0, None),

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -324,14 +324,14 @@ class BlendAlpha(meta.Augmenter):
         If this value is a float ``p``, then for ``p`` percent of all images
         `per_channel` will be treated as True, otherwise as False.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -385,9 +385,9 @@ class BlendAlpha(meta.Augmenter):
 
     def __init__(self, factor=0, foreground=None, background=None,
                  per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlpha, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.factor = iap.handle_continuous_param(
             factor, "factor", value_range=(0, 1.0), tuple_to_uniform=True,
@@ -542,14 +542,14 @@ class BlendAlphaMask(meta.Augmenter):
             * If iterable of ``Augmenter``, then that iterable will be
               converted into a ``Sequential`` and used as the augmenter.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
@@ -565,12 +565,9 @@ class BlendAlphaMask(meta.Augmenter):
 
     def __init__(self, mask_generator,
                  foreground=None, background=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaMask, self).__init__(
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
         self.mask_generator = mask_generator
 
@@ -827,14 +824,14 @@ class BlendAlphaElementwise(BlendAlphaMask):
         If this value is a float ``p``, then for ``p`` percent of all images
         `per_channel` will be treated as True, otherwise as False.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -891,14 +888,14 @@ class BlendAlphaElementwise(BlendAlphaMask):
 
     def __init__(self, factor=0, foreground=None, background=None,
                  per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         factor = iap.handle_continuous_param(
             factor, "factor", value_range=(0, 1.0), tuple_to_uniform=True,
             list_to_choice=True)
         mask_gen = StochasticParameterMaskGen(factor, per_channel)
         super(BlendAlphaElementwise, self).__init__(
             mask_gen, foreground, background,
-            name=name, deterministic=deterministic, random_state=random_state
+            seed=seed, name=name, **old_kwargs
         )
 
     @property
@@ -1028,14 +1025,14 @@ class BlendAlphaSimplexNoise(BlendAlphaElementwise):
             * If ``StochasticParameter``, then a random value will be sampled
               from that parameter per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1080,7 +1077,7 @@ class BlendAlphaSimplexNoise(BlendAlphaElementwise):
                  size_px_max=(2, 16), upscale_method=None,
                  iterations=(1, 3), aggregation_method="max",
                  sigmoid=True, sigmoid_thresh=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         upscale_method_default = iap.Choice(["nearest", "linear", "cubic"],
                                             p=[0.05, 0.6, 0.35])
         sigmoid_thresh_default = iap.Normal(0.0, 5.0)
@@ -1114,7 +1111,7 @@ class BlendAlphaSimplexNoise(BlendAlphaElementwise):
         super(BlendAlphaSimplexNoise, self).__init__(
             factor=noise, foreground=foreground, background=background,
             per_channel=per_channel,
-            name=name, deterministic=deterministic, random_state=random_state
+            seed=seed, name=name, **old_kwargs
         )
 
 
@@ -1257,14 +1254,14 @@ class BlendAlphaFrequencyNoise(BlendAlphaElementwise):
             * If ``StochasticParameter``, then a random value will be sampled
               from that parameter per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1318,7 +1315,7 @@ class BlendAlphaFrequencyNoise(BlendAlphaElementwise):
                  per_channel=False, size_px_max=(4, 16), upscale_method=None,
                  iterations=(1, 3), aggregation_method=["avg", "max"],
                  sigmoid=0.5, sigmoid_thresh=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         upscale_method_default = iap.Choice(["nearest", "linear", "cubic"],
                                             p=[0.05, 0.6, 0.35])
@@ -1354,7 +1351,7 @@ class BlendAlphaFrequencyNoise(BlendAlphaElementwise):
         super(BlendAlphaFrequencyNoise, self).__init__(
             factor=noise, foreground=foreground, background=background,
             per_channel=per_channel,
-            name=name, deterministic=deterministic, random_state=random_state
+            seed=seed, name=name, **old_kwargs
         )
 
 
@@ -1423,14 +1420,14 @@ class BlendAlphaSomeColors(BlendAlphaMask):
     from_colorspace : str, optional
         See :class:`~imgaug.augmenters.blend.SomeColorsMaskGen`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1476,7 +1473,7 @@ class BlendAlphaSomeColors(BlendAlphaMask):
                  nb_bins=(5, 15), smoothness=(0.1, 0.3),
                  alpha=[0.0, 1.0], rotation_deg=(0, 360),
                  from_colorspace="RGB",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaSomeColors, self).__init__(
             SomeColorsMaskGen(
                 nb_bins=nb_bins,
@@ -1487,10 +1484,7 @@ class BlendAlphaSomeColors(BlendAlphaMask):
             ),
             foreground=foreground,
             background=background,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
@@ -1549,14 +1543,14 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
     end_at : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1589,7 +1583,7 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
     def __init__(self, foreground=None, background=None,
                  min_value=(0.0, 0.2), max_value=(0.8, 1.0),
                  start_at=(0.0, 0.2), end_at=(0.8, 1.0),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaHorizontalLinearGradient, self).__init__(
             HorizontalLinearGradientMaskGen(
                 min_value=min_value,
@@ -1599,10 +1593,7 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
             ),
             foreground=foreground,
             background=background,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
@@ -1661,14 +1652,14 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
     end_at : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :class:`~imgaug.augmenters.blend.VerticalLinearGradientMaskGen`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1708,7 +1699,7 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
     def __init__(self, foreground=None, background=None,
                  min_value=(0.0, 0.2), max_value=(0.8, 1.0),
                  start_at=(0.0, 0.2), end_at=(0.8, 1.0),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaVerticalLinearGradient, self).__init__(
             VerticalLinearGradientMaskGen(
                 min_value=min_value,
@@ -1718,10 +1709,7 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
             ),
             foreground=foreground,
             background=background,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class BlendAlphaRegularGrid(BlendAlphaMask):
@@ -1789,14 +1777,14 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
         * If ``StochasticParameter``: That parameter will be queried once
           per batch for ``(N,)`` values -- one per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1827,7 +1815,7 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
     def __init__(self, nb_rows, nb_cols,
                  foreground=None, background=None,
                  alpha=[0.0, 1.0],
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaRegularGrid, self).__init__(
             RegularGridMaskGen(
                 nb_rows=nb_rows,
@@ -1836,10 +1824,7 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
             ),
             foreground=foreground,
             background=background,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class BlendAlphaCheckerboard(BlendAlphaMask):
@@ -1895,14 +1880,14 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
             * If iterable of ``Augmenter``, then that iterable will be
               converted into a ``Sequential`` and used as the augmenter.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1919,7 +1904,7 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
 
     def __init__(self, nb_rows, nb_cols,
                  foreground=None, background=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaCheckerboard, self).__init__(
             CheckerboardMaskGen(
                 nb_rows=nb_rows,
@@ -1927,10 +1912,7 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
             ),
             foreground=foreground,
             background=background,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class BlendAlphaSegMapClassIds(BlendAlphaMask):
@@ -1992,14 +1974,14 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
     nb_sample_classes : None or tuple of int or list of int or imgaug.parameters.StochasticParameter, optional
         See :class:`~imgaug.augmenters.blend.SegMapClassIdsMaskGen`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2040,7 +2022,7 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
                  class_ids,
                  foreground=None, background=None,
                  nb_sample_classes=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaSegMapClassIds, self).__init__(
             SegMapClassIdsMaskGen(
                 class_ids=class_ids,
@@ -2048,10 +2030,7 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
             ),
             foreground=foreground,
             background=background,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class BlendAlphaBoundingBoxes(BlendAlphaMask):
@@ -2108,14 +2087,14 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
     nb_sample_labels : None or tuple of int or list of int or imgaug.parameters.StochasticParameter, optional
         See :class:`~imgaug.augmenters.blend.BoundingBoxesMaskGen`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2162,7 +2141,7 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
                  labels,
                  foreground=None, background=None,
                  nb_sample_labels=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(BlendAlphaBoundingBoxes, self).__init__(
             BoundingBoxesMaskGen(
                 labels=labels,
@@ -2170,10 +2149,7 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
             ),
             foreground=foreground,
             background=background,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 @six.add_metaclass(ABCMeta)
@@ -3460,16 +3436,13 @@ class InvertMaskGen(IBatchwiseMaskGenerator):
                        "Parameter 'first' was renamed to 'foreground'. "
                        "Parameter 'second' was renamed to 'background'.")
 def Alpha(factor=0, first=None, second=None, per_channel=False,
-          name=None, deterministic=False, random_state=None):
+          seed=None, name=None, **old_kwargs):
     return BlendAlpha(
         factor=factor,
         foreground=first,
         background=second,
         per_channel=per_channel,
-        name=name,
-        deterministic=deterministic,
-        random_state=random_state
-    )
+        seed=seed, name=name, **old_kwargs)
 
 
 @ia.deprecated(alt_func="AlphaElementwise",
@@ -3479,16 +3452,13 @@ def Alpha(factor=0, first=None, second=None, per_channel=False,
                        "Parameter 'first' was renamed to 'foreground'. "
                        "Parameter 'second' was renamed to 'background'.")
 def AlphaElementwise(factor=0, first=None, second=None, per_channel=False,
-                     name=None, deterministic=False, random_state=None):
+                     seed=None, name=None, **old_kwargs):
     return BlendAlphaElementwise(
         factor=factor,
         foreground=first,
         background=second,
         per_channel=per_channel,
-        name=name,
-        deterministic=deterministic,
-        random_state=random_state
-    )
+        seed=seed, name=name, **old_kwargs)
 
 
 @ia.deprecated(alt_func="BlendAlphaSimplexNoise",
@@ -3501,7 +3471,7 @@ def SimplexNoiseAlpha(first=None, second=None, per_channel=False,
                       size_px_max=(2, 16), upscale_method=None,
                       iterations=(1, 3), aggregation_method="max",
                       sigmoid=True, sigmoid_thresh=None,
-                      name=None, deterministic=False, random_state=None):
+                      seed=None, name=None, **old_kwargs):
     return BlendAlphaSimplexNoise(
         foreground=first,
         background=second,
@@ -3512,10 +3482,7 @@ def SimplexNoiseAlpha(first=None, second=None, per_channel=False,
         aggregation_method=aggregation_method,
         sigmoid=sigmoid,
         sigmoid_thresh=sigmoid_thresh,
-        name=name,
-        deterministic=deterministic,
-        random_state=random_state
-    )
+        seed=seed, name=name, **old_kwargs)
 
 
 @ia.deprecated(alt_func="BlendAlphaFrequencyNoise",
@@ -3529,7 +3496,7 @@ def FrequencyNoiseAlpha(exponent=(-4, 4), first=None, second=None,
                         upscale_method=None,
                         iterations=(1, 3), aggregation_method=["avg", "max"],
                         sigmoid=0.5, sigmoid_thresh=None,
-                        name=None, deterministic=False, random_state=None):
+                        seed=None, name=None, **old_kwargs):
     return BlendAlphaFrequencyNoise(
         exponent=exponent,
         foreground=first,
@@ -3541,7 +3508,4 @@ def FrequencyNoiseAlpha(exponent=(-4, 4), first=None, second=None,
         aggregation_method=aggregation_method,
         sigmoid=sigmoid,
         sigmoid_thresh=sigmoid_thresh,
-        name=name,
-        deterministic=deterministic,
-        random_state=random_state
-    )
+        seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -406,14 +406,14 @@ class GaussianBlur(meta.Augmenter):
             * If a ``StochasticParameter``, then ``N`` samples will be drawn
               from that parameter per ``N`` input images.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -430,10 +430,10 @@ class GaussianBlur(meta.Augmenter):
 
     """
 
-    def __init__(self, sigma=0, name=None, deterministic=False,
-                 random_state=None):
+    def __init__(self, sigma=0,
+                 seed=None, name=None, **old_kwargs):
         super(GaussianBlur, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.sigma = iap.handle_continuous_param(
             sigma, "sigma", value_range=(0, None), tuple_to_uniform=True,
@@ -514,14 +514,14 @@ class AverageBlur(meta.Augmenter):
               above. This leads to different values for height and width of
               the kernel.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -543,9 +543,9 @@ class AverageBlur(meta.Augmenter):
 
     """
 
-    def __init__(self, k=1, name=None, deterministic=False, random_state=None):
+    def __init__(self, k=1, seed=None, name=None, **old_kwargs):
         super(AverageBlur, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         # TODO replace this by iap.handle_discrete_kernel_size()
         self.mode = "single"
@@ -705,14 +705,14 @@ class MedianBlur(meta.Augmenter):
               a sampled value is not odd, then that value will be increased
               by ``1``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -729,9 +729,9 @@ class MedianBlur(meta.Augmenter):
 
     """
 
-    def __init__(self, k=1, name=None, deterministic=False, random_state=None):
+    def __init__(self, k=1, seed=None, name=None, **old_kwargs):
         super(MedianBlur, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         # TODO replace this by iap.handle_discrete_kernel_size()
         self.k = iap.handle_discrete_param(
@@ -859,14 +859,14 @@ class BilateralBlur(meta.Augmenter):
               from that parameter per ``N`` input images, each representing
               the diameter for the n-th image. Expected to be discrete.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -881,10 +881,10 @@ class BilateralBlur(meta.Augmenter):
     """
 
     def __init__(self, d=1, sigma_color=(10, 250), sigma_space=(10, 250),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=invalid-name
         super(BilateralBlur, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.d = iap.handle_discrete_param(
             d, "d", value_range=(1, None), tuple_to_uniform=True,
@@ -989,14 +989,14 @@ class MotionBlur(iaa_convolutional.Convolve):
         continuous/smooth as `angle` is changed, particularly around multiple
         of ``45`` degrees.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1013,7 +1013,7 @@ class MotionBlur(iaa_convolutional.Convolve):
     """
 
     def __init__(self, k=5, angle=(0, 360), direction=(-1.0, 1.0), order=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # TODO allow (1, None) and set to identity matrix if k == 1
         k_param = iap.handle_discrete_param(
             k, "k", value_range=(3, None), tuple_to_uniform=True,
@@ -1029,8 +1029,8 @@ class MotionBlur(iaa_convolutional.Convolve):
                                                 direction_param, order)
 
         super(MotionBlur, self).__init__(
-            matrix_gen, name=name, deterministic=deterministic,
-            random_state=random_state)
+            matrix_gen,
+            seed=seed, name=name, **old_kwargs)
 
 
 class _MotionBlurMatrixGenerator(object):
@@ -1117,14 +1117,14 @@ class MeanShiftBlur(meta.Augmenter):
               per batch for ``(N,)`` values with ``N`` denoting the number of
               images.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1135,9 +1135,9 @@ class MeanShiftBlur(meta.Augmenter):
 
     """
     def __init__(self, spatial_radius=(5.0, 40.0), color_radius=(5.0, 40.0),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(MeanShiftBlur, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.spatial_window_radius = iap.handle_continuous_param(
             spatial_radius, "spatial_radius",
             value_range=(0.01, None), tuple_to_uniform=True,

--- a/imgaug/augmenters/collections.py
+++ b/imgaug/augmenters/collections.py
@@ -107,6 +107,15 @@ class RandAugment(meta.Sequential):
         ``3`` channels or come from a different dataset than used by the
         paper.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
+    name : None or str, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
+    **old_kwargs
+        Outdated parameters. Avoid using these.
+
     Examples
     --------
     >>> import imgaug.augmenters as iaa
@@ -140,9 +149,9 @@ class RandAugment(meta.Sequential):
     # N=2, M=28 is optimal for ImageNet with EfficientNet-B7
     # for cval they use [125, 122, 113]
     def __init__(self, n=2, m=(6, 12), cval=128,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=invalid-name
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG(seed)
 
         # we don't limit the value range to 10 here, because the paper
         # gives several examples of using more than 10 for M
@@ -169,11 +178,12 @@ class RandAugment(meta.Sequential):
 
         super(RandAugment, self).__init__(
             [
-                meta.Sequential(initial_augs, random_state=random_state),
+                meta.Sequential(initial_augs,
+                                seed=random_state.derive_rng_()),
                 meta.SomeOf(n, main_augs, random_order=True,
-                            random_state=random_state)
+                            seed=random_state.derive_rng_())
             ],
-            name=name, deterministic=deterministic, random_state=random_state
+            seed=random_state, name=name, **old_kwargs
         )
 
     @classmethod

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -945,11 +945,11 @@ def change_color_temperature(image, kelvin, from_colorspace=CSPACE_RGB):
 
 @ia.deprecated(alt_func="WithColorspace")
 def InColorspace(to_colorspace, from_colorspace="RGB", children=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
     """Convert images to another colorspace."""
     # pylint: disable=invalid-name
-    return WithColorspace(to_colorspace, from_colorspace, children, name,
-                          deterministic, random_state)
+    return WithColorspace(to_colorspace, from_colorspace, children,
+                          seed=seed, name=name, **old_kwargs)
 
 
 # TODO add tests
@@ -977,14 +977,14 @@ class WithColorspace(meta.Augmenter):
     children : imgaug.augmenters.meta.Augmenter or list of imgaug.augmenters.meta.Augmenter or None, optional
         One or more augmenters to apply to converted images.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1005,9 +1005,9 @@ class WithColorspace(meta.Augmenter):
     """
 
     def __init__(self, to_colorspace, from_colorspace=CSPACE_RGB, children=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(WithColorspace, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.to_colorspace = to_colorspace
         self.from_colorspace = from_colorspace
@@ -1098,14 +1098,14 @@ class WithBrightnessChannels(meta.Augmenter):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1153,10 +1153,10 @@ class WithBrightnessChannels(meta.Augmenter):
                      CSPACE_Luv,
                      CSPACE_YUV],
                  from_colorspace="RGB",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         super(WithBrightnessChannels, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.children = meta.handle_children_list(children, self.name, "then")
         self.to_colorspace = iap.handle_categorical_string_param(
@@ -1272,14 +1272,14 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
         order (``True``). If ``False``, this augmenter will always first
         multiply and then add.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1303,7 +1303,7 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
                      CSPACE_YUV],
                  from_colorspace="RGB",
                  random_order=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         mul = (
             meta.Identity()
@@ -1318,10 +1318,7 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
             ),
             to_colorspace=to_colorspace,
             from_colorspace=from_colorspace,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
     def __str__(self):
         return (
@@ -1364,14 +1361,14 @@ class MultiplyBrightness(MultiplyAndAddToBrightness):
     from_colorspace : str, optional
         See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1393,7 +1390,7 @@ class MultiplyBrightness(MultiplyAndAddToBrightness):
                      CSPACE_Luv,
                      CSPACE_YUV],
                  from_colorspace="RGB",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         super(MultiplyBrightness, self).__init__(
             mul=mul,
@@ -1401,10 +1398,7 @@ class MultiplyBrightness(MultiplyAndAddToBrightness):
             to_colorspace=to_colorspace,
             from_colorspace=from_colorspace,
             random_order=False,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class AddToBrightness(MultiplyAndAddToBrightness):
@@ -1428,14 +1422,14 @@ class AddToBrightness(MultiplyAndAddToBrightness):
     from_colorspace : str, optional
         See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1457,7 +1451,7 @@ class AddToBrightness(MultiplyAndAddToBrightness):
                      CSPACE_Luv,
                      CSPACE_YUV],
                  from_colorspace="RGB",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         super(AddToBrightness, self).__init__(
             mul=1.0,
@@ -1465,10 +1459,7 @@ class AddToBrightness(MultiplyAndAddToBrightness):
             to_colorspace=to_colorspace,
             from_colorspace=from_colorspace,
             random_order=False,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO Merge this into WithColorspace? A bit problematic due to int16
@@ -1506,14 +1497,14 @@ class WithHueAndSaturation(meta.Augmenter):
         They receive ``int16`` images with two channels (hue, saturation)
         and have to modify these.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1545,10 +1536,10 @@ class WithHueAndSaturation(meta.Augmenter):
 
     """
 
-    def __init__(self, children=None, from_colorspace="RGB", name=None,
-                 deterministic=False, random_state=None):
+    def __init__(self, children=None, from_colorspace="RGB",
+                 seed=None, name=None, **old_kwargs):
         super(WithHueAndSaturation, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.children = meta.handle_children_list(children, self.name, "then")
         self.from_colorspace = from_colorspace
@@ -1725,14 +1716,14 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1758,8 +1749,7 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
 
     def __init__(self, mul=None, mul_hue=None, mul_saturation=None,
                  per_channel=False, from_colorspace="RGB",
-                 name=None, deterministic=False,
-                 random_state=None):
+                 seed=None, name=None, **old_kwargs):
         if mul is not None:
             assert mul_hue is None, (
                 "`mul_hue` may not be set if `mul` is set. "
@@ -1782,10 +1772,14 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
                     mul_saturation, "mul_saturation", value_range=(0.0, 10.0),
                     tuple_to_uniform=True, list_to_choice=True)
 
-        if random_state is None:
+        if "random_state" in old_kwargs:
+            seed = old_kwargs["random_state"]
+            del old_kwargs["random_state"]
+
+        if seed is None:
             rss = [None] * 5
         else:
-            rss = iarandom.RNG(random_state).derive_rngs_(5)
+            rss = iarandom.RNG(seed).derive_rngs_(5)
 
         children = []
         if mul is not None:
@@ -1793,9 +1787,9 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
                 arithmetic.Multiply(
                     mul,
                     per_channel=per_channel,
+                    seed=rss[0],
                     name="%s-Multiply" % (name,),
-                    random_state=rss[0],
-                    deterministic=deterministic
+                    **old_kwargs
                 )
             )
         else:
@@ -1805,13 +1799,13 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
                         0,
                         arithmetic.Multiply(
                             mul_hue,
+                            seed=rss[0],
                             name="%s-MultiplyHue" % (name,),
-                            random_state=rss[0],
-                            deterministic=deterministic
+                            **old_kwargs
                         ),
+                        seed=rss[1],
                         name="%s-WithChannelsHue" % (name,),
-                        random_state=rss[1],
-                        deterministic=deterministic
+                        **old_kwargs
                     )
                 )
             if mul_saturation is not None:
@@ -1820,22 +1814,22 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
                         1,
                         arithmetic.Multiply(
                             mul_saturation,
+                            seed=rss[2],
                             name="%s-MultiplySaturation" % (name,),
-                            random_state=rss[2],
-                            deterministic=deterministic
+                            **old_kwargs
                         ),
+                        seed=rss[3],
                         name="%s-WithChannelsSaturation" % (name,),
-                        random_state=rss[3],
-                        deterministic=deterministic
+                        **old_kwargs
                     )
                 )
 
         super(MultiplyHueAndSaturation, self).__init__(
             children,
             from_colorspace=from_colorspace,
+            seed=rss[4],
             name=name,
-            random_state=rss[4],
-            deterministic=deterministic
+            **old_kwargs
         )
 
 
@@ -1874,14 +1868,14 @@ class MultiplyHue(MultiplyHueAndSaturation):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1893,14 +1887,12 @@ class MultiplyHue(MultiplyHueAndSaturation):
 
     """
 
-    def __init__(self, mul=(-1.0, 1.0), from_colorspace="RGB", name=None,
-                 deterministic=False, random_state=None):
+    def __init__(self, mul=(-1.0, 1.0), from_colorspace="RGB",
+                 seed=None, name=None, **old_kwargs):
         super(MultiplyHue, self).__init__(
             mul_hue=mul,
             from_colorspace=from_colorspace,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class MultiplySaturation(MultiplyHueAndSaturation):
@@ -1935,14 +1927,14 @@ class MultiplySaturation(MultiplyHueAndSaturation):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1954,14 +1946,12 @@ class MultiplySaturation(MultiplyHueAndSaturation):
 
     """
 
-    def __init__(self, mul=(0.0, 3.0), from_colorspace="RGB", name=None,
-                 deterministic=False, random_state=None):
+    def __init__(self, mul=(0.0, 3.0), from_colorspace="RGB",
+                 seed=None, name=None, **old_kwargs):
         super(MultiplySaturation, self).__init__(
             mul_saturation=mul,
             from_colorspace=from_colorspace,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class RemoveSaturation(MultiplySaturation):
@@ -1990,14 +1980,14 @@ class RemoveSaturation(MultiplySaturation):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2019,7 +2009,7 @@ class RemoveSaturation(MultiplySaturation):
     """
 
     def __init__(self, mul=(0.0, 1.0), from_colorspace=CSPACE_RGB,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         mul = iap.Subtract(
             1.0,
             iap.handle_continuous_param(mul, "mul",
@@ -2030,7 +2020,7 @@ class RemoveSaturation(MultiplySaturation):
         )
         super(RemoveSaturation, self).__init__(
             mul, from_colorspace=from_colorspace,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO removed deterministic and random_state here as parameters, because this
@@ -2169,14 +2159,14 @@ class AddToHueAndSaturation(meta.Augmenter):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2193,9 +2183,9 @@ class AddToHueAndSaturation(meta.Augmenter):
 
     def __init__(self, value=None, value_hue=None, value_saturation=None,
                  per_channel=False, from_colorspace="RGB",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(AddToHueAndSaturation, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.value = self._handle_value_arg(value, value_hue, value_saturation)
         self.value_hue = self._handle_value_hue_arg(value_hue)
@@ -2431,14 +2421,14 @@ class AddToHue(AddToHueAndSaturation):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2452,13 +2442,11 @@ class AddToHue(AddToHueAndSaturation):
     """
 
     def __init__(self, value=(-255, 255), from_colorspace=CSPACE_RGB,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(AddToHue, self).__init__(
             value_hue=value,
             from_colorspace=from_colorspace,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class AddToSaturation(AddToHueAndSaturation):
@@ -2496,14 +2484,14 @@ class AddToSaturation(AddToHueAndSaturation):
     from_colorspace : str, optional
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2516,14 +2504,12 @@ class AddToSaturation(AddToHueAndSaturation):
 
     """
 
-    def __init__(self, value=(-75, 75), from_colorspace="RGB", name=None,
-                 deterministic=False, random_state=None):
+    def __init__(self, value=(-75, 75), from_colorspace="RGB",
+                 seed=None, name=None, **old_kwargs):
         super(AddToSaturation, self).__init__(
             value_saturation=value,
             from_colorspace=from_colorspace,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO tests
@@ -2582,14 +2568,14 @@ class ChangeColorspace(meta.Augmenter):
             * If a StochasticParameter, a value will be sampled from the
               parameter per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
@@ -2641,9 +2627,9 @@ class ChangeColorspace(meta.Augmenter):
     }
 
     def __init__(self, to_colorspace, from_colorspace=CSPACE_RGB, alpha=1.0,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ChangeColorspace, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         # TODO somehow merge this with Alpha augmenter?
         self.alpha = iap.handle_continuous_param(
@@ -2766,14 +2752,14 @@ class Grayscale(ChangeColorspace):
         The source colorspace (of the input images).
         See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2793,14 +2779,12 @@ class Grayscale(ChangeColorspace):
     """
 
     def __init__(self, alpha=0, from_colorspace=CSPACE_RGB,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Grayscale, self).__init__(
             to_colorspace=CSPACE_GRAY,
             alpha=alpha,
             from_colorspace=from_colorspace,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class ChangeColorTemperature(meta.Augmenter):
@@ -2841,9 +2825,9 @@ class ChangeColorTemperature(meta.Augmenter):
     """
 
     def __init__(self, kelvin=(1000, 11000), from_colorspace=CSPACE_RGB,
-                 name=None, random_state=None, deterministic=False):
+                 seed=None, name=None, **old_kwargs):
         super(ChangeColorTemperature, self).__init__(
-            name=name, random_state=random_state, deterministic=deterministic)
+            seed=seed, name=name, **old_kwargs)
 
         self.kelvin = iap.handle_continuous_param(
             kelvin, "kelvin", value_range=(1000, 40000), tuple_to_uniform=True,
@@ -2875,10 +2859,10 @@ class _AbstractColorQuantization(meta.Augmenter):
                  to_colorspace=[CSPACE_RGB, CSPACE_Lab],
                  max_size=128,
                  interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         super(_AbstractColorQuantization, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.counts_value_range = counts_value_range
         self.counts = iap.handle_discrete_param(
@@ -2945,15 +2929,13 @@ class _AbstractColorQuantization(meta.Augmenter):
                 cs = ChangeColorspace(
                     from_colorspace=self.from_colorspace,
                     to_colorspace=self.to_colorspace,
-                    random_state=random_state.copy(),
-                    deterministic=True)
+                    random_state=random_state.copy(),)
                 _, to_colorspaces = cs._draw_samples(
                     1, random_state.copy())
                 cs_inv = ChangeColorspace(
                     from_colorspace=to_colorspaces[0],
                     to_colorspace=self.from_colorspace,
-                    random_state=random_state.copy(),
-                    deterministic=True)
+                    random_state=random_state.copy())
 
             image_tf = cs.augment_image(image)
             image_tf_aug = self._quantize(image_tf, counts)
@@ -3079,14 +3061,14 @@ class KMeansColorQuantization(_AbstractColorQuantization):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3127,7 +3109,7 @@ class KMeansColorQuantization(_AbstractColorQuantization):
     def __init__(self, n_colors=(2, 16), from_colorspace=CSPACE_RGB,
                  to_colorspace=[CSPACE_RGB, CSPACE_Lab],
                  max_size=128, interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         super(KMeansColorQuantization, self).__init__(
             counts=n_colors,
@@ -3135,7 +3117,7 @@ class KMeansColorQuantization(_AbstractColorQuantization):
             to_colorspace=to_colorspace,
             max_size=max_size,
             interpolation=interpolation,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     @property
     def n_colors(self):
@@ -3346,14 +3328,14 @@ class UniformColorQuantization(_AbstractColorQuantization):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3390,7 +3372,7 @@ class UniformColorQuantization(_AbstractColorQuantization):
                  to_colorspace=None,
                  max_size=None,
                  interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
         super(UniformColorQuantization, self).__init__(
             counts=n_colors,
@@ -3398,7 +3380,7 @@ class UniformColorQuantization(_AbstractColorQuantization):
             to_colorspace=to_colorspace,
             max_size=max_size,
             interpolation=interpolation,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     @property
     def n_colors(self):
@@ -3491,14 +3473,14 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3531,7 +3513,7 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
                  to_colorspace=None,
                  max_size=None,
                  interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=dangerous-default-value
 
         # wrt value range: for discrete params, (1, 8) results in
@@ -3543,7 +3525,7 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
             to_colorspace=to_colorspace,
             max_size=max_size,
             interpolation=interpolation,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def _quantize(self, image, counts):
         return quantize_uniform_to_n_bits_(image, counts)

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -32,9 +32,9 @@ from ..augmentables import batches as iabatches
 class _ContrastFuncWrapper(meta.Augmenter):
     def __init__(self, func, params1d, per_channel, dtypes_allowed=None,
                  dtypes_disallowed=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(_ContrastFuncWrapper, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.func = func
         self.params1d = params1d
         self.per_channel = iap.handle_probability_param(per_channel,
@@ -447,14 +447,14 @@ class GammaContrast(_ContrastFuncWrapper):
         float ``p``, then for ``p`` percent of all images `per_channel` will
         be treated as ``True``, otherwise as ``False``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -472,8 +472,8 @@ class GammaContrast(_ContrastFuncWrapper):
 
     """
 
-    def __init__(self, gamma=1, per_channel=False, name=None, deterministic=False,
-                 random_state=None):
+    def __init__(self, gamma=1, per_channel=False,
+                 seed=None, name=None, **old_kwargs):
         params1d = [iap.handle_continuous_param(
             gamma, "gamma", value_range=None, tuple_to_uniform=True,
             list_to_choice=True)]
@@ -484,10 +484,7 @@ class GammaContrast(_ContrastFuncWrapper):
                             "int8", "int16", "int32", "int64",
                             "float16", "float32", "float64"],
             dtypes_disallowed=["float96", "float128", "float256", "bool"],
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class SigmoidContrast(_ContrastFuncWrapper):
@@ -534,14 +531,14 @@ class SigmoidContrast(_ContrastFuncWrapper):
         float ``p``, then for ``p`` percent of all images `per_channel` will
         be treated as ``True``, otherwise as ``False``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -562,7 +559,7 @@ class SigmoidContrast(_ContrastFuncWrapper):
 
     """
     def __init__(self, gain=10, cutoff=0.5, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # TODO add inv parameter?
         params1d = [
             iap.handle_continuous_param(
@@ -580,10 +577,7 @@ class SigmoidContrast(_ContrastFuncWrapper):
                             "int8", "int16", "int32", "int64",
                             "float16", "float32", "float64"],
             dtypes_disallowed=["float96", "float128", "float256", "bool"],
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class LogContrast(_ContrastFuncWrapper):
@@ -617,14 +611,14 @@ class LogContrast(_ContrastFuncWrapper):
         float ``p``, then for ``p`` percent of all images `per_channel` will
         be treated as ``True``, otherwise as ``False``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -642,7 +636,7 @@ class LogContrast(_ContrastFuncWrapper):
 
     """
     def __init__(self, gain=1, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # TODO add inv parameter?
         params1d = [iap.handle_continuous_param(
             gain, "gain", value_range=(0, None), tuple_to_uniform=True,
@@ -655,10 +649,7 @@ class LogContrast(_ContrastFuncWrapper):
                             "int8", "int16", "int32", "int64",
                             "float16", "float32", "float64"],
             dtypes_disallowed=["float96", "float128", "float256", "bool"],
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class LinearContrast(_ContrastFuncWrapper):
@@ -689,14 +680,14 @@ class LinearContrast(_ContrastFuncWrapper):
         float ``p``, then for ``p`` percent of all images `per_channel` will
         be treated as ``True``, otherwise as ``False``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -714,7 +705,7 @@ class LinearContrast(_ContrastFuncWrapper):
 
     """
     def __init__(self, alpha=1, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         params1d = [
             iap.handle_continuous_param(
                 alpha, "alpha", value_range=None, tuple_to_uniform=True,
@@ -729,10 +720,7 @@ class LinearContrast(_ContrastFuncWrapper):
                             "float16", "float32", "float64"],
             dtypes_disallowed=["uint64", "int64", "float96", "float128",
                                "float256", "bool"],
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO maybe offer the other contrast augmenters also wrapped in this, similar
@@ -921,14 +909,14 @@ class AllChannelsCLAHE(meta.Augmenter):
         float ``p``, then for ``p`` percent of all images `per_channel` will
         be treated as ``True``, otherwise as ``False``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -954,9 +942,9 @@ class AllChannelsCLAHE(meta.Augmenter):
 
     def __init__(self, clip_limit=40, tile_grid_size_px=8,
                  tile_grid_size_px_min=3, per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(AllChannelsCLAHE, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.clip_limit = iap.handle_continuous_param(
             clip_limit, "clip_limit", value_range=(0+1e-4, None),
@@ -1143,14 +1131,14 @@ class CLAHE(meta.Augmenter):
         to all channels of an input image (without colorspace conversion),
         see ``imgaug.augmenters.contrast.AllChannelsCLAHE``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1206,9 +1194,9 @@ class CLAHE(meta.Augmenter):
                  tile_grid_size_px_min=3,
                  from_colorspace=color_lib.CSPACE_RGB,
                  to_colorspace=color_lib.CSPACE_Lab,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CLAHE, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.all_channel_clahe = AllChannelsCLAHE(
             clip_limit=clip_limit,
@@ -1293,14 +1281,14 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1317,9 +1305,9 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
     strengths. This leads to random strengths of the contrast adjustment.
 
     """
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(AllChannelsHistogramEqualization, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
@@ -1417,14 +1405,14 @@ class HistogramEqualization(meta.Augmenter):
         (without colorspace conversion), see
         ``imgaug.augmenters.contrast.AllChannelsHistogramEqualization``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1458,9 +1446,9 @@ class HistogramEqualization(meta.Augmenter):
 
     def __init__(self, from_colorspace=color_lib.CSPACE_RGB,
                  to_colorspace=color_lib.CSPACE_Lab,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(HistogramEqualization, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.all_channel_histogram_equalization = \
             AllChannelsHistogramEqualization(

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -74,14 +74,14 @@ class Convolve(meta.Augmenter):
               be ``None``, which will result in no changes to the respective
               channel.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -113,9 +113,9 @@ class Convolve(meta.Augmenter):
     """
 
     def __init__(self, matrix=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Convolve, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         if matrix is None:
             self.matrix = None
@@ -263,14 +263,14 @@ class Sharpen(Convolve):
             * If a ``StochasticParameter``, a value will be sampled from that
               parameter per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -289,7 +289,7 @@ class Sharpen(Convolve):
 
     """
     def __init__(self, alpha=0, lightness=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",
             value_range=(0, 1.0), tuple_to_uniform=True, list_to_choice=True)
@@ -300,8 +300,8 @@ class Sharpen(Convolve):
         matrix_gen = _SharpeningMatrixGenerator(alpha_param, lightness_param)
 
         super(Sharpen, self).__init__(
-            matrix=matrix_gen, name=name, deterministic=deterministic,
-            random_state=random_state)
+            matrix=matrix_gen,
+            seed=seed, name=name, **old_kwargs)
 
 
 class _SharpeningMatrixGenerator(object):
@@ -370,14 +370,14 @@ class Emboss(Convolve):
             * If a ``StochasticParameter``, a value will be sampled from the
               parameter per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -390,7 +390,7 @@ class Emboss(Convolve):
 
     """
     def __init__(self, alpha=0, strength=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",
             value_range=(0, 1.0), tuple_to_uniform=True, list_to_choice=True)
@@ -401,8 +401,8 @@ class Emboss(Convolve):
         matrix_gen = _EmbossMatrixGenerator(alpha_param, strength_param)
 
         super(Emboss, self).__init__(
-            matrix=matrix_gen, name=name, deterministic=deterministic,
-            random_state=random_state)
+            matrix=matrix_gen,
+            seed=seed, name=name, **old_kwargs)
 
 
 class _EmbossMatrixGenerator(object):
@@ -457,14 +457,14 @@ class EdgeDetect(Convolve):
             * If a ``StochasticParameter``, a value will be sampled from that
               parameter per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -476,8 +476,8 @@ class EdgeDetect(Convolve):
     blending factor between ``0%`` and ``100%``.
 
     """
-    def __init__(self, alpha=0, name=None, deterministic=False,
-                 random_state=None):
+    def __init__(self, alpha=0,
+                 seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",
             value_range=(0, 1.0), tuple_to_uniform=True, list_to_choice=True)
@@ -485,8 +485,8 @@ class EdgeDetect(Convolve):
         matrix_gen = _EdgeDetectMatrixGenerator(alpha_param)
 
         super(EdgeDetect, self).__init__(
-            matrix=matrix_gen, name=name, deterministic=deterministic,
-            random_state=random_state)
+            matrix=matrix_gen,
+            seed=seed, name=name, **old_kwargs)
 
 
 class _EdgeDetectMatrixGenerator(object):
@@ -563,14 +563,14 @@ class DirectedEdgeDetect(Convolve):
             * If a ``StochasticParameter``, a value will be sampled from the
               parameter per image.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -600,7 +600,7 @@ class DirectedEdgeDetect(Convolve):
 
     """
     def __init__(self, alpha=0, direction=(0.0, 1.0),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",
             value_range=(0, 1.0), tuple_to_uniform=True, list_to_choice=True)
@@ -612,8 +612,8 @@ class DirectedEdgeDetect(Convolve):
                                                         direction_param)
 
         super(DirectedEdgeDetect, self).__init__(
-            matrix=matrix_gen, name=name, deterministic=deterministic,
-            random_state=random_state)
+            matrix=matrix_gen,
+            seed=seed, name=name, **old_kwargs)
 
 
 class _DirectedEdgeDetectMatrixGenerator(object):

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -991,21 +991,21 @@ class _SaveDebugImage(meta.Augmenter):
         The schedule to use to determine for which batches an image is
         supposed to be generated.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
     def __init__(self, destination, schedule,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(_SaveDebugImage, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.destination = destination
         self.schedule = schedule
 
@@ -1046,14 +1046,14 @@ class SaveDebugImageEveryNBatches(_SaveDebugImage):
         executed conditionally or re-instantiated, it may not see all batches
         or the counter may be wrong in other ways.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1071,7 +1071,7 @@ class SaveDebugImageEveryNBatches(_SaveDebugImage):
     """
 
     def __init__(self, destination, interval,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         schedule = _EveryNBatchesSchedule(interval)
         if not isinstance(destination, _IImageDestination):
             assert os.path.isdir(destination), (
@@ -1084,7 +1084,7 @@ class SaveDebugImageEveryNBatches(_SaveDebugImage):
             ])
         super(SaveDebugImageEveryNBatches, self).__init__(
             destination=destination, schedule=schedule,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def get_parameters(self):
         dests = self.destination.destinations

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -256,14 +256,14 @@ class Canny(meta.Augmenter):
         color that was uniformly randomly sampled from the space of all
         ``uint8`` colors.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -314,8 +314,8 @@ class Canny(meta.Augmenter):
                  hysteresis_thresholds=((100-40, 100+40), (200-40, 200+40)),
                  sobel_kernel_size=(3, 7),
                  colorizer=None,
-                 name=None, deterministic=False, random_state=None):
-        super(Canny, self).__init__(name=name, deterministic=deterministic, random_state=random_state)
+                 seed=None, name=None, **old_kwargs):
+        super(Canny, self).__init__(seed=seed, name=name, **old_kwargs)
 
         self.alpha = iap.handle_continuous_param(
             alpha, "alpha", value_range=(0, 1.0), tuple_to_uniform=True,

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -835,14 +835,14 @@ class Fliplr(meta.Augmenter):
     p : number or imgaug.parameters.StochasticParameter, optional
         Probability of each image to get flipped.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -858,9 +858,9 @@ class Fliplr(meta.Augmenter):
 
     """
 
-    def __init__(self, p=0, name=None, deterministic=False, random_state=None):
+    def __init__(self, p=0, seed=None, name=None, **old_kwargs):
         super(Fliplr, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.p = iap.handle_probability_param(p, "p")
 
     def _augment_batch_(self, batch, random_state, parents, hooks):
@@ -936,14 +936,14 @@ class Flipud(meta.Augmenter):
     p : number or imgaug.parameters.StochasticParameter, optional
         Probability of each image to get flipped.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -958,9 +958,9 @@ class Flipud(meta.Augmenter):
 
     """
 
-    def __init__(self, p=0, name=None, deterministic=False, random_state=None):
+    def __init__(self, p=0, seed=None, name=None, **old_kwargs):
         super(Flipud, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.p = iap.handle_probability_param(p, "p")
 
     def _augment_batch_(self, batch, random_state, parents, hooks):

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1063,14 +1063,14 @@ class Affine(meta.Augmenter):
         as RGB). If ``cv2`` is chosen and order is ``2`` or ``4``, it will
         automatically fall back to order ``3``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1149,9 +1149,9 @@ class Affine(meta.Augmenter):
     def __init__(self, scale=1.0, translate_percent=None, translate_px=None,
                  rotate=0.0, shear=0.0, order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Affine, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         assert backend in ["auto", "skimage", "cv2"], (
             "Expected 'backend' to be \"auto\", \"skimage\" or \"cv2\", "
@@ -1534,14 +1534,14 @@ class ScaleX(Affine):
     backend : str, optional
         See :class:`Affine`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1557,7 +1557,7 @@ class ScaleX(Affine):
 
     def __init__(self, scale, order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ScaleX, self).__init__(
             scale={"x": scale},
             order=order,
@@ -1565,10 +1565,7 @@ class ScaleX(Affine):
             mode=mode,
             fit_output=fit_output,
             backend=backend,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO make Affine more efficient for translation-only transformations
@@ -1608,14 +1605,14 @@ class TranslateX(Affine):
     backend : str, optional
         See :class:`Affine`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1634,7 +1631,7 @@ class TranslateX(Affine):
 
     def __init__(self, percent=None, px=None, order=1,
                  cval=0, mode="constant", fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # we don't test here if both are not-None at the same time, because
         # that is already checked in Affine
         assert percent is not None or px is not None, (
@@ -1648,10 +1645,7 @@ class TranslateX(Affine):
             mode=mode,
             fit_output=fit_output,
             backend=backend,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO make Affine more efficient for translation-only transformations
@@ -1691,14 +1685,14 @@ class TranslateY(Affine):
     backend : str, optional
         See :class:`Affine`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1717,7 +1711,7 @@ class TranslateY(Affine):
 
     def __init__(self, percent=None, px=None, order=1,
                  cval=0, mode="constant", fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # we don't test here if both are not-None at the same time, because
         # that is already checked in Affine
         assert percent is not None or px is not None, (
@@ -1731,10 +1725,7 @@ class TranslateY(Affine):
             mode=mode,
             fit_output=fit_output,
             backend=backend,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class ScaleY(Affine):
@@ -1767,14 +1758,14 @@ class ScaleY(Affine):
     backend : str, optional
         See :class:`Affine`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1790,7 +1781,7 @@ class ScaleY(Affine):
 
     def __init__(self, scale, order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ScaleY, self).__init__(
             scale={"y": scale},
             order=order,
@@ -1798,10 +1789,7 @@ class ScaleY(Affine):
             mode=mode,
             fit_output=fit_output,
             backend=backend,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class Rotate(Affine):
@@ -1834,14 +1822,14 @@ class Rotate(Affine):
     backend : str, optional
         See :class:`Affine`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1855,7 +1843,7 @@ class Rotate(Affine):
 
     def __init__(self, rotate, order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Rotate, self).__init__(
             rotate=rotate,
             order=order,
@@ -1863,10 +1851,7 @@ class Rotate(Affine):
             mode=mode,
             fit_output=fit_output,
             backend=backend,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class ShearX(Affine):
@@ -1899,20 +1884,20 @@ class ShearX(Affine):
     backend : str, optional
         See :class:`Affine`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
     def __init__(self, shear, order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ShearX, self).__init__(
             shear={"x": shear},
             order=order,
@@ -1920,10 +1905,7 @@ class ShearX(Affine):
             mode=mode,
             fit_output=fit_output,
             backend=backend,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class ShearY(Affine):
@@ -1956,20 +1938,20 @@ class ShearY(Affine):
     backend : str, optional
         See :class:`Affine`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
     def __init__(self, shear, order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ShearY, self).__init__(
             shear={"y": shear},
             order=order,
@@ -1977,10 +1959,7 @@ class ShearY(Affine):
             mode=mode,
             fit_output=fit_output,
             backend=backend,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class AffineCv2(meta.Augmenter):
@@ -2195,14 +2174,14 @@ class AffineCv2(meta.Augmenter):
               that parameter per image, i.e. it must return only the above
               mentioned strings.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2274,9 +2253,9 @@ class AffineCv2(meta.Augmenter):
     def __init__(self, scale=1.0, translate_percent=None, translate_px=None,
                  rotate=0.0, shear=0.0, order=cv2.INTER_LINEAR, cval=0,
                  mode=cv2.BORDER_CONSTANT,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(AffineCv2, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         # using a context on __init__ seems to produce no warning,
         # so warn manually here
@@ -2840,14 +2819,14 @@ class PiecewiseAffine(meta.Augmenter):
         ``recover_from()`` method, similar to
         :class:`~imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2867,9 +2846,9 @@ class PiecewiseAffine(meta.Augmenter):
 
     def __init__(self, scale=0, nb_rows=4, nb_cols=4, order=1, cval=0,
                  mode="constant", absolute_scale=False, polygon_recoverer=None,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(PiecewiseAffine, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.scale = iap.handle_continuous_param(
             scale, "scale", value_range=(0, None), tuple_to_uniform=True,
@@ -3358,14 +3337,14 @@ class PerspectiveTransform(meta.Augmenter):
         ``recover_from()`` method, similar to
         :class:`~imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3393,9 +3372,9 @@ class PerspectiveTransform(meta.Augmenter):
 
     def __init__(self, scale=0, cval=0, mode="constant", keep_size=True,
                  fit_output=False, polygon_recoverer="auto",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(PerspectiveTransform, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.scale = iap.handle_continuous_param(
             scale, "scale", value_range=(0, None), tuple_to_uniform=True,
@@ -4004,14 +3983,14 @@ class ElasticTransformation(meta.Augmenter):
         ``recover_from()`` method, similar to
         :class:`~imgaug.augmentables.polygons._ConcavePolygonRecoverer`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4053,10 +4032,10 @@ class ElasticTransformation(meta.Augmenter):
     }
 
     def __init__(self, alpha=0, sigma=0, order=3, cval=0, mode="constant",
-                 polygon_recoverer="auto", name=None, deterministic=False,
-                 random_state=None):
+                 polygon_recoverer="auto",
+                 seed=None, name=None, **old_kwargs):
         super(ElasticTransformation, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.alpha = iap.handle_continuous_param(
             alpha, "alpha", value_range=(0, None), tuple_to_uniform=True,
@@ -4657,14 +4636,14 @@ class Rot90(meta.Augmenter):
         image will be resized to the input image's size. Note that this might
         also cause the augmented image to look distorted.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4698,10 +4677,10 @@ class Rot90(meta.Augmenter):
 
     """
 
-    def __init__(self, k, keep_size=True, name=None, deterministic=False,
-                 random_state=None):
+    def __init__(self, k, keep_size=True,
+                 seed=None, name=None, **old_kwargs):
         super(Rot90, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         if k == ia.ALL:
             k = [0, 1, 2, 3]
@@ -4911,14 +4890,14 @@ class WithPolarWarping(meta.Augmenter):
         One or more augmenters to apply to images after they were transformed
         to polar representation.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4946,10 +4925,10 @@ class WithPolarWarping(meta.Augmenter):
 
     """
 
-    def __init__(self, children, name=None, deterministic=False,
-                 random_state=None):
+    def __init__(self, children,
+                 seed=None, name=None, **old_kwargs):
         super(WithPolarWarping, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.children = meta.handle_children_list(children, self.name, "then")
 
     def _augment_batch_(self, batch, random_state, parents, hooks):
@@ -5555,14 +5534,14 @@ class Jigsaw(meta.Augmenter):
         Whether to allow automatically padding images until they are evenly
         divisible by ``nb_rows`` and ``nb_cols``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -5586,9 +5565,9 @@ class Jigsaw(meta.Augmenter):
     """
 
     def __init__(self, nb_rows, nb_cols, max_steps=2, allow_pad=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Jigsaw, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.nb_rows = iap.handle_discrete_param(
             nb_rows, "nb_rows", value_range=(1, None), tuple_to_uniform=True,

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -944,9 +944,9 @@ def apply_elastic_transform(image, severity=1, seed=None):
 
 class _ImgcorruptAugmenterBase(meta.Augmenter):
     def __init__(self, func, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(_ImgcorruptAugmenterBase, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.func = func
         self.severity = iap.handle_discrete_param(
@@ -996,14 +996,14 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1017,10 +1017,10 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(GaussianNoise, self).__init__(
             apply_gaussian_noise, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class ShotNoise(_ImgcorruptAugmenterBase):
@@ -1042,14 +1042,14 @@ class ShotNoise(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1063,10 +1063,10 @@ class ShotNoise(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ShotNoise, self).__init__(
             apply_shot_noise, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class ImpulseNoise(_ImgcorruptAugmenterBase):
@@ -1088,14 +1088,14 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1109,10 +1109,10 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ImpulseNoise, self).__init__(
             apply_impulse_noise, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class SpeckleNoise(_ImgcorruptAugmenterBase):
@@ -1134,14 +1134,14 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1155,10 +1155,10 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(SpeckleNoise, self).__init__(
             apply_speckle_noise, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class GaussianBlur(_ImgcorruptAugmenterBase):
@@ -1180,14 +1180,14 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1201,10 +1201,10 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(GaussianBlur, self).__init__(
             apply_gaussian_blur, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class GlassBlur(_ImgcorruptAugmenterBase):
@@ -1226,14 +1226,14 @@ class GlassBlur(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1247,10 +1247,10 @@ class GlassBlur(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(GlassBlur, self).__init__(
             apply_glass_blur, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class DefocusBlur(_ImgcorruptAugmenterBase):
@@ -1272,14 +1272,14 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1293,10 +1293,10 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(DefocusBlur, self).__init__(
             apply_defocus_blur, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class MotionBlur(_ImgcorruptAugmenterBase):
@@ -1318,14 +1318,14 @@ class MotionBlur(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1339,10 +1339,10 @@ class MotionBlur(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(MotionBlur, self).__init__(
             apply_motion_blur, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class ZoomBlur(_ImgcorruptAugmenterBase):
@@ -1364,14 +1364,14 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1385,10 +1385,10 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ZoomBlur, self).__init__(
             apply_zoom_blur, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Fog(_ImgcorruptAugmenterBase):
@@ -1410,14 +1410,14 @@ class Fog(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1431,10 +1431,10 @@ class Fog(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Fog, self).__init__(
             apply_fog, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Frost(_ImgcorruptAugmenterBase):
@@ -1456,14 +1456,14 @@ class Frost(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1477,10 +1477,10 @@ class Frost(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Frost, self).__init__(
             apply_frost, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Snow(_ImgcorruptAugmenterBase):
@@ -1502,14 +1502,14 @@ class Snow(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1523,10 +1523,10 @@ class Snow(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Snow, self).__init__(
             apply_snow, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Spatter(_ImgcorruptAugmenterBase):
@@ -1548,14 +1548,14 @@ class Spatter(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1569,10 +1569,10 @@ class Spatter(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Spatter, self).__init__(
             apply_spatter, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Contrast(_ImgcorruptAugmenterBase):
@@ -1594,14 +1594,14 @@ class Contrast(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1615,10 +1615,10 @@ class Contrast(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Contrast, self).__init__(
             apply_contrast, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Brightness(_ImgcorruptAugmenterBase):
@@ -1640,14 +1640,14 @@ class Brightness(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1661,10 +1661,10 @@ class Brightness(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Brightness, self).__init__(
             apply_brightness, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Saturate(_ImgcorruptAugmenterBase):
@@ -1686,14 +1686,14 @@ class Saturate(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1707,10 +1707,10 @@ class Saturate(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Saturate, self).__init__(
             apply_saturate, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class JpegCompression(_ImgcorruptAugmenterBase):
@@ -1732,14 +1732,14 @@ class JpegCompression(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1753,10 +1753,10 @@ class JpegCompression(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(JpegCompression, self).__init__(
             apply_jpeg_compression, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Pixelate(_ImgcorruptAugmenterBase):
@@ -1778,14 +1778,14 @@ class Pixelate(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1799,10 +1799,10 @@ class Pixelate(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Pixelate, self).__init__(
             apply_pixelate, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class ElasticTransform(_ImgcorruptAugmenterBase):
@@ -1824,14 +1824,14 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
         Strength of the corruption, with valid values being
         ``1 <= severity <= 5``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1845,7 +1845,7 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
     """
 
     def __init__(self, severity=1,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(ElasticTransform, self).__init__(
             apply_elastic_transform, severity,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -1236,14 +1236,14 @@ class Solarize(arithmetic.Invert):
     threshold : None or number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :class:`~imgaug.augmenters.arithmetic.Invert`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1257,12 +1257,12 @@ class Solarize(arithmetic.Invert):
     """
 
     def __init__(self, p=1.0, threshold=128,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Solarize, self).__init__(
             p=p, per_channel=False,
             min_value=None, max_value=None,
             threshold=threshold, invert_above_threshold=True,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Posterize(colorlib.Posterize):
@@ -1294,14 +1294,14 @@ class Equalize(meta.Augmenter):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1312,9 +1312,9 @@ class Equalize(meta.Augmenter):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(Equalize, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=no-self-use
@@ -1359,14 +1359,14 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
         float ``p``, then for ``p`` percent of all images `per_channel` will
         be treated as ``True``, otherwise as ``False``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1386,7 +1386,7 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
     # pylint: disable=protected-access
 
     def __init__(self, cutoff=(0, 20), per_channel=False,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         params1d = [
             iap.handle_discrete_param(
                 cutoff, "cutoff", value_range=(0, 49), tuple_to_uniform=True,
@@ -1402,17 +1402,14 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
                                "float16", "float32", "float64",
                                "float16", "float32", "float64", "float96",
                                "float128", "float256", "bool"],
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class _EnhanceBase(meta.Augmenter):
     def __init__(self, func, factor, factor_value_range,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(_EnhanceBase, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.func = func
         self.factor = iap.handle_continuous_param(
             factor, "factor", value_range=factor_value_range,
@@ -1460,14 +1457,14 @@ class EnhanceColor(_EnhanceBase):
             * If ``StochasticParameter``: Per batch of size ``N``, the
               parameter will be queried once to return ``(N,)`` samples.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1480,12 +1477,12 @@ class EnhanceColor(_EnhanceBase):
     """
 
     def __init__(self, factor=(0.0, 3.0),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(EnhanceColor, self).__init__(
             func=enhance_color,
             factor=factor,
             factor_value_range=(0.0, None),
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class EnhanceContrast(_EnhanceBase):
@@ -1513,14 +1510,14 @@ class EnhanceContrast(_EnhanceBase):
             * If ``StochasticParameter``: Per batch of size ``N``, the
               parameter will be queried once to return ``(N,)`` samples.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1533,12 +1530,12 @@ class EnhanceContrast(_EnhanceBase):
     """
 
     def __init__(self, factor=(0.5, 1.5),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(EnhanceContrast, self).__init__(
             func=enhance_contrast,
             factor=factor,
             factor_value_range=(0.0, None),
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class EnhanceBrightness(_EnhanceBase):
@@ -1566,14 +1563,14 @@ class EnhanceBrightness(_EnhanceBase):
             * If ``StochasticParameter``: Per batch of size ``N``, the
               parameter will be queried once to return ``(N,)`` samples.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1586,12 +1583,12 @@ class EnhanceBrightness(_EnhanceBase):
     """
 
     def __init__(self, factor=(0.5, 1.5),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(EnhanceBrightness, self).__init__(
             func=enhance_brightness,
             factor=factor,
             factor_value_range=(0.0, None),
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class EnhanceSharpness(_EnhanceBase):
@@ -1619,14 +1616,14 @@ class EnhanceSharpness(_EnhanceBase):
             * If ``StochasticParameter``: Per batch of size ``N``, the
               parameter will be queried once to return ``(N,)`` samples.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1639,19 +1636,19 @@ class EnhanceSharpness(_EnhanceBase):
     """
 
     def __init__(self, factor=(0.0, 2.0),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(EnhanceSharpness, self).__init__(
             func=enhance_sharpness,
             factor=factor,
             factor_value_range=(0.0, None),
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class _FilterBase(meta.Augmenter):
     def __init__(self, func,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(_FilterBase, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.func = func
 
     def _augment_batch_(self, batch, random_state, parents, hooks):
@@ -1680,14 +1677,14 @@ class FilterBlur(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1698,10 +1695,10 @@ class FilterBlur(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterBlur, self).__init__(
             func=filter_blur,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterSmooth(_FilterBase):
@@ -1716,14 +1713,14 @@ class FilterSmooth(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1734,10 +1731,10 @@ class FilterSmooth(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterSmooth, self).__init__(
             func=filter_smooth,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterSmoothMore(_FilterBase):
@@ -1752,14 +1749,14 @@ class FilterSmoothMore(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1771,10 +1768,10 @@ class FilterSmoothMore(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterSmoothMore, self).__init__(
             func=filter_smooth_more,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterEdgeEnhance(_FilterBase):
@@ -1790,14 +1787,14 @@ class FilterEdgeEnhance(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1809,10 +1806,10 @@ class FilterEdgeEnhance(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterEdgeEnhance, self).__init__(
             func=filter_edge_enhance,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterEdgeEnhanceMore(_FilterBase):
@@ -1828,14 +1825,14 @@ class FilterEdgeEnhanceMore(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1847,10 +1844,10 @@ class FilterEdgeEnhanceMore(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterEdgeEnhanceMore, self).__init__(
             func=filter_edge_enhance_more,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterFindEdges(_FilterBase):
@@ -1866,14 +1863,14 @@ class FilterFindEdges(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1884,10 +1881,10 @@ class FilterFindEdges(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterFindEdges, self).__init__(
             func=filter_find_edges,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterContour(_FilterBase):
@@ -1902,14 +1899,14 @@ class FilterContour(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1921,10 +1918,10 @@ class FilterContour(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterContour, self).__init__(
             func=filter_contour,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterEmboss(_FilterBase):
@@ -1939,14 +1936,14 @@ class FilterEmboss(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1957,10 +1954,10 @@ class FilterEmboss(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterEmboss, self).__init__(
             func=filter_emboss,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterSharpen(_FilterBase):
@@ -1975,14 +1972,14 @@ class FilterSharpen(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1993,10 +1990,10 @@ class FilterSharpen(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterSharpen, self).__init__(
             func=filter_sharpen,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class FilterDetail(_FilterBase):
@@ -2011,14 +2008,14 @@ class FilterDetail(_FilterBase):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2030,10 +2027,10 @@ class FilterDetail(_FilterBase):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(FilterDetail, self).__init__(
             func=filter_detail,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class Affine(geometric.Affine):
@@ -2093,14 +2090,14 @@ class Affine(geometric.Affine):
         :class:`~imgaug.augmenters.size.PadToFixedSize` for details
         about valid datatypes of this parameter.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2131,7 +2128,7 @@ class Affine(geometric.Affine):
 
     def __init__(self, scale=1.0, translate_percent=None, translate_px=None,
                  rotate=0.0, shear=0.0, fillcolor=0, center=(0.5, 0.5),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Affine, self).__init__(
             scale=scale,
             translate_percent=translate_percent,
@@ -2143,10 +2140,7 @@ class Affine(geometric.Affine):
             mode="constant",
             fit_output=False,
             backend="auto",
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
         # TODO move that func to iap
         self.center = sizelib._handle_position_parameter(center)
 

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -44,9 +44,9 @@ class _AbstractPoolingBase(meta.Augmenter):
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
     def __init__(self, kernel_size, keep_size=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(_AbstractPoolingBase, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.kernel_size = iap.handle_discrete_kernel_size_param(
             kernel_size,
             "kernel_size",
@@ -243,14 +243,14 @@ class AveragePooling(_AbstractPoolingBase):
         to the input image's size, i.e. the augmenter's output shape is always
         identical to the input shape.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -288,10 +288,10 @@ class AveragePooling(_AbstractPoolingBase):
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
     def __init__(self, kernel_size, keep_size=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(AveragePooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def _pool_image(self, image, kernel_size_h, kernel_size_w):
         return ia.avg_pool(
@@ -354,14 +354,14 @@ class MaxPooling(_AbstractPoolingBase):
         to the input image's size, i.e. the augmenter's output shape is always
         identical to the input shape.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -399,10 +399,10 @@ class MaxPooling(_AbstractPoolingBase):
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
     def __init__(self, kernel_size, keep_size=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(MaxPooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def _pool_image(self, image, kernel_size_h, kernel_size_w):
         # TODO extend max_pool to support pad_mode and set it here
@@ -467,14 +467,14 @@ class MinPooling(_AbstractPoolingBase):
         to the input image's size, i.e. the augmenter's output shape is always
         identical to the input shape.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -512,10 +512,10 @@ class MinPooling(_AbstractPoolingBase):
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
     def __init__(self, kernel_size, keep_size=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(MinPooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def _pool_image(self, image, kernel_size_h, kernel_size_w):
         # TODO extend pool to support pad_mode and set it here
@@ -580,14 +580,14 @@ class MedianPooling(_AbstractPoolingBase):
         to the input image's size, i.e. the augmenter's output shape is always
         identical to the input shape.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -625,10 +625,10 @@ class MedianPooling(_AbstractPoolingBase):
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
     def __init__(self, kernel_size, keep_size=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(MedianPooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
     def _pool_image(self, image, kernel_size_h, kernel_size_w):
         # TODO extend pool to support pad_mode and set it here

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -167,14 +167,14 @@ class Superpixels(meta.Augmenter):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -199,9 +199,9 @@ class Superpixels(meta.Augmenter):
 
     def __init__(self, p_replace=0, n_segments=100, max_size=128,
                  interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Superpixels, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.p_replace = iap.handle_probability_param(
             p_replace, "p_replace", tuple_to_uniform=True, list_to_choice=True)
@@ -528,14 +528,14 @@ class Voronoi(meta.Augmenter):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -574,9 +574,9 @@ class Voronoi(meta.Augmenter):
 
     def __init__(self, points_sampler, p_replace=1.0, max_size=128,
                  interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(Voronoi, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         assert isinstance(points_sampler, IPointsSampler), (
             "Expected 'points_sampler' to be an instance of IPointsSampler, "
@@ -707,14 +707,14 @@ class UniformVoronoi(Voronoi):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -741,16 +741,13 @@ class UniformVoronoi(Voronoi):
 
     def __init__(self, n_points, p_replace=1.0, max_size=128,
                  interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(UniformVoronoi, self).__init__(
             points_sampler=UniformPointsSampler(n_points),
             p_replace=p_replace,
             max_size=max_size,
             interpolation=interpolation,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class RegularGridVoronoi(Voronoi):
@@ -862,14 +859,14 @@ class RegularGridVoronoi(Voronoi):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -897,7 +894,7 @@ class RegularGridVoronoi(Voronoi):
 
     def __init__(self, n_rows, n_cols, p_drop_points=0.4, p_replace=1.0,
                  max_size=128, interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(RegularGridVoronoi, self).__init__(
             points_sampler=DropoutPointsSampler(
                 RegularGridPointsSampler(n_rows, n_cols),
@@ -906,10 +903,7 @@ class RegularGridVoronoi(Voronoi):
             p_replace=p_replace,
             max_size=max_size,
             interpolation=interpolation,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class RelativeRegularGridVoronoi(Voronoi):
@@ -1031,14 +1025,14 @@ class RelativeRegularGridVoronoi(Voronoi):
         exceeded. Valid methods are the same as in
         :func:`~imgaug.imgaug.imresize_single_image`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1071,7 +1065,7 @@ class RelativeRegularGridVoronoi(Voronoi):
 
     def __init__(self, n_rows_frac, n_cols_frac, p_drop_points=0.4,
                  p_replace=1.0, max_size=None, interpolation="linear",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(RelativeRegularGridVoronoi, self).__init__(
             points_sampler=DropoutPointsSampler(
                 RelativeRegularGridPointsSampler(n_rows_frac, n_cols_frac),
@@ -1080,10 +1074,7 @@ class RelativeRegularGridVoronoi(Voronoi):
             p_replace=p_replace,
             max_size=max_size,
             interpolation=interpolation,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 @six.add_metaclass(ABCMeta)

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -1161,14 +1161,14 @@ class Resize(meta.Augmenter):
               queried per image and is expected to return an ``int`` or
               ``str``.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1232,9 +1232,9 @@ class Resize(meta.Augmenter):
     """
 
     def __init__(self, size, interpolation="cubic",
-                 name=None, deterministic=False, random_state=None):
-        super(Resize, self).__init__(name=name, deterministic=deterministic,
-                                     random_state=random_state)
+                 seed=None, name=None, **old_kwargs):
+        super(Resize, self).__init__(
+            seed=seed, name=name, **old_kwargs)
 
         self.size, self.size_order = self._handle_size_arg(size, False)
         self.interpolation = self._handle_interpolation_arg(interpolation)
@@ -1668,14 +1668,14 @@ class CropAndPad(meta.Augmenter):
         all sides. I.e. the crop/pad amount then is the same for all sides.
         If ``True``, four values will be sampled independently, one per side.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1754,10 +1754,10 @@ class CropAndPad(meta.Augmenter):
 
     def __init__(self, px=None, percent=None, pad_mode="constant", pad_cval=0,
                  keep_size=True, sample_independently=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         # pylint: disable=invalid-name
         super(CropAndPad, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.mode, self.all_sides, self.top, self.right, self.bottom, \
             self.left = self._handle_px_and_percent_args(px, percent)
@@ -2236,14 +2236,14 @@ class Pad(CropAndPad):
         all sides. I.e. the pad amount then is the same for all sides.
         If ``True``, four values will be sampled independently, one per side.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2311,7 +2311,7 @@ class Pad(CropAndPad):
 
     def __init__(self, px=None, percent=None, pad_mode="constant", pad_cval=0,
                  keep_size=True, sample_independently=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         def recursive_validate(value):
             if value is None:
                 return value
@@ -2338,10 +2338,7 @@ class Pad(CropAndPad):
             pad_cval=pad_cval,
             keep_size=keep_size,
             sample_independently=sample_independently,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class Crop(CropAndPad):
@@ -2433,14 +2430,14 @@ class Crop(CropAndPad):
         all sides. I.e. the crop amount then is the same for all sides.
         If ``True``, four values will be sampled independently, one per side.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2487,7 +2484,7 @@ class Crop(CropAndPad):
 
     def __init__(self, px=None, percent=None, keep_size=True,
                  sample_independently=True,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         def recursive_negate(value):
             if value is None:
                 return value
@@ -2512,10 +2509,7 @@ class Crop(CropAndPad):
             percent=percent,
             keep_size=keep_size,
             sample_independently=sample_independently,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO maybe rename this to PadToMinimumSize?
@@ -2599,14 +2593,14 @@ class PadToFixedSize(meta.Augmenter):
               positions. First parameter is used for ``x`` coordinates,
               second for ``y`` coordinates.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2645,9 +2639,9 @@ class PadToFixedSize(meta.Augmenter):
 
     def __init__(self, width, height, pad_mode="constant", pad_cval=0,
                  position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(PadToFixedSize, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.size = (width, height)
 
         # Position of where to pad. The further to the top left this is, the
@@ -2848,14 +2842,14 @@ class CenterPadToFixedSize(PadToFixedSize):
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :func:`PadToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2869,11 +2863,11 @@ class CenterPadToFixedSize(PadToFixedSize):
     """
 
     def __init__(self, width, height, pad_mode="constant", pad_cval=0,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterPadToFixedSize, self).__init__(
             width=width, height=height, pad_mode=pad_mode, pad_cval=pad_cval,
             position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO maybe rename this to CropToMaximumSize ?
@@ -2960,14 +2954,14 @@ class CropToFixedSize(meta.Augmenter):
               positions. First parameter is used for ``x`` coordinates,
               second for ``y`` coordinates.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -2996,9 +2990,9 @@ class CropToFixedSize(meta.Augmenter):
     """
 
     def __init__(self, width, height, position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CropToFixedSize, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.size = (width, height)
 
         # Position of where to crop. The further to the top left this is,
@@ -3160,14 +3154,14 @@ class CenterCropToFixedSize(CropToFixedSize):
     height : int or None
         See :func:`CropToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3180,10 +3174,10 @@ class CenterCropToFixedSize(CropToFixedSize):
     """
 
     def __init__(self, width, height,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterCropToFixedSize, self).__init__(
             width=width, height=height, position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CropToMultiplesOf(CropToFixedSize):
@@ -3215,14 +3209,14 @@ class CropToMultiplesOf(CropToFixedSize):
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`CropToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3238,10 +3232,10 @@ class CropToMultiplesOf(CropToFixedSize):
     """
 
     def __init__(self, width_multiple, height_multiple, position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CropToMultiplesOf, self).__init__(
             width=None, height=None, position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.width_multiple = width_multiple
         self.height_multiple = height_multiple
 
@@ -3296,14 +3290,14 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
     height_multiple : int or None
         See :func:`CropToMultiplesOf.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3319,12 +3313,12 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
     """
 
     def __init__(self, width_multiple, height_multiple,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterCropToMultiplesOf, self).__init__(
             width_multiple=width_multiple,
             height_multiple=height_multiple,
             position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class PadToMultiplesOf(PadToFixedSize):
@@ -3355,14 +3349,14 @@ class PadToMultiplesOf(PadToFixedSize):
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`PadToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3380,11 +3374,11 @@ class PadToMultiplesOf(PadToFixedSize):
     def __init__(self, width_multiple, height_multiple,
                  pad_mode="constant", pad_cval=0,
                  position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(PadToMultiplesOf, self).__init__(
             width=None, height=None, pad_mode=pad_mode, pad_cval=pad_cval,
             position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.width_multiple = width_multiple
         self.height_multiple = height_multiple
 
@@ -3447,14 +3441,14 @@ class CenterPadToMultiplesOf(PadToMultiplesOf):
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :func:`~imgaug.augmenters.size.PadToMultiplesOf.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3471,14 +3465,14 @@ class CenterPadToMultiplesOf(PadToMultiplesOf):
 
     def __init__(self, width_multiple, height_multiple,
                  pad_mode="constant", pad_cval=0,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterPadToMultiplesOf, self).__init__(
             width_multiple=width_multiple,
             height_multiple=height_multiple,
             pad_mode=pad_mode,
             pad_cval=pad_cval,
             position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CropToPowersOf(CropToFixedSize):
@@ -3517,14 +3511,14 @@ class CropToPowersOf(CropToFixedSize):
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`CropToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3540,10 +3534,10 @@ class CropToPowersOf(CropToFixedSize):
     """
 
     def __init__(self, width_base, height_base, position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CropToPowersOf, self).__init__(
             width=None, height=None, position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.width_base = width_base
         self.height_base = height_base
 
@@ -3598,14 +3592,14 @@ class CenterCropToPowersOf(CropToPowersOf):
     height_base : int or None
         See :func:`CropToPowersOf.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3621,10 +3615,10 @@ class CenterCropToPowersOf(CropToPowersOf):
     """
 
     def __init__(self, width_base, height_base,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterCropToPowersOf, self).__init__(
             width_base=width_base, height_base=height_base, position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class PadToPowersOf(PadToFixedSize):
@@ -3662,14 +3656,14 @@ class PadToPowersOf(PadToFixedSize):
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`PadToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3687,11 +3681,11 @@ class PadToPowersOf(PadToFixedSize):
     def __init__(self, width_base, height_base,
                  pad_mode="constant", pad_cval=0,
                  position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(PadToPowersOf, self).__init__(
             width=None, height=None, pad_mode=pad_mode, pad_cval=pad_cval,
             position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.width_base = width_base
         self.height_base = height_base
 
@@ -3753,14 +3747,14 @@ class CenterPadToPowersOf(PadToPowersOf):
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :func:`~imgaug.augmenters.size.PadToPowersOf.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3777,12 +3771,12 @@ class CenterPadToPowersOf(PadToPowersOf):
 
     def __init__(self, width_base, height_base,
                  pad_mode="constant", pad_cval=0,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterPadToPowersOf, self).__init__(
             width_base=width_base, height_base=height_base,
             pad_mode=pad_mode, pad_cval=pad_cval,
             position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CropToAspectRatio(CropToFixedSize):
@@ -3807,14 +3801,14 @@ class CropToAspectRatio(CropToFixedSize):
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`CropToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3830,10 +3824,10 @@ class CropToAspectRatio(CropToFixedSize):
     """
 
     def __init__(self, aspect_ratio, position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CropToAspectRatio, self).__init__(
             width=None, height=None, position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.aspect_ratio = aspect_ratio
 
     def _draw_samples(self, batch, random_state):
@@ -3887,14 +3881,14 @@ class CenterCropToAspectRatio(CropToAspectRatio):
     aspect_ratio : number
         See :func:`CropToAspectRatio.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3910,10 +3904,10 @@ class CenterCropToAspectRatio(CropToAspectRatio):
     """
 
     def __init__(self, aspect_ratio,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterCropToAspectRatio, self).__init__(
             aspect_ratio=aspect_ratio, position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class PadToAspectRatio(PadToFixedSize):
@@ -3941,14 +3935,14 @@ class PadToAspectRatio(PadToFixedSize):
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -3965,11 +3959,11 @@ class PadToAspectRatio(PadToFixedSize):
 
     def __init__(self, aspect_ratio, pad_mode="constant", pad_cval=0,
                  position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(PadToAspectRatio, self).__init__(
             width=None, height=None, pad_mode=pad_mode, pad_cval=pad_cval,
             position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.aspect_ratio = aspect_ratio
 
     def _draw_samples(self, batch, random_state):
@@ -4050,11 +4044,11 @@ class CenterPadToAspectRatio(PadToAspectRatio):
     """
 
     def __init__(self, aspect_ratio, pad_mode="constant", pad_cval=0,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterPadToAspectRatio, self).__init__(
             aspect_ratio=aspect_ratio, position="center",
             pad_mode=pad_mode, pad_cval=pad_cval,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CropToSquare(CropToAspectRatio):
@@ -4074,14 +4068,14 @@ class CropToSquare(CropToAspectRatio):
     position : {'uniform', 'normal', 'center', 'left-top', 'left-center', 'left-bottom', 'center-top', 'center-center', 'center-bottom', 'right-top', 'right-center', 'right-bottom'} or tuple of float or StochasticParameter or tuple of StochasticParameter, optional
         See :func:`CropToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4096,10 +4090,10 @@ class CropToSquare(CropToAspectRatio):
     """
 
     def __init__(self, position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CropToSquare, self).__init__(
             aspect_ratio=1.0, position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CenterCropToSquare(CropToSquare):
@@ -4124,14 +4118,14 @@ class CenterCropToSquare(CropToSquare):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4145,10 +4139,10 @@ class CenterCropToSquare(CropToSquare):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(CenterCropToSquare, self).__init__(
             position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class PadToSquare(PadToAspectRatio):
@@ -4172,14 +4166,14 @@ class PadToSquare(PadToAspectRatio):
     pad_cval : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
         See :func:`~imgaug.augmenters.size.PadToFixedSize.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4194,11 +4188,11 @@ class PadToSquare(PadToAspectRatio):
     """
 
     def __init__(self, pad_mode="constant", pad_cval=0, position="uniform",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(PadToSquare, self).__init__(
             aspect_ratio=1.0, pad_mode=pad_mode, pad_cval=pad_cval,
             position=position,
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class CenterPadToSquare(PadToSquare):
@@ -4245,10 +4239,10 @@ class CenterPadToSquare(PadToSquare):
     """
 
     def __init__(self, pad_mode="constant", pad_cval=0,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CenterPadToSquare, self).__init__(
             pad_mode=pad_mode, pad_cval=pad_cval, position="center",
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 class KeepSizeByResize(meta.Augmenter):
@@ -4307,14 +4301,14 @@ class KeepSizeByResize(meta.Augmenter):
         neighbour interpolation (i.e. ``nearest``) make sense in the vast
         majority of all cases.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -4357,9 +4351,9 @@ class KeepSizeByResize(meta.Augmenter):
                  interpolation="cubic",
                  interpolation_heatmaps=SAME_AS_IMAGES,
                  interpolation_segmaps="nearest",
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(KeepSizeByResize, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.children = children
 
         def _validate_param(val, allow_same_as_images):

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -80,14 +80,14 @@ class FastSnowyLandscape(meta.Augmenter):
         The source colorspace of the input images.
         See :func:`~imgaug.augmenters.color.ChangeColorspace.__init__`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -127,9 +127,9 @@ class FastSnowyLandscape(meta.Augmenter):
     def __init__(self, lightness_threshold=(100, 255),
                  lightness_multiplier=(1.0, 4.0),
                  from_colorspace=colorlib.CSPACE_RGB,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(FastSnowyLandscape, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
         self.lightness_threshold = iap.handle_continuous_param(
             lightness_threshold, "lightness_threshold",
@@ -314,14 +314,14 @@ class CloudLayer(meta.Augmenter):
             * If a ``StochasticParameter``, then a value will be sampled
               per image from that parameter.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
@@ -329,9 +329,9 @@ class CloudLayer(meta.Augmenter):
                  intensity_coarse_scale, alpha_min, alpha_multiplier,
                  alpha_size_px_max, alpha_freq_exponent, sparsity,
                  density_multiplier,
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
         super(CloudLayer, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.intensity_mean = iap.handle_continuous_param(
             intensity_mean, "intensity_mean")
         self.intensity_freq_exponent = intensity_freq_exponent
@@ -509,14 +509,14 @@ class Clouds(meta.SomeOf):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -527,7 +527,8 @@ class Clouds(meta.SomeOf):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
+        # FIXME random state not transferred to children
         layers = [
             CloudLayer(
                 intensity_mean=(196, 255),
@@ -557,9 +558,7 @@ class Clouds(meta.SomeOf):
             (1, 2),
             children=layers,
             random_order=False,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO add vertical gradient alpha to have fog only at skylevel/groundlevel
@@ -597,14 +596,14 @@ class Fog(CloudLayer):
 
     Parameters
     ----------
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -615,7 +614,7 @@ class Fog(CloudLayer):
 
     """
 
-    def __init__(self, name=None, deterministic=False, random_state=None):
+    def __init__(self, seed=None, name=None, **old_kwargs):
         super(Fog, self).__init__(
             intensity_mean=(220, 255),
             intensity_freq_exponent=(-2.0, -1.5),
@@ -626,10 +625,7 @@ class Fog(CloudLayer):
             alpha_freq_exponent=(-4.0, -2.0),
             sparsity=0.9,
             density_multiplier=(0.4, 0.9),
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 # TODO add examples and add these to the overview docs
@@ -783,23 +779,23 @@ class SnowflakesLayer(meta.Augmenter):
         will be clipped to be within that range. This prevents extreme
         values for very small or large images.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
     def __init__(self, density, density_uniformity, flake_size,
                  flake_size_uniformity, angle, speed, blur_sigma_fraction,
-                 blur_sigma_limits=(0.5, 3.75), name=None, deterministic=False,
-                 random_state=None):
+                 blur_sigma_limits=(0.5, 3.75),
+                 seed=None, name=None, **old_kwargs):
         super(SnowflakesLayer, self).__init__(
-            name=name, deterministic=deterministic, random_state=random_state)
+            seed=seed, name=name, **old_kwargs)
         self.density = density
         self.density_uniformity = iap.handle_continuous_param(
             density_uniformity, "density_uniformity", value_range=(0.0, 1.0))
@@ -1104,14 +1100,14 @@ class Snowflakes(meta.SomeOf):
             * If a ``StochasticParameter``, then a value will be sampled
               per image from that parameter.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1133,7 +1129,8 @@ class Snowflakes(meta.SomeOf):
     def __init__(self, density=(0.005, 0.075), density_uniformity=(0.3, 0.9),
                  flake_size=(0.2, 0.7), flake_size_uniformity=(0.4, 0.8),
                  angle=(-30, 30), speed=(0.007, 0.03),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
+        # FIXME random state not transferred to children
         layer = SnowflakesLayer(
             density=density,
             density_uniformity=density_uniformity,
@@ -1148,10 +1145,7 @@ class Snowflakes(meta.SomeOf):
             (1, 3),
             children=[layer.deepcopy() for _ in range(3)],
             random_order=False,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
 
 class RainLayer(SnowflakesLayer):
@@ -1203,27 +1197,26 @@ class RainLayer(SnowflakesLayer):
     blur_sigma_limits : tuple of float, optional
         Same as in :class:`~imgaug.augmenters.weather.SnowflakesLayer`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     """
 
     def __init__(self, density, density_uniformity, drop_size,
                  drop_size_uniformity, angle, speed, blur_sigma_fraction,
-                 blur_sigma_limits=(0.5, 3.75), name=None, deterministic=False,
-                 random_state=None):
+                 blur_sigma_limits=(0.5, 3.75),
+                 seed=None, name=None, **old_kwargs):
         super(RainLayer, self).__init__(
             density, density_uniformity, drop_size,
             drop_size_uniformity, angle, speed, blur_sigma_fraction,
             blur_sigma_limits=blur_sigma_limits,
-            name=name, deterministic=deterministic, random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)
 
     @classmethod
     def _blur(cls, noise, sigma):
@@ -1300,14 +1293,14 @@ class Rain(meta.SomeOf):
     speed : number or tuple of number or list of number or imgaug.parameters.StochasticParameter
         See :class:`~imgaug.augmenters.weather.RainLayer`.
 
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
+        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+
     name : None or str, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
 
-    deterministic : bool, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
-
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
-        See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
+    **old_kwargs
+        Outdated parameters. Avoid using these.
 
     Examples
     --------
@@ -1329,7 +1322,8 @@ class Rain(meta.SomeOf):
     def __init__(self, nb_iterations=(1, 3),
                  drop_size=(0.01, 0.02),
                  speed=(0.04, 0.20),
-                 name=None, deterministic=False, random_state=None):
+                 seed=None, name=None, **old_kwargs):
+        # FIXME random state not transferred to children
         layer = RainLayer(
             density=(0.03, 0.14),
             density_uniformity=(0.8, 1.0),
@@ -1344,7 +1338,4 @@ class Rain(meta.SomeOf):
             nb_iterations,
             children=[layer.deepcopy() for _ in range(3)],
             random_order=False,
-            name=name,
-            deterministic=deterministic,
-            random_state=random_state
-        )
+            seed=seed, name=name, **old_kwargs)

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -1194,7 +1194,7 @@ class TestAdd(unittest.TestCase):
                 assert not np.allclose(image_aug[:, :, 1:], image_aug[:, :, :-1])
 
     def test_pickleable(self):
-        aug = iaa.Add((0, 50), per_channel=True, random_state=1)
+        aug = iaa.Add((0, 50), per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1687,7 +1687,7 @@ class TestAddElementwise(unittest.TestCase):
                 assert not np.allclose(image_aug[:, :, 1:], image_aug[:, :, :-1])
 
     def test_pickleable(self):
-        aug = iaa.AddElementwise((0, 50), per_channel=True, random_state=1)
+        aug = iaa.AddElementwise((0, 50), per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=2)
 
 
@@ -1890,7 +1890,7 @@ class AdditiveGaussianNoise(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.AdditiveGaussianNoise(scale=(0.1, 10), per_channel=True,
-                                        random_state=1)
+                                        seed=1)
         runtest_pickleable_uint8_img(aug, iterations=2)
 
 
@@ -2356,7 +2356,7 @@ class TestDropout(unittest.TestCase):
         assert np.allclose(hm.arr_0to1, hm_aug.arr_0to1)
 
     def test_pickleable(self):
-        aug = iaa.Dropout(p=0.5, per_channel=True, random_state=1)
+        aug = iaa.Dropout(p=0.5, per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -2454,7 +2454,7 @@ class TestCoarseDropout(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.CoarseDropout(p=0.5, size_px=10, per_channel=True,
-                                random_state=1)
+                                seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(40, 40, 3))
 
 
@@ -2810,7 +2810,7 @@ class TestDropout2d(unittest.TestCase):
                         assert np.sum(image_aug == 0) == 7
 
     def test_pickleable(self):
-        aug = iaa.Dropout2d(p=0.5, random_state=1)
+        aug = iaa.Dropout2d(p=0.5, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(1, 1, 50))
 
 
@@ -3118,7 +3118,7 @@ class TestTotalDropout(unittest.TestCase):
                                 == 5*3)
 
     def test_pickleable(self):
-        aug = iaa.TotalDropout(p=0.5, random_state=1)
+        aug = iaa.TotalDropout(p=0.5, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=30, shape=(4, 4, 2))
 
 
@@ -3592,7 +3592,7 @@ class TestMultiply(unittest.TestCase):
             """
 
     def test_pickleable(self):
-        aug = iaa.Multiply((0.5, 1.5), per_channel=True, random_state=1)
+        aug = iaa.Multiply((0.5, 1.5), per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -4100,7 +4100,7 @@ class TestMultiplyElementwise(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.MultiplyElementwise((0.5, 1.5), per_channel=True,
-                                      random_state=1)
+                                      seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -4476,7 +4476,7 @@ class TestReplaceElementwise(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.ReplaceElementwise(mask=0.5, replacement=(0, 255),
-                                     per_channel=True, random_state=1)
+                                     per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -4503,7 +4503,7 @@ class TestSaltAndPepper(unittest.TestCase):
         assert nb_salt > 200
 
     def test_pickleable(self):
-        aug = iaa.SaltAndPepper(p=0.5, per_channel=True, random_state=1)
+        aug = iaa.SaltAndPepper(p=0.5, per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -4594,7 +4594,7 @@ class TestCoarseSaltAndPepper(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.CoarseSaltAndPepper(p=0.5, size_px=(4, 15),
-                                      per_channel=True, random_state=1)
+                                      per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -4623,7 +4623,7 @@ class TestSalt(unittest.TestCase):
         assert nb_salt > 200
 
     def test_pickleable(self):
-        aug = iaa.Salt(p=0.5, per_channel=True, random_state=1)
+        aug = iaa.Salt(p=0.5, per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -4715,7 +4715,7 @@ class TestCoarseSalt(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.CoarseSalt(p=0.5, size_px=(4, 15),
-                             per_channel=True, random_state=1)
+                             per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -4743,7 +4743,7 @@ class TestPepper(unittest.TestCase):
         assert nb_salt == 0
 
     def test_pickleable(self):
-        aug = iaa.Pepper(p=0.5, per_channel=True, random_state=1)
+        aug = iaa.Pepper(p=0.5, per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -4835,7 +4835,7 @@ class TestCoarsePepper(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.CoarsePepper(p=0.5, size_px=(4, 15),
-                               per_channel=True, random_state=1)
+                               per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -5639,7 +5639,7 @@ class TestInvert(unittest.TestCase):
                 assert np.allclose(image_max_aug, image_min)
 
     def test_pickleable(self):
-        aug = iaa.Invert(p=0.5, per_channel=True, random_state=1)
+        aug = iaa.Invert(p=0.5, per_channel=True, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20, shape=(2, 2, 5))
 
 
@@ -5891,5 +5891,5 @@ class TestJpegCompression(unittest.TestCase):
                 assert image_aug.shape == image.shape
 
     def test_pickleable(self):
-        aug = iaa.JpegCompression((0, 100), random_state=1)
+        aug = iaa.JpegCompression((0, 100), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)

--- a/test/augmenters/test_artistic.py
+++ b/test/augmenters/test_artistic.py
@@ -239,5 +239,5 @@ class TestCartoon(unittest.TestCase):
         assert params[4] == iaa.CSPACE_RGB
 
     def test_pickleable(self):
-        aug = iaa.Cartoon(random_state=1)
+        aug = iaa.Cartoon(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=6)

--- a/test/augmenters/test_blend.py
+++ b/test/augmenters/test_blend.py
@@ -1059,10 +1059,10 @@ class TestBlendAlpha(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.BlendAlpha(
             (0.1, 0.9),
-            iaa.Add((1, 10), random_state=1),
-            iaa.Add((11, 20), random_state=2),
+            iaa.Add((1, 10), seed=1),
+            iaa.Add((11, 20), seed=2),
             per_channel=True,
-            random_state=3)
+            seed=3)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1733,10 +1733,10 @@ class TestBlendAlphaElementwise(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.BlendAlphaElementwise(
             (0.1, 0.9),
-            iaa.Add((1, 10), random_state=1),
-            iaa.Add((11, 20), random_state=2),
+            iaa.Add((1, 10), seed=1),
+            iaa.Add((11, 20), seed=2),
             per_channel=True,
-            random_state=3)
+            seed=3)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -1798,9 +1798,9 @@ class TestBlendAlphaSomeColors(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.BlendAlphaSomeColors(
-            iaa.Add((1, 10), random_state=1),
-            iaa.Add((11, 20), random_state=2),
-            random_state=3)
+            iaa.Add((1, 10), seed=1),
+            iaa.Add((11, 20), seed=2),
+            seed=3)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -1859,9 +1859,9 @@ class TestBlendAlphaHorizontalLinearGradient(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.BlendAlphaHorizontalLinearGradient(
-            iaa.Add((1, 10), random_state=1),
-            iaa.Add((11, 20), random_state=2),
-            random_state=3)
+            iaa.Add((1, 10), seed=1),
+            iaa.Add((11, 20), seed=2),
+            seed=3)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -1920,9 +1920,9 @@ class TestBlendAlphaVerticalLinearGradient(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.BlendAlphaVerticalLinearGradient(
-            iaa.Add((1, 10), random_state=1),
-            iaa.Add((11, 20), random_state=2),
-            random_state=3)
+            iaa.Add((1, 10), seed=1),
+            iaa.Add((11, 20), seed=2),
+            seed=3)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -1980,9 +1980,9 @@ class TestBlendAlphaRegularGrid(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.BlendAlphaRegularGrid(
             2, 3,
-            iaa.Add((1, 10), random_state=1),
-            iaa.Add((11, 20), random_state=2),
-            random_state=3)
+            iaa.Add((1, 10), seed=1),
+            iaa.Add((11, 20), seed=2),
+            seed=3)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -2037,9 +2037,9 @@ class TestBlendAlphaCheckerboard(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.BlendAlphaCheckerboard(
             2, 3,
-            iaa.Add((1, 10), random_state=1),
-            iaa.Add((11, 20), random_state=2),
-            random_state=3)
+            iaa.Add((1, 10), seed=1),
+            iaa.Add((11, 20), seed=2),
+            seed=3)
         runtest_pickleable_uint8_img(aug, iterations=3)
 
 
@@ -2110,10 +2110,10 @@ class TestBlendAlphaSegMapClassIds(unittest.TestCase):
         iterations = 3
         augmenter = iaa.BlendAlphaSegMapClassIds(
             [1, 2],
-            foreground=iaa.Add((1, 10), random_state=1),
-            background=iaa.Add((11, 20), random_state=2),
+            foreground=iaa.Add((1, 10), seed=1),
+            background=iaa.Add((11, 20), seed=2),
             nb_sample_classes=1,
-            random_state=3)
+            seed=3)
         image = np.mod(np.arange(int(np.prod(shape))), 256).astype(np.uint8)
         image = image.reshape(shape)
         segmap_arr = np.zeros((15, 15, 1), dtype=np.int32)
@@ -2200,10 +2200,10 @@ class TestBlendAlphaBoundingBoxes(unittest.TestCase):
         iterations = 3
         augmenter = iaa.BlendAlphaBoundingBoxes(
             ["bb1", "bb2", "bb3"],
-            foreground=iaa.Add((1, 10), random_state=1),
-            background=iaa.Add((11, 20), random_state=2),
+            foreground=iaa.Add((1, 10), seed=1),
+            background=iaa.Add((11, 20), seed=2),
             nb_sample_labels=1,
-            random_state=3)
+            seed=3)
         image = np.mod(np.arange(int(np.prod(shape))), 256).astype(np.uint8)
         image = image.reshape(shape)
         bbs = [ia.BoundingBox(x1=1, y1=1, x2=5, y2=5, label="bb1"),

--- a/test/augmenters/test_blur.py
+++ b/test/augmenters/test_blur.py
@@ -825,7 +825,7 @@ class TestGaussianBlur(unittest.TestCase):
             assert got_exception
 
     def test_pickleable(self):
-        aug = iaa.GaussianBlur((0.1, 3.0), random_state=1)
+        aug = iaa.GaussianBlur((0.1, 3.0), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1208,7 +1208,7 @@ class TestAverageBlur(unittest.TestCase):
             assert got_exception
 
     def test_pickleable(self):
-        aug = iaa.AverageBlur((1, 11), random_state=1)
+        aug = iaa.AverageBlur((1, 11), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1351,7 +1351,7 @@ class TestMedianBlur(unittest.TestCase):
         assert keypoints_equal(observed, expected)
 
     def test_pickleable(self):
-        aug = iaa.MedianBlur((1, 11), random_state=1)
+        aug = iaa.MedianBlur((1, 11), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1376,7 +1376,7 @@ class TestBilateralBlur(unittest.TestCase):
                 assert image_aug.shape == image.shape
 
     def test_pickleable(self):
-        aug = iaa.BilateralBlur((1, 11), random_state=1)
+        aug = iaa.BilateralBlur((1, 11), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1649,7 +1649,7 @@ class TestMotionBlur(unittest.TestCase):
         assert np.allclose(img_aug, expected)
 
     def test_pickleable(self):
-        aug = iaa.MotionBlur((3, 11), random_state=1)
+        aug = iaa.MotionBlur((3, 11), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1721,5 +1721,5 @@ class TestMeanShiftBlur(unittest.TestCase):
         assert params[1] is aug.color_window_radius
 
     def test_pickleable(self):
-        aug = iaa.MeanShiftBlur(random_state=1)
+        aug = iaa.MeanShiftBlur(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(40, 40, 3))

--- a/test/augmenters/test_color.py
+++ b/test/augmenters/test_color.py
@@ -598,7 +598,8 @@ class TestWithBrightnessChannels(unittest.TestCase):
         assert len(children_lsts[0]) == 1
         assert children_lsts[0][0] is child
 
-    def test_to_deterministic(self):
+    # TODO this test exists two times
+    def test_to_deterministic2(self):
         child = iaa.Identity()
         aug = iaa.WithBrightnessChannels([child])
 
@@ -610,8 +611,7 @@ class TestWithBrightnessChannels(unittest.TestCase):
         assert aug_det.children[0].deterministic
 
     def test_pickleable(self):
-        aug = iaa.WithBrightnessChannels(iaa.Add((0, 50), random_state=1),
-                                         random_state=2)
+        aug = iaa.WithBrightnessChannels(iaa.Add((0, 50), seed=1), seed=2)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -643,7 +643,7 @@ class TestMultiplyBrightness(unittest.TestCase):
         assert np.average(image_aug) > np.average(image)
 
     def test_pickleable(self):
-        aug = iaa.MultiplyBrightness((0.5, 1.5), random_state=1)
+        aug = iaa.MultiplyBrightness((0.5, 1.5), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -675,7 +675,7 @@ class TestAddToBrightness(unittest.TestCase):
         assert np.average(image_aug) > np.average(image)
 
     def test_pickleable(self):
-        aug = iaa.AddToBrightness((0, 50), random_state=1)
+        aug = iaa.AddToBrightness((0, 50), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -779,7 +779,7 @@ class TestMultiplyAndAddToBrightness(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.MultiplyAndAddToBrightness(mul=(0.5, 1.5), add=(0, 50),
-                                             random_state=1)
+                                             seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -999,8 +999,7 @@ class TestWithHueAndSaturation(unittest.TestCase):
         assert observed == expected
 
     def test_pickleable(self):
-        aug = iaa.WithHueAndSaturation(iaa.Add((0, 50), random_state=1),
-                                       random_state=2)
+        aug = iaa.WithHueAndSaturation(iaa.Add((0, 50), seed=1), seed=2)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1249,8 +1248,10 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
         images = rs.integers(0, 255, size=(32, 4, 4, 3), dtype=np.uint8)
 
         for deterministic in [False, True]:
-            aug = iaa.MultiplyHueAndSaturation(mul=(0.1, 5.0),
-                                               deterministic=deterministic)
+            aug = iaa.MultiplyHueAndSaturation(
+                mul=(0.1, 5.0))
+            if deterministic:
+                aug = aug.to_deterministic()
             images_aug1 = aug.augment_images(images)
             images_aug2 = aug.augment_images(images)
             equal = np.array_equal(images_aug1, images_aug2)
@@ -1259,9 +1260,10 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
             else:
                 assert not equal
 
-            aug = iaa.MultiplyHueAndSaturation(mul_hue=(0.1, 5.0),
-                                               mul_saturation=(0.1, 5.0),
-                                               deterministic=deterministic)
+            aug = iaa.MultiplyHueAndSaturation(
+                mul_hue=(0.1, 5.0), mul_saturation=(0.1, 5.0))
+            if deterministic:
+                aug = aug.to_deterministic()
             images_aug1 = aug.augment_images(images)
             images_aug2 = aug.augment_images(images)
             equal = np.array_equal(images_aug1, images_aug2)
@@ -1273,7 +1275,7 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.MultiplyHueAndSaturation(mul_hue=(0.5, 1.5),
                                            mul_saturation=(0.5, 1.5),
-                                           random_state=1)
+                                           seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -1294,7 +1296,7 @@ class TestMultiplyHue(unittest.TestCase):
         assert np.isclose(aug.children[0].children[0].mul.b.value, 1.1)
 
     def test_pickleable(self):
-        aug = iaa.MultiplyHue((0.5, 1.5), random_state=1)
+        aug = iaa.MultiplyHue((0.5, 1.5), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(50, 50, 3))
 
 
@@ -1316,7 +1318,7 @@ class TestMultiplySaturation(unittest.TestCase):
         assert np.isclose(aug.children[0].children[0].mul.b.value, 1.1)
 
     def test_pickleable(self):
-        aug = iaa.MultiplySaturation((0.5, 1.5), random_state=1)
+        aug = iaa.MultiplySaturation((0.5, 1.5), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(50, 50, 3))
 
 
@@ -1372,7 +1374,7 @@ class TestRemoveSaturation(unittest.TestCase):
         assert np.any(np.float32(saturations) <= 0.5 * image_sat)
 
     def test_pickleable(self):
-        aug = iaa.RemoveSaturation((0.1, 0.9), random_state=1)
+        aug = iaa.RemoveSaturation((0.1, 0.9), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(100, 100, 3))
 
 
@@ -1752,7 +1754,7 @@ class TestAddToHueAndSaturation(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.AddToHueAndSaturation(value_hue=(-50, 50),
                                         value_saturation=(-50, 50),
-                                        random_state=1)
+                                        seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(50, 50, 3))
 
 
@@ -1765,7 +1767,7 @@ class TestAddToHue(unittest.TestCase):
         assert aug.value_hue.b.value == 20
 
     def test_pickleable(self):
-        aug = iaa.AddToHue((-50, 50), random_state=1)
+        aug = iaa.AddToHue((-50, 50), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(50, 50, 3))
 
 
@@ -1778,7 +1780,7 @@ class TestAddToSaturation(unittest.TestCase):
         assert aug.value_saturation.b.value == 20
 
     def test_pickleable(self):
-        aug = iaa.AddToSaturation((-50, 50), random_state=1)
+        aug = iaa.AddToSaturation((-50, 50), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(50, 50, 3))
 
 
@@ -1850,7 +1852,7 @@ class TestGrayscale(unittest.TestCase):
                               rtol=0, atol=density_tolerance)
 
     def test_pickleable(self):
-        aug = iaa.Grayscale((0.1, 0.9), random_state=1)
+        aug = iaa.Grayscale((0.1, 0.9), seed=1)
         runtest_pickleable_uint8_img(aug)
 
 
@@ -1925,7 +1927,7 @@ class TestChangeColorTemperature(unittest.TestCase):
         assert params[1] == iaa.CSPACE_HLS
 
     def test_pickleable(self):
-        aug = iaa.ChangeColorTemperature(random_state=1)
+        aug = iaa.ChangeColorTemperature(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10)
 
 
@@ -2230,7 +2232,7 @@ class TestKMeansColorQuantization(unittest.TestCase):
         assert params[4] == "cubic"
 
     def test_pickleable(self):
-        aug = self.augmenter(n_colors=(2, 16), random_state=1)
+        aug = self.augmenter(n_colors=(2, 16), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(100, 100, 3))
 
 
@@ -2504,7 +2506,7 @@ class TestUniformColorQuantization(TestKMeansColorQuantization):
             == "foo")
 
     def test_pickleable(self):
-        aug = self.augmenter(n_colors=(2, 32), random_state=1)
+        aug = self.augmenter(n_colors=(2, 32), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(100, 100, 3))
 
 
@@ -2594,7 +2596,7 @@ class TestUniformColorQuantizationToNBits(unittest.TestCase):
         assert np.array_equal(observed, expected)
 
     def test_pickleable(self):
-        aug = iaa.UniformColorQuantizationToNBits(random_state=1)
+        aug = iaa.UniformColorQuantizationToNBits(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(100, 100, 3))
 
 

--- a/test/augmenters/test_contrast.py
+++ b/test/augmenters/test_contrast.py
@@ -264,7 +264,7 @@ class TestGammaContrast(unittest.TestCase):
                                 assert _allclose(value_aug, value_expected)
 
     def test_pickleable(self):
-        aug = iaa.GammaContrast((0.5, 2.0), random_state=1)
+        aug = iaa.GammaContrast((0.5, 2.0), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -498,7 +498,7 @@ class TestSigmoidContrast(unittest.TestCase):
                         assert _allclose(image_aug, expected)
 
     def test_pickleable(self):
-        aug = iaa.SigmoidContrast(gain=(1, 2), random_state=1)
+        aug = iaa.SigmoidContrast(gain=(1, 2), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -691,7 +691,7 @@ class TestLogContrast(unittest.TestCase):
                         assert _allclose(image_aug, expected)
 
     def test_pickleable(self):
-        aug = iaa.LogContrast((1, 2), random_state=1)
+        aug = iaa.LogContrast((1, 2), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -815,7 +815,7 @@ class TestLinearContrast(unittest.TestCase):
     # test for other dtypes are in Test_adjust_contrast_linear
 
     def test_pickleable(self):
-        aug = iaa.LinearContrast((0.5, 2.0), random_state=1)
+        aug = iaa.LinearContrast((0.5, 2.0), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -1266,7 +1266,7 @@ class TestAllChannelsCLAHE(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.AllChannelsCLAHE(clip_limit=(30, 50),
                                    tile_grid_size_px=(4, 12),
-                                   random_state=1)
+                                   seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(100, 100, 3))
 
 
@@ -1828,7 +1828,7 @@ class TestCLAHE(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.CLAHE(clip_limit=(30, 50),
                         tile_grid_size_px=(4, 12),
-                        random_state=1)
+                        seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(100, 100, 3))
 
 
@@ -1993,7 +1993,7 @@ class TestAllChannelsHistogramEqualization(unittest.TestCase):
         assert len(params) == 0
 
     def test_pickleable(self):
-        aug = iaa.AllChannelsHistogramEqualization(random_state=1)
+        aug = iaa.AllChannelsHistogramEqualization(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=2, shape=(100, 100, 3))
 
 
@@ -2111,5 +2111,5 @@ class TestHistogramEqualization(unittest.TestCase):
         assert params[1] == iaa.CSPACE_HSV
 
     def test_pickleable(self):
-        aug = iaa.HistogramEqualization(random_state=1)
+        aug = iaa.HistogramEqualization(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=2, shape=(100, 100, 3))

--- a/test/augmenters/test_convolutional.py
+++ b/test/augmenters/test_convolutional.py
@@ -401,12 +401,12 @@ class TestConvolve(unittest.TestCase):
 
     def test_pickleable__identity_matrix(self):
         identity_matrix = np.int64([[1]])
-        aug = iaa.Convolve(identity_matrix, random_state=1)
+        aug = iaa.Convolve(identity_matrix, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
     def test_pickleable__callback_function(self):
         aug = iaa.Convolve(_convolve_pickleable_matrix_generator,
-                           random_state=1)
+                           seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -644,7 +644,7 @@ class TestSharpen(unittest.TestCase):
     """
 
     def test_pickleable(self):
-        aug = iaa.Sharpen(alpha=(0.0, 1.0), lightness=(1, 3), random_state=1)
+        aug = iaa.Sharpen(alpha=(0.0, 1.0), lightness=(1, 3), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)
 
 
@@ -796,5 +796,5 @@ class TestEmboss(unittest.TestCase):
         assert got_exception
 
     def test_pickleable(self):
-        aug = iaa.Emboss(alpha=(0.0, 1.0), strength=(1, 3), random_state=1)
+        aug = iaa.Emboss(alpha=(0.0, 1.0), strength=(1, 3), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)

--- a/test/augmenters/test_edges.py
+++ b/test/augmenters/test_edges.py
@@ -528,7 +528,7 @@ class TestCanny(unittest.TestCase):
                 hysteresis_thresholds=100,
                 sobel_kernel_size=3,
                 colorizer=colorizer,
-                random_state=i)
+                seed=i)
 
             image_aug = aug.augment_image(image)
             color_true = np.unique(image_aug[image_canny])
@@ -587,7 +587,7 @@ class TestCanny(unittest.TestCase):
                                        iap.Deterministic(200)),
                 sobel_kernel_size=[3, 5],
                 colorizer=colorizer,
-                random_state=i)
+                seed=i)
 
             image_aug = aug.augment_image(image)
             match_index = None
@@ -682,5 +682,5 @@ class TestCanny(unittest.TestCase):
         assert observed == expected
 
     def test_pickleable(self):
-        aug = iaa.Canny(random_state=1)
+        aug = iaa.Canny(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=20)

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -5414,8 +5414,7 @@ class TestPiecewiseAffine(unittest.TestCase):
                                            np.float128(value)))
 
     def test_pickleable(self):
-        aug = iaa.PiecewiseAffine(scale=0.2, nb_rows=4, nb_cols=4,
-                                  random_state=1)
+        aug = iaa.PiecewiseAffine(scale=0.2, nb_rows=4, nb_cols=4, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(25, 25, 1))
 
 
@@ -6302,7 +6301,7 @@ class TestPerspectiveTransform(unittest.TestCase):
 
     def test_mode_replicate_copies_values(self):
         aug = iaa.PerspectiveTransform(
-            scale=0.001, mode="replicate", cval=0, random_state=31)
+            scale=0.001, mode="replicate", cval=0, seed=31)
         img = np.ones((256, 256, 3), dtype=np.uint8) * 255
 
         img_aug = aug.augment_image(img)
@@ -6311,9 +6310,9 @@ class TestPerspectiveTransform(unittest.TestCase):
 
     def test_mode_constant_uses_cval(self):
         aug255 = iaa.PerspectiveTransform(
-            scale=0.001, mode="constant", cval=255, random_state=31)
+            scale=0.001, mode="constant", cval=255, seed=31)
         aug0 = iaa.PerspectiveTransform(
-            scale=0.001, mode="constant", cval=0, random_state=31)
+            scale=0.001, mode="constant", cval=0, seed=31)
         img = np.ones((256, 256, 3), dtype=np.uint8) * 255
 
         img_aug255 = aug255.augment_image(img)
@@ -6610,7 +6609,7 @@ class TestPerspectiveTransform(unittest.TestCase):
                     ) > 0.7
 
     def test_pickleable(self):
-        aug = iaa.PerspectiveTransform(0.2, random_state=1)
+        aug = iaa.PerspectiveTransform(0.2, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=4, shape=(25, 25, 1))
 
 
@@ -7802,7 +7801,7 @@ class TestElasticTransformation(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.ElasticTransformation(alpha=(0.2, 1.5), sigma=(1.0, 10.0),
-                                        random_state=1)
+                                        seed=1)
         runtest_pickleable_uint8_img(aug, iterations=4, shape=(25, 25, 1))
 
 
@@ -8842,7 +8841,7 @@ class TestRot90(unittest.TestCase):
                     assert _allclose(image_aug[2, 2], np.float128(value))
 
     def test_pickleable(self):
-        aug = iaa.Rot90([0, 1, 2, 3], random_state=1)
+        aug = iaa.Rot90([0, 1, 2, 3], seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5)
 
 
@@ -9459,8 +9458,8 @@ class TestWithPolarWarping(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.WithPolarWarping(
-            iaa.Affine(translate_px=(0, 10), random_state=1),
-            random_state=2)
+            iaa.Affine(translate_px=(0, 10), seed=1),
+            seed=2)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(25, 25, 1))
 
 
@@ -10009,7 +10008,7 @@ class TestJigsaw(unittest.TestCase):
     def test_images_and_keypoints_aligned(self):
         for i in np.arange(20):
             aug = iaa.Jigsaw(nb_rows=(1, 3), nb_cols=(1, 3), max_steps=(2, 5),
-                             random_state=i)
+                             seed=i)
             # make sure that these coords are not exactly at a grid cell
             # border with any possibly sampled height/width in grid cells
             y = 17.5

--- a/test/augmenters/test_imgcorruptlike.py
+++ b/test/augmenters/test_imgcorruptlike.py
@@ -260,13 +260,13 @@ class TestAugmenters(unittest.TestCase):
         # to get different augmentations as many functions are dependend
         # only on the severity. So we change only for some functions only
         # the seed and for the others severity+seed.
-        image_aug1 = aug_cls(severity=severity, random_state=1)(image=image)
-        image_aug2 = aug_cls(severity=severity, random_state=1)(image=image)
+        image_aug1 = aug_cls(severity=severity, seed=1)(image=image)
+        image_aug2 = aug_cls(severity=severity, seed=1)(image=image)
         if dependent_on_seed:
-            image_aug3 = aug_cls(severity=severity, random_state=2)(
+            image_aug3 = aug_cls(severity=severity, seed=2)(
                 image=image)
         else:
-            image_aug3 = aug_cls(severity=severity-1, random_state=2)(
+            image_aug3 = aug_cls(severity=severity-1, seed=2)(
                 image=image)
         image_aug_exp = func_expected(
             image,

--- a/test/augmenters/test_pooling.py
+++ b/test/augmenters/test_pooling.py
@@ -83,7 +83,7 @@ class _TestPoolingAugmentersBase(object):
         segmap = SegmentationMapsOnImage(arr, shape=(6, 6, 3))
         mock_aug_segmaps.return_value = [segmap]
         rng = iarandom.RNG(0)
-        aug = self.augmenter(2, keep_size=False, random_state=rng)
+        aug = self.augmenter(2, keep_size=False, seed=rng)
 
         _ = aug.augment_segmentation_maps(segmap)
 

--- a/test/augmenters/test_segmentation.py
+++ b/test/augmenters/test_segmentation.py
@@ -283,7 +283,7 @@ class TestSuperpixels(unittest.TestCase):
                 assert _allclose(img_aug, (7/8)*v2 + (1/8)*v1)
 
     def test_pickleable(self):
-        aug = iaa.Superpixels(p_replace=0.5, random_state=1)
+        aug = iaa.Superpixels(p_replace=0.5, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(25, 25, 1))
 
 
@@ -755,7 +755,7 @@ class TestVoronoi(unittest.TestCase):
 
     def test_pickleable(self):
         sampler = iaa.RegularGridPointsSampler(5, 5)
-        aug = iaa.Voronoi(sampler, p_replace=0.5, random_state=1)
+        aug = iaa.Voronoi(sampler, p_replace=0.5, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=10, shape=(25, 25, 1))
 
 
@@ -785,9 +785,8 @@ class TestUniformVoronoi(unittest.TestCase):
                 p_replace=0.5,
                 max_size=5,
                 interpolation="cubic",
-                name="foo",
-                deterministic=True,
-                random_state=rs
+                seed=rs,
+                name="foo"
             )
 
         assert mock_voronoi.call_count == 1
@@ -798,8 +797,7 @@ class TestUniformVoronoi(unittest.TestCase):
         assert mock_voronoi.call_args_list[0][1]["max_size"] == 5
         assert mock_voronoi.call_args_list[0][1]["interpolation"] == "cubic"
         assert mock_voronoi.call_args_list[0][1]["name"] == "foo"
-        assert mock_voronoi.call_args_list[0][1]["deterministic"] is True
-        assert mock_voronoi.call_args_list[0][1]["random_state"] is rs
+        assert mock_voronoi.call_args_list[0][1]["seed"] is rs
 
     def test___init___integrationtest(self):
         rs = iarandom.RNG(10)
@@ -808,20 +806,18 @@ class TestUniformVoronoi(unittest.TestCase):
             p_replace=0.5,
             max_size=5,
             interpolation="cubic",
-            name=None,
-            deterministic=True,
-            random_state=rs
+            seed=rs,
+            name=None
         )
         assert aug.points_sampler.n_points.value == 100
         assert np.isclose(aug.p_replace.p.value, 0.5)
         assert aug.max_size == 5
         assert aug.interpolation == "cubic"
         assert aug.name == "UnnamedUniformVoronoi"
-        assert aug.deterministic is True
         assert aug.random_state.equals(rs)
 
     def test_pickleable(self):
-        aug = iaa.UniformVoronoi((10, 50), p_replace=0.5, random_state=1)
+        aug = iaa.UniformVoronoi((10, 50), p_replace=0.5, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(50, 50, 1))
 
 
@@ -840,9 +836,8 @@ class TestRegularGridVoronoi(unittest.TestCase):
                 p_replace=0.5,
                 max_size=5,
                 interpolation="cubic",
-                name="foo",
-                deterministic=True,
-                random_state=rs
+                seed=rs,
+                name="foo"
             )
 
         assert mock_voronoi.call_count == 1
@@ -858,8 +853,7 @@ class TestRegularGridVoronoi(unittest.TestCase):
         assert mock_voronoi.call_args_list[0][1]["max_size"] == 5
         assert mock_voronoi.call_args_list[0][1]["interpolation"] == "cubic"
         assert mock_voronoi.call_args_list[0][1]["name"] == "foo"
-        assert mock_voronoi.call_args_list[0][1]["deterministic"] is True
-        assert mock_voronoi.call_args_list[0][1]["random_state"] is rs
+        assert mock_voronoi.call_args_list[0][1]["seed"] is rs
 
     def test___init___integrationtest(self):
         rs = iarandom.RNG(10)
@@ -869,9 +863,8 @@ class TestRegularGridVoronoi(unittest.TestCase):
             p_replace=0.5,
             max_size=5,
             interpolation="cubic",
-            name=None,
-            deterministic=True,
-            random_state=rs
+            seed=rs,
+            name=None
         )
         assert np.isclose(aug.points_sampler.p_drop.p.value, 1-0.4)
         assert aug.points_sampler.other_points_sampler.n_rows.value == 10
@@ -883,12 +876,11 @@ class TestRegularGridVoronoi(unittest.TestCase):
         assert aug.max_size == 5
         assert aug.interpolation == "cubic"
         assert aug.name == "UnnamedRegularGridVoronoi"
-        assert aug.deterministic is True
         assert aug.random_state.equals(rs)
 
     def test_pickleable(self):
         aug = iaa.RegularGridVoronoi((5, 10), (5, 10), p_replace=0.5,
-                                     random_state=1)
+                                     seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(50, 50, 1))
 
 
@@ -907,9 +899,8 @@ class TestRelativeRegularGridVoronoi(unittest.TestCase):
                 p_replace=0.5,
                 max_size=5,
                 interpolation="cubic",
-                name="foo",
-                deterministic=True,
-                random_state=rs
+                seed=rs,
+                name="foo"
             )
 
         assert mock_voronoi.call_count == 1
@@ -925,8 +916,7 @@ class TestRelativeRegularGridVoronoi(unittest.TestCase):
         assert mock_voronoi.call_args_list[0][1]["max_size"] == 5
         assert mock_voronoi.call_args_list[0][1]["interpolation"] == "cubic"
         assert mock_voronoi.call_args_list[0][1]["name"] == "foo"
-        assert mock_voronoi.call_args_list[0][1]["deterministic"] is True
-        assert mock_voronoi.call_args_list[0][1]["random_state"] is rs
+        assert mock_voronoi.call_args_list[0][1]["seed"] is rs
 
     def test___init___integrationtest(self):
         rs = iarandom.RNG(10)
@@ -936,9 +926,8 @@ class TestRelativeRegularGridVoronoi(unittest.TestCase):
             p_replace=0.5,
             max_size=5,
             interpolation="cubic",
-            name=None,
-            deterministic=True,
-            random_state=rs
+            seed=rs,
+            name=None
         )
 
         ps = aug.points_sampler
@@ -951,12 +940,11 @@ class TestRelativeRegularGridVoronoi(unittest.TestCase):
         assert aug.max_size == 5
         assert aug.interpolation == "cubic"
         assert aug.name == "UnnamedRelativeRegularGridVoronoi"
-        assert aug.deterministic is True
         assert aug.random_state.equals(rs)
 
     def test_pickleable(self):
         aug = iaa.RelativeRegularGridVoronoi((0.01, 0.2), (0.01, 0.2),
-                                             p_replace=0.5, random_state=1)
+                                             p_replace=0.5, seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(50, 50, 1))
 
 

--- a/test/augmenters/test_size.py
+++ b/test/augmenters/test_size.py
@@ -1463,7 +1463,7 @@ class TestResize(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.Resize({"height": (10, 30), "width": (10, 30)},
                          interpolation=["nearest", "linear"],
-                         random_state=1)
+                         seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(50, 50, 1))
 
 
@@ -2865,7 +2865,7 @@ class TestPad(unittest.TestCase):
                                            np.float128(value)))
 
     def test_pickleable(self):
-        aug = iaa.Pad((0, 10), random_state=1)
+        aug = iaa.Pad((0, 10), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5)
 
 
@@ -3978,7 +3978,7 @@ class TestCrop(unittest.TestCase):
                                            np.float128(value)))
 
     def test_pickleable(self):
-        aug = iaa.Crop((0, 10), random_state=1)
+        aug = iaa.Crop((0, 10), seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(30, 30, 1))
 
 
@@ -4657,7 +4657,7 @@ class TestPadToFixedSize(unittest.TestCase):
                                            np.float128(value)))
 
     def test_pickleable(self):
-        aug = iaa.PadToFixedSize(20, 20, position="uniform", random_state=1)
+        aug = iaa.PadToFixedSize(20, 20, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(10, 10, 1))
 
 
@@ -5293,7 +5293,7 @@ class TestCropToFixedSize(unittest.TestCase):
                                            np.float128(value)))
 
     def test_pickleable(self):
-        aug = iaa.CropToFixedSize(10, 10, position="uniform", random_state=1)
+        aug = iaa.CropToFixedSize(10, 10, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(20, 20, 1))
 
 
@@ -5463,7 +5463,7 @@ class TestCropToMultiplesOf(unittest.TestCase):
                 assert image_aug.shape == image.shape
 
     def test_pickleable(self):
-        aug = iaa.CropToMultiplesOf(5, 5, position="uniform", random_state=1)
+        aug = iaa.CropToMultiplesOf(5, 5, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(14, 14, 1))
 
 
@@ -5671,7 +5671,7 @@ class TestPadToMultiplesOf(unittest.TestCase):
                 assert image_aug.shape == expected_shape
 
     def test_pickleable(self):
-        aug = iaa.PadToMultiplesOf(5, 5, position="uniform", random_state=1)
+        aug = iaa.PadToMultiplesOf(5, 5, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(11, 11, 1))
 
 
@@ -5848,7 +5848,7 @@ class TestCropToPowersOf(unittest.TestCase):
                 assert image_aug.shape == image.shape
 
     def test_pickleable(self):
-        aug = iaa.CropToPowersOf(2, 2, position="uniform", random_state=1)
+        aug = iaa.CropToPowersOf(2, 2, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(15, 15, 1))
 
 
@@ -6055,7 +6055,7 @@ class TestPadToPowersOf(unittest.TestCase):
                 assert image_aug.shape == expected_shape
 
     def test_pickleable(self):
-        aug = iaa.PadToPowersOf(2, 2, position="uniform", random_state=1)
+        aug = iaa.PadToPowersOf(2, 2, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(9, 9, 1))
 
 
@@ -6204,7 +6204,7 @@ class TestCropToAspectRatio(unittest.TestCase):
                     assert image_aug.shape == image.shape
 
     def test_pickleable(self):
-        aug = iaa.CropToAspectRatio(1.0, position="uniform", random_state=1)
+        aug = iaa.CropToAspectRatio(1.0, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(20, 10, 1))
 
 
@@ -6406,7 +6406,7 @@ class TestPadToAspectRatio(unittest.TestCase):
                 assert image_aug.shape == expected_shape
 
     def test_pickleable(self):
-        aug = iaa.PadToAspectRatio(2.0, position="uniform", random_state=1)
+        aug = iaa.PadToAspectRatio(2.0, position="uniform", seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(10, 10, 1))
 
 
@@ -6918,8 +6918,8 @@ class TestKeepSizeByResize(unittest.TestCase):
 
     def test_pickleable(self):
         aug = iaa.KeepSizeByResize([
-            iaa.CropToFixedSize(10, 10, position="uniform", random_state=1)
-        ], interpolation=["nearest", "linear"], random_state=1)
+            iaa.CropToFixedSize(10, 10, position="uniform", seed=1)
+        ], interpolation=["nearest", "linear"], seed=1)
         runtest_pickleable_uint8_img(aug, iterations=5, shape=(15, 15, 1))
 
     def test_get_children_lists(self):

--- a/test/augmenters/test_weather.py
+++ b/test/augmenters/test_weather.py
@@ -162,7 +162,7 @@ class TestFastSnowyLandscape(unittest.TestCase):
     def test_pickleable(self):
         aug = iaa.FastSnowyLandscape(lightness_threshold=(50, 150),
                                      lightness_multiplier=(1.0, 3.0),
-                                     random_state=1)
+                                     seed=1)
         runtest_pickleable_uint8_img(aug)
 
 
@@ -241,7 +241,7 @@ class TestClouds(unittest.TestCase):
                 assert image_aug.shape == shape
 
     def test_pickleable(self):
-        aug = iaa.Clouds(random_state=1)
+        aug = iaa.Clouds(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(20, 20, 3))
 
 
@@ -320,7 +320,7 @@ class TestFog(unittest.TestCase):
                 assert image_aug.shape == shape
 
     def test_pickleable(self):
-        aug = iaa.Fog(random_state=1)
+        aug = iaa.Fog(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(20, 20, 3))
 
 
@@ -405,7 +405,7 @@ class TestSnowflakes(unittest.TestCase):
                 assert image_aug.shape == shape
 
     def test_pickleable(self):
-        aug = iaa.Snowflakes(random_state=1)
+        aug = iaa.Snowflakes(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(20, 20, 3))
 
     @classmethod
@@ -513,5 +513,5 @@ class TestRain(unittest.TestCase):
                 assert image_aug.shape == shape
 
     def test_pickleable(self):
-        aug = iaa.Rain(random_state=1)
+        aug = iaa.Rain(seed=1)
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(20, 20, 3))


### PR DESCRIPTION
Change the standard parameters shared by all augmenters to a
reduced and more self-explanatory set. Previously, all augmenters
shared the parameters `name`, `random_state` and `deterministic`.
The new parameters are `seed` and `name`.

`deterministic` is removed as it was hardly ever used and because
it caused frequently confusion with regards to its meaning. The
parameter is still accepted but will now produce a deprecation
warning. Use `<augmenter>.to_deterministic()` instead.
(Reminder: `to_deterministic()` is necessary if you want to get
the same samples in consecutive augmentation calls. It is *not*
necessary if you want your generated samples to be dependent on
an initial seed or random state as that is *always* the case
anyways. You only have to manually set the seed, either
augmenter-specific via the `seed` parameter or global via
`imgaug.random.seed()` (affects only augmenters without their
own seed).)

`random_state` is renamed to `seed` as providing a seed value
is the more common use case compared to providing a random state.
Many users also seemed to be unaware that `random_state` accepted
seed values. The new name should make this more clear.
The old parameter `random_state` is still accepted, but will
likely be deprecated in the future.

**[breaking]** This patch breaks if one relied on the order of
`name` and `random_state` instead of their names. These parameters
are now in inverted order, i.e. `(..., seed=None, name=None, ...)`
as seeds are much more commonly used than names.