### PR TITLE
Replace 'note ::' with 'note::'

### DIFF
--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -2524,7 +2524,7 @@ class ChangeColorspace(meta.Augmenter):
         This augmenter is not tested. Some colorspaces might work, others
         might not.
 
-    ..note ::
+    ..note::
 
         This augmenter tries to project the colorspace value range on
         0-255. It outputs dtype=uint8 images.

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -713,7 +713,7 @@ class Affine(meta.Augmenter):
     of the input image to generate output pixel values. The parameter `order`
     deals with the method of interpolation used for this.
 
-    .. note ::
+    .. note::
 
         While this augmenter supports segmentation maps and heatmaps that
         have a different size than the corresponding image, it is strongly

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -981,7 +981,7 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.gaussian_noise`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1027,7 +1027,7 @@ class ShotNoise(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.shot_noise`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1073,7 +1073,7 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.impulse_noise`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1119,7 +1119,7 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.speckle_noise`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1165,7 +1165,7 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.gaussian_blur`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1211,7 +1211,7 @@ class GlassBlur(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.glass_blur`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1257,7 +1257,7 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.defocus_blur`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1303,7 +1303,7 @@ class MotionBlur(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.motion_blur`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1349,7 +1349,7 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.zoom_blur`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1395,7 +1395,7 @@ class Fog(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.fog`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1441,7 +1441,7 @@ class Frost(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.frost`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1487,7 +1487,7 @@ class Snow(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.snow`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1533,7 +1533,7 @@ class Spatter(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.spatter`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1579,7 +1579,7 @@ class Contrast(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.contrast`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1625,7 +1625,7 @@ class Brightness(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.brightness`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1671,7 +1671,7 @@ class Saturate(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.saturate`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1717,7 +1717,7 @@ class JpegCompression(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.jpeg_compression`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1763,7 +1763,7 @@ class Pixelate(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.pixelate`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 
@@ -1809,7 +1809,7 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
     """
     Wrapper around function :func:`imagecorruption.elastic_transform`.
 
-    .. note ::
+    .. note::
 
         This augmenter only affects images. Other data is not changed.
 

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -2039,7 +2039,7 @@ class Affine(geometric.Affine):
     This augmenter has identical outputs to
     :func:`PIL.Image.transform` with parameter ``method=PIL.Image.AFFINE``.
 
-    .. note ::
+    .. note::
 
         This augmenter can currently only transform image-data.
         Batches containing heatmaps, segmentation maps and
@@ -2047,7 +2047,7 @@ class Affine(geometric.Affine):
         Use :class:`~imgaug.augmenters.geometric.Affine` if you have to
         transform such inputs.
 
-    .. note ::
+    .. note::
 
         This augmenter uses the image center as the transformation center.
         This has to be explicitly enforced in PIL using corresponding


### PR DESCRIPTION
This fixes a few docstrings where note blocks where marked in the
wrong way, leading to them accidentally being comments.