### PR TITLE
Add -Walways to run_tests.sh

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -6,4 +6,4 @@
 # The command below executes all tests.
 # To execute only one specific test, use e.g.
 # pytest ./test/augmenters/test_geometric.py::TestRot90::test_empty_polygons
-python -m pytest ./test --verbose --xdoctest-modules -s --durations=20
+python -m pytest ./test --verbose --xdoctest-modules -s --durations=20 -Walways


### PR DESCRIPTION
This adds the argument `-Walways` to the command in `run_tests.sh`.
Adding this argument makes python 2.7 behave more similarly to
3+ so that it no longer swallows warnings after they have been
shown once.