### PR TITLE
Fix Jigsaw not only depending on its own RNG

### DIFF
--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -5604,7 +5604,9 @@ class Jigsaw(meta.Augmenter):
             for i in np.arange(len(samples.destinations)):
                 padder = size_lib.CenterPadToMultiplesOf(
                     width_multiple=samples.nb_cols[i],
-                    height_multiple=samples.nb_rows[i])
+                    height_multiple=samples.nb_rows[i],
+                    seed=random_state
+                )
                 row = batch.subselect_rows_by_indices([i])
                 row = padder.augment_batch_(row, parents=parents + [self],
                                             hooks=hooks)


### PR DESCRIPTION
`Jigsaw` behaved previously non-deterministically as it dependent on
its own local RNG and additionally the global RNG.
This patch fixes that issue.