### PR TITLE
Add missing pickling tests of augmenters

### DIFF
--- a/changelogs/master/20191111_pickleable.md
+++ b/changelogs/master/20191111_pickleable.md
@@ -1,4 +1,4 @@
-# All Augmenters Pickle-able #493
+# All Augmenters Pickle-able #493 #575
 
 Ensured that all augmenters can be pickled.
 

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -2152,6 +2152,18 @@ class TestCutout(unittest.TestCase):
         assert params[5] is aug.cval
         assert params[6] is aug.fill_per_channel
 
+    def test_pickleable(self):
+        aug = iaa.Cutout(
+            nb_iterations=1,
+            position=(0.5, 0.5),
+            size=0.1,
+            squared=0.6,
+            fill_mode=["gaussian", "constant"],
+            cval=(0, 255),
+            fill_per_channel=0.5
+        )
+        runtest_pickleable_uint8_img(aug)
+
 
 # this is mostly copy-pasted cutout code from
 # https://github.com/uoguelph-mlrg/Cutout/blob/master/util/cutout.py
@@ -5662,6 +5674,10 @@ class TestSolarize(unittest.TestCase):
             .astype(np.uint8).reshape((2, 2, 1))
         assert observed.dtype.name == "uint8"
         assert np.array_equal(observed, expected)
+
+    def test_pickleable(self):
+        aug = iaa.pillike.Solarize(p=1.0, threshold=(100, 110))
+        runtest_pickleable_uint8_img(aug)
 
 
 class TestContrastNormalization(unittest.TestCase):

--- a/test/augmenters/test_collections.py
+++ b/test/augmenters/test_collections.py
@@ -17,7 +17,7 @@ matplotlib.use('Agg')  # fix execution of tests involving matplotlib on travis
 import numpy as np
 
 from imgaug import augmenters as iaa
-from imgaug.testutils import reseed
+from imgaug.testutils import reseed, runtest_pickleable_uint8_img
 
 
 class TestRandAugment(unittest.TestCase):
@@ -93,3 +93,7 @@ class TestRandAugment(unittest.TestCase):
         assert params[0] is aug[1].n
         assert params[1] is aug._m
         assert params[2] is aug._cval
+
+    def test_pickleable(self):
+        aug = iaa.RandAugment(m=(0, 10), n=(1, 2))
+        runtest_pickleable_uint8_img(aug, iterations=50)

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -10082,3 +10082,7 @@ class TestJigsaw(unittest.TestCase):
         assert params[1] is aug.nb_cols
         assert params[2] is aug.max_steps
         assert params[3] is True
+
+    def test_pickleable(self):
+        aug = iaa.Jigsaw(nb_rows=(1, 4), nb_cols=(1, 4), max_steps=(1, 3))
+        runtest_pickleable_uint8_img(aug, iterations=20, shape=(32, 32, 3))

--- a/test/augmenters/test_meta.py
+++ b/test/augmenters/test_meta.py
@@ -15,6 +15,10 @@ try:
     import unittest.mock as mock
 except ImportError:
     import mock
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 import matplotlib
 matplotlib.use('Agg')  # fix execution of tests involving matplotlib on travis
@@ -8681,6 +8685,19 @@ class TestRemoveCBAsByOutOfImageFraction(unittest.TestCase):
         assert len(params) == 1
         assert np.isclose(params[0], 0.51)
 
+    def test_pickleable(self):
+        item1 = ia.Keypoint(x=5, y=1)
+        item2 = ia.Keypoint(x=15, y=1)
+        cbaoi = ia.KeypointsOnImage([item1, item2], shape=(10, 10, 3))
+
+        augmenter = iaa.RemoveCBAsByOutOfImageFraction(0.51)
+        augmenter_pkl = pickle.loads(pickle.dumps(augmenter, protocol=-1))
+
+        for _ in np.arange(3):
+            cbaoi_aug = augmenter(keypoints=cbaoi)
+            cbaoi_aug_pkl = augmenter_pkl(keypoints=cbaoi)
+            assert np.allclose(cbaoi_aug.to_xy_array(), cbaoi_aug_pkl.to_xy_array())
+
 
 class TestClipCBAsToImagePlanes(unittest.TestCase):
     def setUp(self):
@@ -8774,3 +8791,16 @@ class TestClipCBAsToImagePlanes(unittest.TestCase):
         aug = iaa.ClipCBAsToImagePlanes()
         params = aug.get_parameters()
         assert len(params) == 0
+
+    def test_pickleable(self):
+        item1 = ia.Keypoint(x=5, y=1)
+        item2 = ia.Keypoint(x=15, y=1)
+        cbaoi = ia.KeypointsOnImage([item1, item2], shape=(10, 10, 3))
+
+        augmenter = iaa.ClipCBAsToImagePlanes()
+        augmenter_pkl = pickle.loads(pickle.dumps(augmenter, protocol=-1))
+
+        for _ in np.arange(3):
+            cbaoi_aug = augmenter(keypoints=cbaoi)
+            cbaoi_aug_pkl = augmenter_pkl(keypoints=cbaoi)
+            assert np.allclose(cbaoi_aug.to_xy_array(), cbaoi_aug_pkl.to_xy_array())

--- a/test/augmenters/test_pillike.py
+++ b/test/augmenters/test_pillike.py
@@ -24,7 +24,7 @@ import PIL.ImageFilter
 import imgaug as ia
 from imgaug import augmenters as iaa
 from imgaug import random as iarandom
-from imgaug.testutils import reseed
+from imgaug.testutils import reseed, runtest_pickleable_uint8_img
 
 
 def _test_shape_hw(func):
@@ -981,6 +981,10 @@ class TestSolarize(unittest.TestCase):
         assert np.isclose(aug.threshold.value, 128)
         assert aug.invert_above_threshold.value == 1
 
+    def test_pickleable(self):
+        aug = iaa.pillike.Solarize()
+        runtest_pickleable_uint8_img(aug)
+
 
 class TestPosterize(unittest.TestCase):
     def setUp(self):
@@ -989,6 +993,10 @@ class TestPosterize(unittest.TestCase):
     def test_returns_posterize(self):
         aug = iaa.pillike.Posterize()
         assert isinstance(aug, iaa.Posterize)
+
+    def test_pickleable(self):
+        aug = iaa.pillike.Posterize()
+        runtest_pickleable_uint8_img(aug)
 
 
 class TestEqualize(unittest.TestCase):
@@ -1021,6 +1029,10 @@ class TestEqualize(unittest.TestCase):
                 assert np.all(channelwise_sums > 0)
             assert np.min(image_aug) < 50
             assert np.max(image_aug) > 150
+
+    def test_pickleable(self):
+        aug = iaa.pillike.Equalize()
+        runtest_pickleable_uint8_img(aug)
 
 
 class TestAutocontrast(unittest.TestCase):
@@ -1077,6 +1089,10 @@ class TestAutocontrast(unittest.TestCase):
         assert np.min(image_aug) < 50
         assert np.max(image_aug) > 150
 
+    def test_pickleable(self):
+        aug = iaa.pillike.Autocontrast((0, 30), per_channel=0.5)
+        runtest_pickleable_uint8_img(aug)
+
 
 class TestEnhanceColor(unittest.TestCase):
     def setUp(self):
@@ -1131,6 +1147,10 @@ class TestEnhanceColor(unittest.TestCase):
         params = aug.get_parameters()
         assert params[0] is aug.factor
 
+    def test_pickleable(self):
+        aug = iaa.pillike.EnhanceColor((0.1, 2.0))
+        runtest_pickleable_uint8_img(aug)
+
 
 # we don't have to test very much here, because some functions of the base
 # class are already tested via EnhanceColor
@@ -1174,6 +1194,10 @@ class TestEnhanceContrast(unittest.TestCase):
 
         assert np.allclose(hm_aug.get_arr(), hm.get_arr())
 
+    def test_pickleable(self):
+        aug = iaa.pillike.EnhanceContrast((0.1, 2.0))
+        runtest_pickleable_uint8_img(aug)
+
 
 # we don't have to test very much here, because some functions of the base
 # class are already tested via EnhanceColor
@@ -1211,6 +1235,10 @@ class TestEnhanceBrightness(unittest.TestCase):
         hm_aug = aug(heatmaps=hm)
 
         assert np.allclose(hm_aug.get_arr(), hm.get_arr())
+
+    def test_pickleable(self):
+        aug = iaa.pillike.EnhanceBrightness((0.1, 2.0))
+        runtest_pickleable_uint8_img(aug)
 
 
 # we don't have to test very much here, because some functions of the base
@@ -1251,6 +1279,10 @@ class TestEnhanceSharpness(unittest.TestCase):
 
         assert np.allclose(hm_aug.get_arr(), hm.get_arr())
 
+    def test_pickleable(self):
+        aug = iaa.pillike.EnhanceSharpness((0.1, 2.0))
+        runtest_pickleable_uint8_img(aug)
+
 
 class _TestFilter(unittest.TestCase):
     def _test___init__(self, cls, func):
@@ -1263,6 +1295,10 @@ class _TestFilter(unittest.TestCase):
         image_aug_pil = PIL.Image.fromarray(image).filter(pil_kernel)
         assert np.array_equal(image_aug, image_aug_pil)
 
+    def _test_pickleable(self, cls):
+        aug = cls()
+        runtest_pickleable_uint8_img(aug)
+
 
 class FilterBlur(_TestFilter):
     def test___init__(self):
@@ -1272,6 +1308,9 @@ class FilterBlur(_TestFilter):
     def test_image(self):
         self._test_image(iaa.pillike.FilterBlur,
                          PIL.ImageFilter.BLUR)
+
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterBlur)
 
 
 class FilterSmooth(_TestFilter):
@@ -1283,6 +1322,9 @@ class FilterSmooth(_TestFilter):
         self._test_image(iaa.pillike.FilterSmooth,
                          PIL.ImageFilter.SMOOTH)
 
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterSmooth)
+
 
 class FilterSmoothMore(_TestFilter):
     def test___init__(self):
@@ -1292,6 +1334,9 @@ class FilterSmoothMore(_TestFilter):
     def test_image(self):
         self._test_image(iaa.pillike.FilterSmoothMore,
                          PIL.ImageFilter.SMOOTH_MORE)
+
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterSmoothMore)
 
 
 class FilterEdgeEnhance(_TestFilter):
@@ -1303,6 +1348,9 @@ class FilterEdgeEnhance(_TestFilter):
         self._test_image(iaa.pillike.FilterEdgeEnhance,
                          PIL.ImageFilter.EDGE_ENHANCE)
 
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterEdgeEnhance)
+
 
 class FilterEdgeEnhanceMore(_TestFilter):
     def test___init__(self):
@@ -1312,6 +1360,9 @@ class FilterEdgeEnhanceMore(_TestFilter):
     def test_image(self):
         self._test_image(iaa.pillike.FilterEdgeEnhanceMore,
                          PIL.ImageFilter.EDGE_ENHANCE_MORE)
+
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterEdgeEnhanceMore)
 
 
 class FilterFindEdges(_TestFilter):
@@ -1323,6 +1374,9 @@ class FilterFindEdges(_TestFilter):
         self._test_image(iaa.pillike.FilterFindEdges,
                          PIL.ImageFilter.FIND_EDGES)
 
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterFindEdges)
+
 
 class FilterContour(_TestFilter):
     def test___init__(self):
@@ -1332,6 +1386,9 @@ class FilterContour(_TestFilter):
     def test_image(self):
         self._test_image(iaa.pillike.FilterContour,
                          PIL.ImageFilter.CONTOUR)
+
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterContour)
 
 
 class FilterEmboss(_TestFilter):
@@ -1343,6 +1400,9 @@ class FilterEmboss(_TestFilter):
         self._test_image(iaa.pillike.FilterEmboss,
                          PIL.ImageFilter.EMBOSS)
 
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterEmboss)
+
 
 class FilterSharpen(_TestFilter):
     def test___init__(self):
@@ -1353,6 +1413,9 @@ class FilterSharpen(_TestFilter):
         self._test_image(iaa.pillike.FilterSharpen,
                          PIL.ImageFilter.SHARPEN)
 
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterSharpen)
+
 
 class FilterDetail(_TestFilter):
     def test___init__(self):
@@ -1362,6 +1425,9 @@ class FilterDetail(_TestFilter):
     def test_image(self):
         self._test_image(iaa.pillike.FilterDetail,
                          PIL.ImageFilter.DETAIL)
+
+    def test_pickleable(self):
+        self._test_pickleable(iaa.pillike.FilterDetail)
 
 
 class TestAffine(unittest.TestCase):
@@ -1484,3 +1550,14 @@ class TestAffine(unittest.TestCase):
         assert params[3] is aug.shear
         assert params[4] is aug.cval
         assert params[5] is aug.center
+
+    def test_pickleable(self):
+        aug = iaa.pillike.Affine(
+            scale={"x": 1.25, "y": 1.5},
+            translate_px={"x": 10, "y": 20},
+            rotate=30,
+            shear={"x": 40, "y": 50},
+            fillcolor=(100, 200),
+            center="uniform"
+        )
+        runtest_pickleable_uint8_img(aug)

--- a/test/augmenters/test_size.py
+++ b/test/augmenters/test_size.py
@@ -4675,6 +4675,10 @@ class TestCenterPadToFixedSize(unittest.TestCase):
             expected = iaa.pad(image, right=1, bottom=1)
             assert np.array_equal(observed, expected)
 
+    def test_pickleable(self):
+        aug = iaa.CenterPadToFixedSize(height=20, width=15)
+        runtest_pickleable_uint8_img(aug, shape=(10, 10, 3))
+
 
 class TestCropToFixedSize(unittest.TestCase):
     def setUp(self):
@@ -5310,6 +5314,10 @@ class TestCenterCropToFixedSize(unittest.TestCase):
 
             assert np.array_equal(observed, image[5-1:5+2, 5-1:5+2, :])
 
+    def test_pickleable(self):
+        aug = iaa.CenterCropToFixedSize(height=12, width=10)
+        runtest_pickleable_uint8_img(aug, shape=(15, 20, 3))
+
 
 class TestCropToMultiplesOf(unittest.TestCase):
     def setUp(self):
@@ -5481,6 +5489,10 @@ class TestCenterCropToMultiplesOf(unittest.TestCase):
             observed = aug(image=image)
 
             assert np.array_equal(observed, image[1:-1, 2:-2, :])
+
+    def test_pickleable(self):
+        aug = iaa.CenterCropToMultiplesOf(5, 5)
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(14, 14, 1))
 
 
 class TestPadToMultiplesOf(unittest.TestCase):
@@ -5689,6 +5701,10 @@ class TestCenterPadToMultiplesOf(unittest.TestCase):
             expected = iaa.pad(image, top=1, right=2, bottom=1, left=2)
             assert np.array_equal(observed, expected)
 
+    def test_pickleable(self):
+        aug = iaa.CenterPadToMultiplesOf(5, 5)
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(11, 11, 1))
+
 
 class TestCropToPowersOf(unittest.TestCase):
     def setUp(self):
@@ -5864,6 +5880,10 @@ class TestCenterCropToPowersOf(unittest.TestCase):
             observed = aug(image=image)
 
             assert np.array_equal(observed, image[1:-2, 2:-2, :])
+
+    def test_pickleable(self):
+        aug = iaa.CenterCropToPowersOf(2, 2)
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(15, 15, 1))
 
 
 class TestPadToPowersOf(unittest.TestCase):
@@ -6073,6 +6093,10 @@ class TestCenterPadToPowersOf(unittest.TestCase):
             expected = iaa.pad(image, top=1, right=2, bottom=2, left=1)
             assert np.array_equal(observed, expected)
 
+    def test_pickleable(self):
+        aug = iaa.CenterPadToPowersOf(2, 2)
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(9, 9, 1))
+
 
 class TestCropToAspectRatio(unittest.TestCase):
     def setUp(self):
@@ -6220,6 +6244,10 @@ class TestCenterCropToAspectRatio(unittest.TestCase):
             observed = aug(image=image)
 
             assert np.array_equal(observed, image[1:3, 0:4, :])
+
+    def test_pickleable(self):
+        aug = iaa.CenterCropToAspectRatio(1.0)
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(20, 10, 1))
 
 
 class TestPadToAspectRatio(unittest.TestCase):
@@ -6424,6 +6452,10 @@ class TestCenterPadToAspectRatio(unittest.TestCase):
             expected = iaa.pad(image, left=1, right=2)
             assert np.array_equal(observed, expected)
 
+    def test_pickleable(self):
+        aug = iaa.CenterPadToAspectRatio(2.0)
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(10, 10, 1))
+
 
 class TestCropToSquare(unittest.TestCase):
     def setUp(self):
@@ -6436,6 +6468,10 @@ class TestCropToSquare(unittest.TestCase):
         observed = aug(image=image)
 
         assert np.array_equal(observed, image[1:5, 0:4, :])
+
+    def test_pickleable(self):
+        aug = iaa.CropToSquare(position="uniform")
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(10, 15, 1))
 
 
 class TestCenterCropToSquare(unittest.TestCase):
@@ -6451,6 +6487,10 @@ class TestCenterCropToSquare(unittest.TestCase):
 
             assert np.array_equal(observed, image[1:5, 0:4, :])
 
+    def test_pickleable(self):
+        aug = iaa.CenterCropToSquare()
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(10, 15, 1))
+
 
 class TestPadToSquare(unittest.TestCase):
     def setUp(self):
@@ -6464,6 +6504,10 @@ class TestPadToSquare(unittest.TestCase):
 
         expected = iaa.pad(image, left=1, right=2)
         assert np.array_equal(observed, expected)
+
+    def test_pickleable(self):
+        aug = iaa.PadToSquare(position="uniform")
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(10, 15, 1))
 
 
 class TestCenterPadToSquare(unittest.TestCase):
@@ -6479,6 +6523,10 @@ class TestCenterPadToSquare(unittest.TestCase):
 
             expected = iaa.pad(image, left=1, right=2)
             assert np.array_equal(observed, expected)
+
+    def test_pickleable(self):
+        aug = iaa.CenterPadToSquare()
+        runtest_pickleable_uint8_img(aug, iterations=5, shape=(10, 15, 1))
 
 
 class TestKeepSizeByResize(unittest.TestCase):


### PR DESCRIPTION
Some new augmenters had no tests yet that verified whether these
augmenters can be pickled. This patch adds these tests to all
remaining augmenters.