### PR TITLE
Rename 'random_state' to 'seed' in generate_jigsaw_destinations()

### DIFF
--- a/changelogs/master/added/20191027_jigsaw.md
+++ b/changelogs/master/added/20191027_jigsaw.md
@@ -1,4 +1,4 @@
-# Jigsaw Augmenter #476
+# Jigsaw Augmenter #476 #577
 
 * Added function `imgaug.augmenters.geometric.apply_jigsaw()`.
 * Added function `imgaug.augmenters.geometric.apply_jigsaw_to_coords()`.

--- a/checks/check_jigsaw.py
+++ b/checks/check_jigsaw.py
@@ -26,7 +26,7 @@ def main():
     )
     print("Time to generate 128x dest:", gen_time)
 
-    destinations = iaa.generate_jigsaw_destinations(10, 10, 1, random_state=1)
+    destinations = iaa.generate_jigsaw_destinations(10, 10, 1, seed=1)
     image_jig = iaa.apply_jigsaw(image, destinations)
     ia.imshow(image_jig)
 

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -504,7 +504,7 @@ def apply_jigsaw_to_coords(coords, destinations, image_shape):
     return result
 
 
-def generate_jigsaw_destinations(nb_rows, nb_cols, max_steps, random_state,
+def generate_jigsaw_destinations(nb_rows, nb_cols, max_steps, seed,
                                  connectivity=4):
     """Generate a destination pattern for :func:`apply_jigsaw`.
 
@@ -519,8 +519,9 @@ def generate_jigsaw_destinations(nb_rows, nb_cols, max_steps, random_state,
     max_steps : int
         Maximum number of cells that each cell may be moved.
 
-    random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState
-        RNG or seed to use. If ``None`` the global RNG will be used.
+    seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState
+        Seed value or alternatively RNG to use.
+        If ``None`` the global RNG will be used.
 
     connectivity : int, optional
         Whether a diagonal move of a cell counts as one step
@@ -535,7 +536,7 @@ def generate_jigsaw_destinations(nb_rows, nb_cols, max_steps, random_state,
     """
     assert connectivity in (4, 8), (
         "Expected connectivity of 4 or 8, got %d." % (connectivity,))
-    random_state = iarandom.RNG(random_state)
+    random_state = iarandom.RNG(seed)
     steps = random_state.integers(0, max_steps, size=(nb_rows, nb_cols),
                                   endpoint=True)
     directions = random_state.integers(0, connectivity,
@@ -5661,7 +5662,7 @@ class Jigsaw(meta.Augmenter):
             destinations.append(
                 generate_jigsaw_destinations(
                     nb_rows[i], nb_cols[i], max_steps[i],
-                    random_state=random_state)
+                    seed=random_state)
             )
 
         samples = _JigsawSamples(nb_rows, nb_cols, max_steps, destinations)


### PR DESCRIPTION
This patch renames the parameter `random_state` to `seed`
in `generate_jigsaw_destinations()` as that makes it more clear
that the parameter also accepts seed values, which is the
standard use case.