### PR TITLE
Improve dtype support docstrings

### DIFF
--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -62,7 +62,8 @@ def add_scalar(image, value):
 
     This method ensures that ``uint8`` does not overflow during the addition.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: limited; tested (1)
@@ -210,7 +211,8 @@ def add_elementwise(image, values):
 
     This method ensures that ``uint8`` does not overflow during the addition.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: limited; tested (1)
@@ -332,7 +334,8 @@ def multiply_scalar(image, multiplier):
     This method ensures that ``uint8`` does not overflow during the
     multiplication.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: limited; tested (1)
@@ -351,7 +354,9 @@ def multiply_scalar(image, multiplier):
         - (1) Non-uint8 dtypes can overflow. For floats, this can result in
               +/-inf.
 
-        Note: tests were only conducted for rather small multipliers, around
+    note::
+
+        Tests were only conducted for rather small multipliers, around
         ``-10.0`` to ``+10.0``.
 
         In general, the multipliers sampled from `multiplier` must be in a
@@ -497,7 +502,8 @@ def multiply_elementwise(image, multipliers):
 
     This method ensures that ``uint8`` does not overflow during the addition.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: limited; tested (1)
@@ -516,7 +522,9 @@ def multiply_elementwise(image, multipliers):
         - (1) Non-uint8 dtypes can overflow. For floats, this can result
               in +/-inf.
 
-        Note: tests were only conducted for rather small multipliers, around
+    note::
+
+        Tests were only conducted for rather small multipliers, around
         ``-10.0`` to ``+10.0``.
 
         In general, the multipliers sampled from `multipliers` must be in a
@@ -640,9 +648,10 @@ def cutout(image, x1, y1, x2, y2,
         in the interval ``[0.0, 1.0]`` and hence sample values from a
         gaussian within that interval, i.e. from ``N(0.5, std=0.5/3)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
+    See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     Parameters
     ----------
@@ -698,12 +707,14 @@ def cutout_(image, x1, y1, x2, y2,
         in the interval ``[0.0, 1.0]`` and hence sample values from a
         gaussian within that interval, i.e. from ``N(0.5, std=0.5/3)``.
 
-    dtype support::
 
-        minimum of (
-            :func:`~imgaug.augmenters.arithmetic._fill_rectangle_gaussian_`,
-            :func:`~imgaug.augmenters.arithmetic._fill_rectangle_constant_`
-        )
+    Supported dtypes
+    ----------------
+
+    minimum of (
+        :func:`~imgaug.augmenters.arithmetic._fill_rectangle_gaussian_`,
+        :func:`~imgaug.augmenters.arithmetic._fill_rectangle_constant_`
+    )
 
     Parameters
     ----------
@@ -774,7 +785,8 @@ def _fill_rectangle_gaussian_(image, x1, y1, x2, y2, cval, per_channel,
                               random_state):
     """Fill a rectangular image area with samples from a gaussian.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -842,7 +854,8 @@ def _fill_rectangle_constant_(image, x1, y1, x2, y2, cval, per_channel,
     in `cval` does not match the number of channels in `image`, it may
     be tiled up to the number of channels.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -881,7 +894,8 @@ def _fill_rectangle_constant_(image, x1, y1, x2, y2, cval, per_channel,
 def replace_elementwise_(image, mask, replacements):
     """Replace components in an image array with new values.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -993,9 +1007,10 @@ def invert(image, min_value=None, max_value=None, threshold=None,
            invert_above_threshold=True):
     """Invert an array.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.invert_`.
+    See :func:`~imgaug.augmenters.arithmetic.invert_`.
 
     Parameters
     ----------
@@ -1029,46 +1044,47 @@ def invert_(image, min_value=None, max_value=None, threshold=None,
             invert_above_threshold=True):
     """Invert an array in-place.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (min_value=None and max_value=None)::
+    if (min_value=None and max_value=None):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: yes; tested
-            * ``uint64``: yes; tested
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested
-            * ``int64``: yes; tested
-            * ``float16``: yes; tested
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: yes; tested
-            * ``bool``: yes; tested
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested
+        * ``uint64``: yes; tested
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested
+        * ``int64``: yes; tested
+        * ``float16``: yes; tested
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: yes; tested
+        * ``bool``: yes; tested
 
-        if (min_value!=None or max_value!=None)::
+    if (min_value!=None or max_value!=None):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: yes; tested
-            * ``uint64``: no (1)
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested
-            * ``int64``: no (2)
-            * ``float16``: yes; tested
-            * ``float32``: yes; tested
-            * ``float64``: no (2)
-            * ``float128``: no (3)
-            * ``bool``: no (4)
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested
+        * ``uint64``: no (1)
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested
+        * ``int64``: no (2)
+        * ``float16``: yes; tested
+        * ``float32``: yes; tested
+        * ``float64``: no (2)
+        * ``float128``: no (3)
+        * ``bool``: no (4)
 
-            - (1) Not allowed due to numpy's clip converting from ``uint64`` to
-                  ``float64``.
-            - (2) Not allowed as int/float have to be increased in resolution
-                  when using min/max values.
-            - (3) Not tested.
-            - (4) Makes no sense when using min/max values.
+        - (1) Not allowed due to numpy's clip converting from ``uint64`` to
+              ``float64``.
+        - (2) Not allowed as int/float have to be increased in resolution
+              when using min/max values.
+        - (3) Not tested.
+        - (4) Makes no sense when using min/max values.
 
     Parameters
     ----------
@@ -1291,9 +1307,10 @@ def _generate_table_for_invert_uint8(min_value, max_value, threshold,
 def solarize(image, threshold=128):
     """Invert pixel values above a threshold.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`solarize_`.
+    See :func:`solarize_`.
 
     Parameters
     ----------
@@ -1320,9 +1337,10 @@ def solarize_(image, threshold=128):
     This function performs the same transformation as
     :func:`PIL.ImageOps.solarize`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`invert_(min_value=None and max_value=None)`.
+    See ``invert_(min_value=None and max_value=None)``.
 
     Parameters
     ----------
@@ -1332,6 +1350,7 @@ def solarize_(image, threshold=128):
     threshold : None or number, optional
         See :func:`invert_`.
         Note: The default threshold is optimized for ``uint8`` images.
+
 
     Returns
     -------
@@ -1346,7 +1365,8 @@ def solarize_(image, threshold=128):
 def compress_jpeg(image, compression):
     """Compress an image using jpeg compression.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: ?
@@ -1448,9 +1468,10 @@ class Add(meta.Augmenter):
     """
     Add a value to all pixels in an image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.add_scalar`.
+    See :func:`~imgaug.augmenters.arithmetic.add_scalar`.
 
     Parameters
     ----------
@@ -1583,9 +1604,10 @@ class AddElementwise(meta.Augmenter):
     and *per pixel* (and optionally per channel), i.e. intensities of
     neighbouring pixels may be increased/decreased by different amounts.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.add_elementwise`.
+    See :func:`~imgaug.augmenters.arithmetic.add_elementwise`.
 
     Parameters
     ----------
@@ -1697,9 +1719,10 @@ class AdditiveGaussianNoise(AddElementwise):
     different noise values to neighbouring pixels and is comparable
     to ``AddElementwise``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.AddElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.AddElementwise`.
 
     Parameters
     ----------
@@ -1809,9 +1832,10 @@ class AdditiveLaplaceNoise(AddElementwise):
     different noise values to neighbouring pixels and is comparable
     to ``AddElementwise``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.AddElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.AddElementwise`.
 
     Parameters
     ----------
@@ -1920,9 +1944,10 @@ class AdditivePoissonNoise(AddElementwise):
     different noise values to neighbouring pixels and is comparable
     to ``AddElementwise``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.AddElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.AddElementwise`.
 
     Parameters
     ----------
@@ -2010,9 +2035,10 @@ class Multiply(meta.Augmenter):
 
     This augmenter can be used to make images lighter or darker.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.multiply_scalar`.
+    See :func:`~imgaug.augmenters.arithmetic.multiply_scalar`.
 
     Parameters
     ----------
@@ -2142,9 +2168,10 @@ class MultiplyElementwise(meta.Augmenter):
     image* (and optionally channel), this augmenter samples the multipliers
     to use per image and *per pixel* (and optionally per channel).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.multiply_elementwise`.
+    See :func:`~imgaug.augmenters.arithmetic.multiply_elementwise`.
 
     Parameters
     ----------
@@ -2294,9 +2321,10 @@ class Cutout(meta.Augmenter):
         in the interval ``[0.0, 1.0]`` and hence sample values from a
         gaussian within that interval, i.e. from ``N(0.5, std=0.5/3)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.cutout_`.
+    See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
     Parameters
     ----------
@@ -2595,9 +2623,10 @@ class Dropout(MultiplyElementwise):
     """
     Set a fraction of pixels in images to zero.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.MultiplyElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.MultiplyElementwise`.
 
     Parameters
     ----------
@@ -2730,9 +2759,10 @@ class CoarseDropout(MultiplyElementwise):
     ``CoarseDropout`` can drop multiple rectangles (with some correlation
     between the sizes of these rectangles).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.MultiplyElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.MultiplyElementwise`.
 
     Parameters
     ----------
@@ -2888,7 +2918,8 @@ class Dropout2d(meta.Augmenter):
         It does so if and only if *all* channels of an image are dropped.
         If ``nb_keep_channels >= 1`` then that never happens.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3070,7 +3101,8 @@ class TotalDropout(meta.Augmenter):
         maps to zero and removes all coordinate-based data (e.g. it removes
         all bounding boxes on images that were filled with zeros).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3202,9 +3234,10 @@ class ReplaceElementwise(meta.Augmenter):
     """
     Replace pixels in an image with new values.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.replace_elementwise_`.
+    See :func:`~imgaug.augmenters.arithmetic.replace_elementwise_`.
 
     Parameters
     ----------
@@ -3361,9 +3394,10 @@ class SaltAndPepper(ReplaceElementwise):
     """
     Replace pixels in images with salt/pepper noise (white/black-ish colors).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.ReplaceElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.ReplaceElementwise`.
 
     Parameters
     ----------
@@ -3431,9 +3465,10 @@ class ImpulseNoise(SaltAndPepper):
     This is identical to ``SaltAndPepper``, except that `per_channel` is
     always set to ``True``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.SaltAndPepper``.
+    See :class:`~imgaug.augmenters.arithmetic.SaltAndPepper`.
 
     Parameters
     ----------
@@ -3488,9 +3523,10 @@ class CoarseSaltAndPepper(ReplaceElementwise):
     TODO replace dtype support with uint8 only, because replacement is
          geared towards that value range
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.ReplaceElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.ReplaceElementwise`.
 
     Parameters
     ----------
@@ -3627,9 +3663,10 @@ class Salt(ReplaceElementwise):
     This augmenter is similar to ``SaltAndPepper``, but adds no pepper noise to
     images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.ReplaceElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.ReplaceElementwise`.
 
     Parameters
     ----------
@@ -3698,9 +3735,10 @@ class CoarseSalt(ReplaceElementwise):
 
     See also the similar ``CoarseSaltAndPepper``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.ReplaceElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.ReplaceElementwise`.
 
     Parameters
     ----------
@@ -3833,9 +3871,10 @@ class Pepper(ReplaceElementwise):
     This augmenter is similar to ``Dropout``, but slower and the black pixels
     are not uniformly black.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.ReplaceElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.ReplaceElementwise`.
 
     Parameters
     ----------
@@ -3902,9 +3941,10 @@ class CoarsePepper(ReplaceElementwise):
     """
     Replace rectangular areas in images with black-ish pixel noise.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.arithmetic.ReplaceElementwise``.
+    See :class:`~imgaug.augmenters.arithmetic.ReplaceElementwise`.
 
     Parameters
     ----------
@@ -4038,9 +4078,10 @@ class Invert(meta.Augmenter):
     ``v`` a value. Then the distance of ``v`` to ``m`` is ``d=abs(v-m)`` and
     the new value is given by ``v'=M-d``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.invert_`.
+    See :func:`~imgaug.augmenters.arithmetic.invert_`.
 
     Parameters
     ----------
@@ -4249,9 +4290,10 @@ class Solarize(Invert):
 
     See :class:`Invert` for more details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`Invert`.
+    See :class:`Invert`.
 
     Parameters
     ----------
@@ -4388,9 +4430,10 @@ class JpegCompression(meta.Augmenter):
     the images with JPEG compression and then reloads them into arrays). It
     does not return the raw JPEG file content.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.compress_jpeg`.
+    See :func:`~imgaug.augmenters.arithmetic.compress_jpeg`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -52,7 +52,8 @@ def blend_alpha(image_fg, image_bg, alpha, eps=1e-2):
     ``a`` is the alpha value. Each pixel intensity is then computed as
     ``a * A_ij + (1-a) * B_ij``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; fully tested
@@ -279,9 +280,10 @@ class BlendAlpha(meta.Augmenter):
         foreground branch are used as the new coordinates, otherwise the
         results of the background branch.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.blend.blend_alpha`.
+    See :func:`~imgaug.augmenters.blend.blend_alpha`.
 
     Parameters
     ----------
@@ -513,9 +515,10 @@ class BlendAlphaMask(meta.Augmenter):
         (on an image) of the foreground or all of the background branch will
         be used, based on the average over the whole alpha mask.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.blend.blend_alpha`.
+    See :func:`~imgaug.augmenters.blend.blend_alpha`.
 
     Parameters
     ----------
@@ -779,9 +782,10 @@ class BlendAlphaElementwise(BlendAlphaMask):
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -910,9 +914,10 @@ class BlendAlphaSimplexNoise(BlendAlphaElementwise):
     connected blobs of 1s surrounded by 0s. If nearest neighbour
     upsampling is used, these blobs can be rectangular with sharp edges.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.blend.BlendAlphaElementwise``.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaElementwise`.
 
     Parameters
     ----------
@@ -1124,9 +1129,10 @@ class BlendAlphaFrequencyNoise(BlendAlphaElementwise):
     neighbour upsampling is used, these blobs can be rectangular with sharp
     edges.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.blend.BlendAlphaElementwise``.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaElementwise`.
 
     Parameters
     ----------
@@ -1379,9 +1385,10 @@ class BlendAlphaSomeColors(BlendAlphaMask):
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
+    See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
@@ -1505,9 +1512,10 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -1614,9 +1622,10 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -1733,9 +1742,10 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -1846,9 +1856,10 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -1942,9 +1953,10 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
         This class will produce an ``AssertionError`` if there are no
         segmentation maps in a batch.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -2055,9 +2067,10 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
         This class will produce an ``AssertionError`` if there are no
         bounding boxes in a batch.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
+    See :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
     Parameters
     ----------
@@ -2290,9 +2303,10 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
         This mask generator will produce an ``AssertionError`` for batches
         that contain no images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
+    See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -32,89 +32,90 @@ def blur_gaussian_(image, sigma, ksize=None, backend="auto", eps=1e-3):
 
     This operation *may* change the input image in-place.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (backend="auto")::
+    if (backend="auto"):
 
-            * ``uint8``: yes; fully tested (1)
-            * ``uint16``: yes; tested (1)
-            * ``uint32``: yes; tested (2)
-            * ``uint64``: yes; tested (2)
-            * ``int8``: yes; tested (1)
-            * ``int16``: yes; tested (1)
-            * ``int32``: yes; tested (1)
-            * ``int64``: yes; tested (2)
-            * ``float16``: yes; tested (1)
-            * ``float32``: yes; tested (1)
-            * ``float64``: yes; tested (1)
-            * ``float128``: no
-            * ``bool``: yes; tested (1)
+        * ``uint8``: yes; fully tested (1)
+        * ``uint16``: yes; tested (1)
+        * ``uint32``: yes; tested (2)
+        * ``uint64``: yes; tested (2)
+        * ``int8``: yes; tested (1)
+        * ``int16``: yes; tested (1)
+        * ``int32``: yes; tested (1)
+        * ``int64``: yes; tested (2)
+        * ``float16``: yes; tested (1)
+        * ``float32``: yes; tested (1)
+        * ``float64``: yes; tested (1)
+        * ``float128``: no
+        * ``bool``: yes; tested (1)
 
-            - (1) Handled by ``cv2``. See ``backend="cv2"``.
-            - (2) Handled by ``scipy``. See ``backend="scipy"``.
+        - (1) Handled by ``cv2``. See ``backend="cv2"``.
+        - (2) Handled by ``scipy``. See ``backend="scipy"``.
 
-        if (backend="cv2")::
+    if (backend="cv2"):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: no (2)
-            * ``uint64``: no (3)
-            * ``int8``: yes; tested (4)
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested (5)
-            * ``int64``: no (6)
-            * ``float16``: yes; tested (7)
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: no (8)
-            * ``bool``: yes; tested (1)
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: no (2)
+        * ``uint64``: no (3)
+        * ``int8``: yes; tested (4)
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested (5)
+        * ``int64``: no (6)
+        * ``float16``: yes; tested (7)
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: no (8)
+        * ``bool``: yes; tested (1)
 
-            - (1) Mapped internally to ``float32``. Otherwise causes
-                  ``TypeError: src data type = 0 is not supported``.
-            - (2) Causes ``TypeError: src data type = 6 is not supported``.
-            - (3) Causes ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957:
-                  error: (-213:The function/feature is not implemented)
-                  Unsupported combination of source format (=4), and buffer
-                  format (=5) in function 'getLinearRowFilter'``.
-            - (4) Mapped internally to ``int16``. Otherwise causes
-                  ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957: error:
-                  (-213:The function/feature is not implemented) Unsupported
-                  combination of source format (=1), and buffer format (=5)
-                  in function 'getLinearRowFilter'``.
-            - (5) Mapped internally to ``float64``. Otherwise causes
-                  ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957: error:
-                  (-213:The function/feature is not implemented) Unsupported
-                  combination of source format (=4), and buffer format (=5)
-                  in function 'getLinearRowFilter'``.
-            - (6) Causes ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957:
-                  error: (-213:The function/feature is not implemented)
-                  Unsupported combination of source format (=4), and buffer
-                  format (=5) in function 'getLinearRowFilter'``.
-            - (7) Mapped internally to ``float32``. Otherwise causes
-                  ``TypeError: src data type = 23 is not supported``.
-            - (8) Causes ``TypeError: src data type = 13 is not supported``.
+        - (1) Mapped internally to ``float32``. Otherwise causes
+              ``TypeError: src data type = 0 is not supported``.
+        - (2) Causes ``TypeError: src data type = 6 is not supported``.
+        - (3) Causes ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957:
+              error: (-213:The function/feature is not implemented)
+              Unsupported combination of source format (=4), and buffer
+              format (=5) in function 'getLinearRowFilter'``.
+        - (4) Mapped internally to ``int16``. Otherwise causes
+              ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957: error:
+              (-213:The function/feature is not implemented) Unsupported
+              combination of source format (=1), and buffer format (=5)
+              in function 'getLinearRowFilter'``.
+        - (5) Mapped internally to ``float64``. Otherwise causes
+              ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957: error:
+              (-213:The function/feature is not implemented) Unsupported
+              combination of source format (=4), and buffer format (=5)
+              in function 'getLinearRowFilter'``.
+        - (6) Causes ``cv2.error: OpenCV(3.4.5) (...)/filter.cpp:2957:
+              error: (-213:The function/feature is not implemented)
+              Unsupported combination of source format (=4), and buffer
+              format (=5) in function 'getLinearRowFilter'``.
+        - (7) Mapped internally to ``float32``. Otherwise causes
+              ``TypeError: src data type = 23 is not supported``.
+        - (8) Causes ``TypeError: src data type = 13 is not supported``.
 
-        if (backend="scipy")::
+    if (backend="scipy"):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: yes; tested
-            * ``uint64``: yes; tested
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested
-            * ``int64``: yes; tested
-            * ``float16``: yes; tested (1)
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: no (2)
-            * ``bool``: yes; tested (3)
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested
+        * ``uint64``: yes; tested
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested
+        * ``int64``: yes; tested
+        * ``float16``: yes; tested (1)
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: no (2)
+        * ``bool``: yes; tested (3)
 
-            - (1) Mapped internally to ``float32``. Otherwise causes
-                  ``RuntimeError: array type dtype('float16') not supported``.
-            - (2) Causes ``RuntimeError: array type dtype('float128') not
-                  supported``.
-            - (3) Mapped internally to ``float32``. Otherwise too inaccurate.
+        - (1) Mapped internally to ``float32``. Otherwise causes
+              ``RuntimeError: array type dtype('float16') not supported``.
+        - (2) Causes ``RuntimeError: array type dtype('float128') not
+              supported``.
+        - (3) Mapped internally to ``float32``. Otherwise too inaccurate.
 
     Parameters
     ----------
@@ -286,7 +287,8 @@ def blur_mean_shift_(image, spatial_window_radius, color_window_radius):
 
         This function is quite slow.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no (1)
@@ -386,9 +388,10 @@ def _compute_gaussian_blur_ksize(sigma):
 class GaussianBlur(meta.Augmenter):
     """Augmenter to blur images using gaussian kernels.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.blur.blur_gaussian_(backend="auto")`.
+    See ``~imgaug.augmenters.blur.blur_gaussian_(backend="auto")``.
 
     Parameters
     ----------
@@ -466,7 +469,8 @@ class AverageBlur(meta.Augmenter):
     The padding behaviour around the image borders is cv2's
     ``BORDER_REFLECT_101``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -671,7 +675,8 @@ class MedianBlur(meta.Augmenter):
     Median blurring can be used to remove small dirt from images.
     At larger kernel sizes, its effects have some similarity with Superpixels.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: ?
@@ -793,7 +798,8 @@ class BilateralBlur(meta.Augmenter):
     http://docs.opencv.org/2.4/modules/imgproc/doc/filtering.html#bilateralfilter
     for more information regarding the parameters.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; not tested
         * ``uint16``: ?
@@ -935,9 +941,10 @@ class BilateralBlur(meta.Augmenter):
 class MotionBlur(iaa_convolutional.Convolve):
     """Blur images in a way that fakes camera or object movements.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.convolutional.Convolve``.
+    See :class:`~imgaug.augmenters.convolutional.Convolve`.
 
     Parameters
     ----------
@@ -1087,9 +1094,10 @@ class MeanShiftBlur(meta.Augmenter):
 
         This augmenter is quite slow.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.blur.blur_mean_shift_`.
+    See :func:`~imgaug.augmenters.blur.blur_mean_shift_`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -185,7 +185,8 @@ def change_colorspace_(image, to_colorspace, from_colorspace=CSPACE_RGB):
 
         Output grayscale images will still have three channels.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -321,9 +322,10 @@ def change_colorspaces_(images, to_colorspaces, from_colorspaces=CSPACE_RGB):
 
         Output grayscale images will still have three channels.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspace_`.
+    See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -962,9 +964,10 @@ class WithColorspace(meta.Augmenter):
     child augmenters C and finally changes the colorspace back from B to A.
     See also ChangeColorspace() for more.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
+    See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
@@ -1069,9 +1072,10 @@ class WithBrightnessChannels(meta.Augmenter):
     it reintegrates the augmented channel into the full image and converts
     back to the input colorspace.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
+    See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
@@ -1249,9 +1253,10 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
     This is a wrapper around :class:`WithBrightnessChannels` and hence
     performs internally the same projection to random colorspaces.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.WithBrightnessChannels`.
+    See :class:`~imgaug.augmenters.color.WithBrightnessChannels`.
 
     Parameters
     ----------
@@ -1346,9 +1351,10 @@ class MultiplyBrightness(MultiplyAndAddToBrightness):
     This is a wrapper around :class:`WithBrightnessChannels` and hence
     performs internally the same projection to random colorspaces.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.MultiplyAndAddToBrightness`.
+    See :class:`~imgaug.augmenters.color.MultiplyAndAddToBrightness`.
 
     Parameters
     ----------
@@ -1407,9 +1413,10 @@ class AddToBrightness(MultiplyAndAddToBrightness):
     This is a wrapper around :class:`WithBrightnessChannels` and hence
     performs internally the same projection to random colorspaces.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.MultiplyAndAddToBrightness`.
+    See :class:`~imgaug.augmenters.color.MultiplyAndAddToBrightness`.
 
     Parameters
     ----------
@@ -1483,9 +1490,10 @@ class WithHueAndSaturation(meta.Augmenter):
     is applied to the hue channel's values, followed by a mapping from
     ``[0, 255]`` to ``[0, 180]`` (and finally the colorspace conversion).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
+    See :func:`~imgaug.augmenters.color.change_colorspaces_`.
 
     Parameters
     ----------
@@ -1648,9 +1656,10 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
 
     This augmenter is a wrapper around ``WithHueAndSaturation``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See `imgaug.augmenters.color.WithHueAndSaturation`.
+    See :class:`~imgaug.augmenters.color.WithHueAndSaturation`.
 
     Parameters
     ----------
@@ -1843,9 +1852,10 @@ class MultiplyHue(MultiplyHueAndSaturation):
 
     This augmenter is a shortcut for ``MultiplyHueAndSaturation(mul_hue=...)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See `imgaug.augmenters.color.MultiplyHueAndSaturation`.
+    See :class:`~imgaug.augmenters.color.MultiplyHueAndSaturation`.
 
     Parameters
     ----------
@@ -1906,9 +1916,10 @@ class MultiplySaturation(MultiplyHueAndSaturation):
     This augmenter is a shortcut for
     ``MultiplyHueAndSaturation(mul_saturation=...)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See `imgaug.augmenters.color.MultiplyHueAndSaturation`.
+    See :class:`~imgaug.augmenters.color.MultiplyHueAndSaturation`.
 
     Parameters
     ----------
@@ -2093,9 +2104,10 @@ class AddToHueAndSaturation(meta.Augmenter):
 
     TODO add float support
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspace_`.
+    See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -2397,9 +2409,10 @@ class AddToHue(AddToHueAndSaturation):
 
     This augmenter is a shortcut for ``AddToHueAndSaturation(value_hue=...)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See `imgaug.augmenters.color.AddToHueAndSaturation`.
+    See :class:`~imgaug.augmenters.color.AddToHueAndSaturation`.
 
     Parameters
     ----------
@@ -2463,9 +2476,10 @@ class AddToSaturation(AddToHueAndSaturation):
     This augmenter is a shortcut for
     ``AddToHueAndSaturation(value_saturation=...)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See `imgaug.augmenters.color.AddToHueAndSaturation`.
+    See :class:`~imgaug.augmenters.color.AddToHueAndSaturation`.
 
     Parameters
     ----------
@@ -2529,9 +2543,10 @@ class ChangeColorspace(meta.Augmenter):
         This augmenter tries to project the colorspace value range on
         0-255. It outputs dtype=uint8 images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspace_`.
+    See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -2728,9 +2743,10 @@ class Grayscale(ChangeColorspace):
 
     TODO check dtype support
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.change_colorspace_`.
+    See :func:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -2999,22 +3015,23 @@ class KMeansColorQuantization(_AbstractColorQuantization):
         images have 4 channels, it is assumed that the 4th channel is an alpha
         channel and it will not be quantized.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (image size <= max_size)::
+    if (image size <= max_size):
 
-            minimum of (
-                ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`~imgaug.augmenters.color.quantize_colors_kmeans`
-            )
+        minimum of (
+            :class:`~imgaug.augmenters.color.ChangeColorspace`,
+            :func:`~imgaug.augmenters.color.quantize_colors_kmeans`
+        )
 
-        if (image size > max_size)::
+    if (image size > max_size):
 
-            minimum of (
-                ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`~imgaug.augmenters.color.quantize_colors_kmeans`,
-                :func:`~imgaug.imgaug.imresize_single_image`
-            )
+        minimum of (
+            :class:`~imgaug.augmenters.color.ChangeColorspace`,
+            :func:`~imgaug.augmenters.color.quantize_colors_kmeans`,
+            :func:`~imgaug.imgaug.imresize_single_image`
+        )
 
     Parameters
     ----------
@@ -3151,7 +3168,8 @@ def quantize_kmeans(arr, nb_clusters, nb_max_iter=10, eps=1.0):
         internal RNG and imgaug's global RNG. This is necessary in order
         to ensure that the k-means clustering happens deterministically.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -3268,22 +3286,23 @@ class UniformColorQuantization(_AbstractColorQuantization):
         images have 4 channels, it is assumed that the 4th channel is an alpha
         channel and it will not be quantized.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (image size <= max_size)::
+    if (image size <= max_size):
 
-            minimum of (
-                ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`~imgaug.augmenters.color.quantize_uniform_`
-            )
+        minimum of (
+            :class:`~imgaug.augmenters.color.ChangeColorspace`,
+            :func:`~imgaug.augmenters.color.quantize_uniform_`
+        )
 
-        if (image size > max_size)::
+    if (image size > max_size):
 
-            minimum of (
-                ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`~imgaug.augmenters.color.quantize_uniform_`,
-                :func:`~imgaug.imgaug.imresize_single_image`
-            )
+        minimum of (
+            :class:`~imgaug.augmenters.color.ChangeColorspace`,
+            :func:`~imgaug.augmenters.color.quantize_uniform_`,
+            :func:`~imgaug.imgaug.imresize_single_image`
+        )
 
     Parameters
     ----------
@@ -3413,22 +3432,23 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
         images have 4 channels, it is assumed that the 4th channel is an alpha
         channel and it will not be quantized.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (image size <= max_size)::
+    if (image size <= max_size):
 
-            minimum of (
-                ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`~imgaug.augmenters.color.quantize_colors_uniform`
-            )
+        minimum of (
+            :class:`~imgaug.augmenters.color.ChangeColorspace`,
+            :func:`~imgaug.augmenters.color.quantize_colors_uniform`
+        )
 
-        if (image size > max_size)::
+    if (image size > max_size):
 
-            minimum of (
-                ``imgaug.augmenters.color.ChangeColorspace``,
-                :func:`~imgaug.augmenters.color.quantize_colors_uniform`,
-                :func:`~imgaug.imgaug.imresize_single_image`
-            )
+        minimum of (
+            :class:`~imgaug.augmenters.color.ChangeColorspace`,
+            :func:`~imgaug.augmenters.color.quantize_colors_uniform`,
+            :func:`~imgaug.imgaug.imresize_single_image`
+        )
 
     Parameters
     ----------
@@ -3534,9 +3554,10 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
 class Posterize(UniformColorQuantizationToNBits):
     """Alias for :class:`UniformColorQuantizationToNBits`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.color.UniformColorQuantizationToNBits`.
+    See :class:`~imgaug.augmenters.color.UniformColorQuantizationToNBits`.
 
     """
 
@@ -3552,9 +3573,10 @@ def quantize_uniform(arr, nb_bins, to_bin_centers=True):
 
     See :func:`quantize_uniform_` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.quantize_uniform_`.
+    See :func:`~imgaug.augmenters.color.quantize_uniform_`.
 
     Parameters
     ----------
@@ -3588,7 +3610,8 @@ def quantize_uniform_(arr, nb_bins, to_bin_centers=True):
     the target number of bins (roughly matches number of colors) after
     quantization.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -3731,9 +3754,10 @@ def quantize_uniform_to_n_bits(arr, nb_bits):
 
     See :func:`quantize_uniform_to_n_bits` for details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits_`.
+    See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits_`.
 
     Parameters
     ----------
@@ -3766,9 +3790,10 @@ def quantize_uniform_to_n_bits_(arr, nb_bits):
     This function produces the same outputs as :func:`PIL.ImageOps.posterize`,
     but is significantly faster.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.quantize_uniform_`.
+    See :func:`~imgaug.augmenters.color.quantize_uniform_`.
 
     Parameters
     ----------
@@ -3811,9 +3836,10 @@ def posterize(arr, nb_bits):
     This function is an alias for :func:`quantize_uniform_to_n_bits` and was
     added for users familiar with the same function in PIL.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits`.
+    See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -96,7 +96,8 @@ def adjust_contrast_gamma(arr, gamma):
     """
     Adjust image contrast by scaling pixel values to ``255*((v/255)**gamma)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested (1) (2) (3)
         * ``uint16``: yes; tested (2) (3)
@@ -174,7 +175,8 @@ def adjust_contrast_sigmoid(arr, gain, cutoff):
     """
     Adjust image contrast to ``255*1/(1+exp(gain*(cutoff-I_ij/255)))``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested (1) (2) (3)
         * ``uint16``: yes; tested (2) (3)
@@ -261,7 +263,8 @@ def adjust_contrast_log(arr, gain):
     """
     Adjust image contrast by scaling pixels to ``255*gain*log_2(1+v/255)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested (1) (2) (3)
         * ``uint16``: yes; tested (2) (3)
@@ -341,7 +344,8 @@ def adjust_contrast_log(arr, gain):
 def adjust_contrast_linear(arr, alpha):
     """Adjust contrast by scaling each pixel to ``127 + alpha*(v-127)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested (1) (2)
         * ``uint16``: yes; tested (2)
@@ -424,9 +428,10 @@ class GammaContrast(_ContrastFuncWrapper):
 
     Values in the range ``gamma=(0.5, 2.0)`` seem to be sensible.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.contrast.adjust_contrast_gamma`.
+    See :func:`~imgaug.augmenters.contrast.adjust_contrast_gamma`.
 
     Parameters
     ----------
@@ -494,9 +499,10 @@ class SigmoidContrast(_ContrastFuncWrapper):
     Values in the range ``gain=(5, 20)`` and ``cutoff=(0.25, 0.75)`` seem to
     be sensible.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.contrast.adjust_contrast_sigmoid`.
+    See :func:`~imgaug.augmenters.contrast.adjust_contrast_sigmoid`.
 
     Parameters
     ----------
@@ -586,9 +592,10 @@ class LogContrast(_ContrastFuncWrapper):
     This augmenter is fairly similar to
     ``imgaug.augmenters.arithmetic.Multiply``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.contrast.adjust_contrast_log`.
+    See :func:`~imgaug.augmenters.contrast.adjust_contrast_log`.
 
     Parameters
     ----------
@@ -655,9 +662,10 @@ class LogContrast(_ContrastFuncWrapper):
 class LinearContrast(_ContrastFuncWrapper):
     """Adjust contrast by scaling each pixel to ``127 + alpha*(v-127)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.contrast.adjust_contrast_linear`.
+    See :func:`~imgaug.augmenters.contrast.adjust_contrast_linear`.
 
     Parameters
     ----------
@@ -869,7 +877,8 @@ class AllChannelsCLAHE(meta.Augmenter):
     perform any colorspace transformations and does not focus on specific
     channels (e.g. ``L`` in ``Lab`` colorspace).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -1054,7 +1063,8 @@ class CLAHE(meta.Augmenter):
     colorspace (without any colorspace conversion), use
     ``imgaug.augmenters.contrast.AllChannelsCLAHE`` instead.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no (1)
@@ -1070,8 +1080,9 @@ class CLAHE(meta.Augmenter):
         * ``float128``: no (1)
         * ``bool``: no (1)
 
-        - (1) This augmenter uses ChangeColorspace, which is currently
-              limited to ``uint8``.
+        - (1) This augmenter uses
+              :class:`~imgaug.augmenters.color.ChangeColorspace`, which is
+              currently limited to ``uint8``.
 
     Parameters
     ----------
@@ -1258,7 +1269,8 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
     not perform any colorspace transformations and does not focus on specific
     channels (e.g. ``L`` in ``Lab`` colorspace).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no (1)
@@ -1368,7 +1380,8 @@ class HistogramEqualization(meta.Augmenter):
     input image's colorspace (without any colorspace conversion), use
     ``imgaug.augmenters.contrast.AllChannelsHistogramEqualization`` instead.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no (1)
@@ -1384,7 +1397,8 @@ class HistogramEqualization(meta.Augmenter):
         * ``float128``: no (1)
         * ``bool``: no (1)
 
-        - (1) This augmenter uses AllChannelsHistogramEqualization, which only supports ``uint8``.
+        - (1) This augmenter uses :class:`AllChannelsHistogramEqualization`,
+              which only supports ``uint8``.
 
     Parameters
     ----------

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -34,7 +34,8 @@ class Convolve(meta.Augmenter):
     """
     Apply a convolution to input images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -231,9 +232,10 @@ class Sharpen(Convolve):
     """
     Sharpen images and alpha-blend the result with the original input images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.convolutional.Convolve``.
+    See :class:`~imgaug.augmenters.convolutional.Convolve`.
 
     Parameters
     ----------
@@ -339,9 +341,10 @@ class Emboss(Convolve):
     The embossed version pronounces highlights and shadows,
     letting the image look as if it was recreated on a metal plate ("embossed").
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.convolutional.Convolve``.
+    See :class:`~imgaug.augmenters.convolutional.Convolve`.
 
     Parameters
     ----------
@@ -439,9 +442,10 @@ class EdgeDetect(Convolve):
     """
     Generate a black & white edge image and alpha-blend it with the input image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.convolutional.Convolve``.
+    See :class:`~imgaug.augmenters.convolutional.Convolve`.
 
     Parameters
     ----------
@@ -531,9 +535,10 @@ class DirectedEdgeDetect(Convolve):
     The result of applying the kernel is a black (non-edges) and white (edges)
     image. That image is alpha-blended with the input image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.convolutional.Convolve``.
+    See :class:`~imgaug.augmenters.convolutional.Convolve`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -168,7 +168,8 @@ class Canny(meta.Augmenter):
     """
     Apply a canny edge detector to input images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no; not tested

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -679,7 +679,8 @@ _FLIPLR_DTYPES_CV2 = {"uint8", "uint16", "int8", "int16"}
 def fliplr(arr):
     """Flip an image-like array horizontally.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; fully tested
@@ -764,7 +765,8 @@ def _fliplr_cv2(arr):
 def flipud(arr):
     """Flip an image-like array vertically.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; fully tested
@@ -826,9 +828,10 @@ class Fliplr(meta.Augmenter):
         So, to flip *all* input images use ``Fliplr(1.0)`` and *not* just
         ``Fliplr()``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.flip.fliplr`.
+    See :func:`~imgaug.augmenters.flip.fliplr`.
 
     Parameters
     ----------
@@ -927,9 +930,10 @@ class Flipud(meta.Augmenter):
         So, to flip *all* input images use ``Flipud(1.0)`` and *not* just
         ``Flipud()``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.flip.flipud`.
+    See :func:`~imgaug.augmenters.flip.flipud`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -358,7 +358,8 @@ def apply_jigsaw(arr, destinations):
     This function will split the image into ``rows x cols`` cells and
     move each cell to the target index given in `destinations`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; fully tested
@@ -725,9 +726,53 @@ class Affine(meta.Augmenter):
         For performance reasons, there is no explicit validation of whether
         the aspect ratios are similar.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (backend="skimage", order in [0, 1])::
+    if (backend="skimage", order in [0, 1]):
+
+        * ``uint8``: yes; tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested (1)
+        * ``uint64``: no (2)
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested  (1)
+        * ``int64``: no (2)
+        * ``float16``: yes; tested
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: no (2)
+        * ``bool``: yes; tested
+
+        - (1) scikit-image converts internally to float64, which might
+              affect the accuracy of large integers. In tests this seemed
+              to not be an issue.
+        - (2) results too inaccurate
+
+    if (backend="skimage", order in [3, 4]):
+
+        * ``uint8``: yes; tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested (1)
+        * ``uint64``: no (2)
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested  (1)
+        * ``int64``: no (2)
+        * ``float16``: yes; tested
+        * ``float32``: yes; tested
+        * ``float64``: limited; tested (3)
+        * ``float128``: no (2)
+        * ``bool``: yes; tested
+
+        - (1) scikit-image converts internally to float64, which might
+              affect the accuracy of large integers. In tests this seemed
+              to not be an issue.
+        - (2) results too inaccurate
+        - (3) ``NaN`` around minimum and maximum of float64 value range
+
+    if (backend="skimage", order=5]):
 
             * ``uint8``: yes; tested
             * ``uint16``: yes; tested
@@ -739,124 +784,81 @@ class Affine(meta.Augmenter):
             * ``int64``: no (2)
             * ``float16``: yes; tested
             * ``float32``: yes; tested
-            * ``float64``: yes; tested
+            * ``float64``: limited; not tested (3)
             * ``float128``: no (2)
             * ``bool``: yes; tested
 
-            - (1) scikit-image converts internally to float64, which might
-                  affect the accuracy of large integers. In tests this seemed
-                  to not be an issue.
-            - (2) results too inaccurate
-
-        if (backend="skimage", order in [3, 4])::
-
-            * ``uint8``: yes; tested
-            * ``uint16``: yes; tested
-            * ``uint32``: yes; tested (1)
-            * ``uint64``: no (2)
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested  (1)
-            * ``int64``: no (2)
-            * ``float16``: yes; tested
-            * ``float32``: yes; tested
-            * ``float64``: limited; tested (3)
-            * ``float128``: no (2)
-            * ``bool``: yes; tested
-
-            - (1) scikit-image converts internally to float64, which might
-                  affect the accuracy of large integers. In tests this seemed
-                  to not be an issue.
+            - (1) scikit-image converts internally to ``float64``, which
+                  might affect the accuracy of large integers. In tests
+                  this seemed to not be an issue.
             - (2) results too inaccurate
             - (3) ``NaN`` around minimum and maximum of float64 value range
 
-        if (backend="skimage", order=5])::
+    if (backend="cv2", order=0):
 
-                * ``uint8``: yes; tested
-                * ``uint16``: yes; tested
-                * ``uint32``: yes; tested (1)
-                * ``uint64``: no (2)
-                * ``int8``: yes; tested
-                * ``int16``: yes; tested
-                * ``int32``: yes; tested  (1)
-                * ``int64``: no (2)
-                * ``float16``: yes; tested
-                * ``float32``: yes; tested
-                * ``float64``: limited; not tested (3)
-                * ``float128``: no (2)
-                * ``bool``: yes; tested
+        * ``uint8``: yes; tested
+        * ``uint16``: yes; tested
+        * ``uint32``: no (1)
+        * ``uint64``: no (2)
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested
+        * ``int64``: no (2)
+        * ``float16``: yes; tested (3)
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: no (1)
+        * ``bool``: yes; tested (3)
 
-                - (1) scikit-image converts internally to ``float64``, which
-                      might affect the accuracy of large integers. In tests
-                      this seemed to not be an issue.
-                - (2) results too inaccurate
-                - (3) ``NaN`` around minimum and maximum of float64 value range
+        - (1) rejected by cv2
+        - (2) changed to ``int32`` by cv2
+        - (3) mapped internally to ``float32``
 
-        if (backend="cv2", order=0)::
+    if (backend="cv2", order=1):
 
-            * ``uint8``: yes; tested
-            * ``uint16``: yes; tested
-            * ``uint32``: no (1)
-            * ``uint64``: no (2)
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested
-            * ``int64``: no (2)
-            * ``float16``: yes; tested (3)
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: no (1)
-            * ``bool``: yes; tested (3)
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: no (1)
+        * ``uint64``: no (2)
+        * ``int8``: yes; tested (3)
+        * ``int16``: yes; tested
+        * ``int32``: no (2)
+        * ``int64``: no (2)
+        * ``float16``: yes; tested (4)
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: no (1)
+        * ``bool``: yes; tested (4)
 
-            - (1) rejected by cv2
-            - (2) changed to ``int32`` by cv2
-            - (3) mapped internally to ``float32``
+        - (1) rejected by cv2
+        - (2) causes cv2 error: ``cv2.error: OpenCV(3.4.4)
+              (...)imgwarp.cpp:1805: error:
+              (-215:Assertion failed) ifunc != 0 in function 'remap'``
+        - (3) mapped internally to ``int16``
+        - (4) mapped internally to ``float32``
 
-        if (backend="cv2", order=1):
+    if (backend="cv2", order=3):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: no (1)
-            * ``uint64``: no (2)
-            * ``int8``: yes; tested (3)
-            * ``int16``: yes; tested
-            * ``int32``: no (2)
-            * ``int64``: no (2)
-            * ``float16``: yes; tested (4)
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: no (1)
-            * ``bool``: yes; tested (4)
+        * ``uint8``: yes; tested
+        * ``uint16``: yes; tested
+        * ``uint32``: no (1)
+        * ``uint64``: no (2)
+        * ``int8``: yes; tested (3)
+        * ``int16``: yes; tested
+        * ``int32``: no (2)
+        * ``int64``: no (2)
+        * ``float16``: yes; tested (4)
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: no (1)
+        * ``bool``: yes; tested (4)
 
-            - (1) rejected by cv2
-            - (2) causes cv2 error: ``cv2.error: OpenCV(3.4.4)
-                  (...)imgwarp.cpp:1805: error:
-                  (-215:Assertion failed) ifunc != 0 in function 'remap'``
-            - (3) mapped internally to ``int16``
-            - (4) mapped internally to ``float32``
-
-        if (backend="cv2", order=3):
-
-            * ``uint8``: yes; tested
-            * ``uint16``: yes; tested
-            * ``uint32``: no (1)
-            * ``uint64``: no (2)
-            * ``int8``: yes; tested (3)
-            * ``int16``: yes; tested
-            * ``int32``: no (2)
-            * ``int64``: no (2)
-            * ``float16``: yes; tested (4)
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: no (1)
-            * ``bool``: yes; tested (4)
-
-            - (1) rejected by cv2
-            - (2) causes cv2 error: ``cv2.error: OpenCV(3.4.4)
-                  (...)imgwarp.cpp:1805: error:
-                  (-215:Assertion failed) ifunc != 0 in function 'remap'``
-            - (3) mapped internally to ``int16``
-            - (4) mapped internally to ``float32``
+        - (1) rejected by cv2
+        - (2) causes cv2 error: ``cv2.error: OpenCV(3.4.4)
+              (...)imgwarp.cpp:1805: error:
+              (-215:Assertion failed) ifunc != 0 in function 'remap'``
+        - (3) mapped internally to ``int16``
+        - (4) mapped internally to ``float32``
 
 
     Parameters
@@ -1509,9 +1511,10 @@ class ScaleX(Affine):
 
     This is a wrapper around :class:`Affine`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.geometric.Affine`.
+    See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1573,9 +1576,10 @@ class ScaleY(Affine):
 
     This is a wrapper around :class:`Affine`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.geometric.Affine`.
+    See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1638,9 +1642,10 @@ class TranslateX(Affine):
 
     This is a wrapper around :class:`Affine`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.geometric.Affine`.
+    See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1718,9 +1723,10 @@ class TranslateY(Affine):
 
     This is a wrapper around :class:`Affine`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.geometric.Affine`.
+    See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1798,9 +1804,10 @@ class Rotate(Affine):
     This is a wrapper around :class:`Affine`.
     It is the same as ``Affine(rotate=<value>)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.geometric.Affine`.
+    See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1859,9 +1866,10 @@ class ShearX(Affine):
 
     This is a wrapper around :class:`Affine`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.geometric.Affine`.
+    See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1913,9 +1921,10 @@ class ShearY(Affine):
 
     This is a wrapper around :class:`Affine`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.geometric.Affine`.
+    See :class:`~imgaug.augmenters.geometric.Affine`.
 
     Parameters
     ----------
@@ -1990,7 +1999,8 @@ class AffineCv2(meta.Augmenter):
     of the input image to generate output pixel values. The parameter `order`
     deals with the method of interpolation used for this.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: ?
@@ -2735,7 +2745,8 @@ class PiecewiseAffine(meta.Augmenter):
         which will make it significantly slower for such inputs than other
         augmenters. See :ref:`performance`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested (1)
@@ -3220,37 +3231,38 @@ class PerspectiveTransform(meta.Augmenter):
     Code partially from
     http://www.pyimagesearch.com/2014/08/25/4-point-opencv-getperspective-transform-example/
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (keep_size=False)::
+    if (keep_size=False):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: no (1)
-            * ``uint64``: no (2)
-            * ``int8``: yes; tested (3)
-            * ``int16``: yes; tested
-            * ``int32``: no (2)
-            * ``int64``: no (2)
-            * ``float16``: yes; tested (4)
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: no (1)
-            * ``bool``: yes; tested (4)
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: no (1)
+        * ``uint64``: no (2)
+        * ``int8``: yes; tested (3)
+        * ``int16``: yes; tested
+        * ``int32``: no (2)
+        * ``int64``: no (2)
+        * ``float16``: yes; tested (4)
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: no (1)
+        * ``bool``: yes; tested (4)
 
-            - (1) rejected by opencv
-            - (2) leads to opencv error: cv2.error: ``OpenCV(3.4.4)
-                  (...)imgwarp.cpp:1805: error: (-215:Assertion failed)
-                  ifunc != 0 in function 'remap'``.
-            - (3) mapped internally to ``int16``.
-            - (4) mapped intenally to ``float32``.
+        - (1) rejected by opencv
+        - (2) leads to opencv error: cv2.error: ``OpenCV(3.4.4)
+              (...)imgwarp.cpp:1805: error: (-215:Assertion failed)
+              ifunc != 0 in function 'remap'``.
+        - (3) mapped internally to ``int16``.
+        - (4) mapped intenally to ``float32``.
 
-        if (keep_size=True)::
+    if (keep_size=True):
 
-            minimum of (
-                ``imgaug.augmenters.geometric.PerspectiveTransform(keep_size=False)``,
-                :func:`~imgaug.imgaug.imresize_many_images`
-            )
+        minimum of (
+            ``imgaug.augmenters.geometric.PerspectiveTransform(keep_size=False)``,
+            :func:`~imgaug.imgaug.imresize_many_images`
+        )
 
     Parameters
     ----------
@@ -3871,7 +3883,8 @@ class ElasticTransformation(meta.Augmenter):
         which will make it significantly slower for such inputs than other
         augmenters. See :ref:`performance`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested (1)
         * ``uint16``: yes; tested (1)
@@ -4347,115 +4360,116 @@ class ElasticTransformation(meta.Augmenter):
     def _map_coordinates(cls, image, dx, dy, order=1, cval=0, mode="constant"):
         """Remap pixels in an image according to x/y shift maps.
 
-        dtype support::
+        Supported dtypes
+        ----------------
 
-            if (backend="scipy" and order=0)::
+        if (backend="scipy" and order=0):
 
-                * ``uint8``: yes
-                * ``uint16``: yes
-                * ``uint32``: yes
-                * ``uint64``: no (1)
-                * ``int8``: yes
-                * ``int16``: yes
-                * ``int32``: yes
-                * ``int64``: no (2)
-                * ``float16``: yes
-                * ``float32``: yes
-                * ``float64``: yes
-                * ``float128``: no (3)
-                * ``bool``: yes
+            * ``uint8``: yes
+            * ``uint16``: yes
+            * ``uint32``: yes
+            * ``uint64``: no (1)
+            * ``int8``: yes
+            * ``int16``: yes
+            * ``int32``: yes
+            * ``int64``: no (2)
+            * ``float16``: yes
+            * ``float32``: yes
+            * ``float64``: yes
+            * ``float128``: no (3)
+            * ``bool``: yes
 
-                - (1) produces array filled with only 0
-                - (2) produces array filled with <min_value> when testing
-                      with <max_value>
-                - (3) causes: 'data type no supported'
+            - (1) produces array filled with only 0
+            - (2) produces array filled with <min_value> when testing
+                  with <max_value>
+            - (3) causes: 'data type no supported'
 
-            if (backend="scipy" and order>0)::
+        if (backend="scipy" and order>0):
 
-                * ``uint8``: yes (1)
-                * ``uint16``: yes (1)
-                * ``uint32``: yes (1)
-                * ``uint64``: yes (1)
-                * ``int8``: yes (1)
-                * ``int16``: yes (1)
-                * ``int32``: yes (1)
-                * ``int64``: yes (1)
-                * ``float16``: yes (1)
-                * ``float32``: yes (1)
-                * ``float64``: yes (1)
-                * ``float128``: no (2)
-                * ``bool``: yes
+            * ``uint8``: yes (1)
+            * ``uint16``: yes (1)
+            * ``uint32``: yes (1)
+            * ``uint64``: yes (1)
+            * ``int8``: yes (1)
+            * ``int16``: yes (1)
+            * ``int32``: yes (1)
+            * ``int64``: yes (1)
+            * ``float16``: yes (1)
+            * ``float32``: yes (1)
+            * ``float64``: yes (1)
+            * ``float128``: no (2)
+            * ``bool``: yes
 
-                - (1) rather loose test, to avoid having to re-compute the
-                      interpolation
-                - (2) causes: 'data type no supported'
+            - (1) rather loose test, to avoid having to re-compute the
+                  interpolation
+            - (2) causes: 'data type no supported'
 
-            if (backend="cv2" and order=0)::
+        if (backend="cv2" and order=0):
 
-                * ``uint8``: yes
-                * ``uint16``: yes
-                * ``uint32``: no (1)
-                * ``uint64``: no (2)
-                * ``int8``: yes
-                * ``int16``: yes
-                * ``int32``: yes
-                * ``int64``: no (2)
-                * ``float16``: yes
-                * ``float32``: yes
-                * ``float64``: yes
-                * ``float128``: no (3)
-                * ``bool``: no (4)
+            * ``uint8``: yes
+            * ``uint16``: yes
+            * ``uint32``: no (1)
+            * ``uint64``: no (2)
+            * ``int8``: yes
+            * ``int16``: yes
+            * ``int32``: yes
+            * ``int64``: no (2)
+            * ``float16``: yes
+            * ``float32``: yes
+            * ``float64``: yes
+            * ``float128``: no (3)
+            * ``bool``: no (4)
 
-                - (1) causes: src data type = 6 is not supported
-                - (2) silently converts to int32
-                - (3) causes: src data type = 13 is not supported
-                - (4) causes: src data type = 0 is not supported
+            - (1) causes: src data type = 6 is not supported
+            - (2) silently converts to int32
+            - (3) causes: src data type = 13 is not supported
+            - (4) causes: src data type = 0 is not supported
 
-            if (backend="cv2" and order=1)::
+        if (backend="cv2" and order=1):
 
-                * ``uint8``: yes
-                * ``uint16``: yes
-                * ``uint32``: no (1)
-                * ``uint64``: no (2)
-                * ``int8``: no (2)
-                * ``int16``: no (2)
-                * ``int32``: no (2)
-                * ``int64``: no (2)
-                * ``float16``: yes
-                * ``float32``: yes
-                * ``float64``: yes
-                * ``float128``: no (3)
-                * ``bool``: no (4)
+            * ``uint8``: yes
+            * ``uint16``: yes
+            * ``uint32``: no (1)
+            * ``uint64``: no (2)
+            * ``int8``: no (2)
+            * ``int16``: no (2)
+            * ``int32``: no (2)
+            * ``int64``: no (2)
+            * ``float16``: yes
+            * ``float32``: yes
+            * ``float64``: yes
+            * ``float128``: no (3)
+            * ``bool``: no (4)
 
-                - (1) causes: src data type = 6 is not supported
-                - (2) causes: OpenCV(3.4.5) (...)/imgwarp.cpp:1805:
-                      error: (-215:Assertion failed) ifunc != 0 in function
-                      'remap'
-                - (3) causes: src data type = 13 is not supported
-                - (4) causes: src data type = 0 is not supported
+            - (1) causes: src data type = 6 is not supported
+            - (2) causes: OpenCV(3.4.5) (...)/imgwarp.cpp:1805:
+                  error: (-215:Assertion failed) ifunc != 0 in function
+                  'remap'
+            - (3) causes: src data type = 13 is not supported
+            - (4) causes: src data type = 0 is not supported
 
-            if (backend="cv2" and order>=2)::
+        if (backend="cv2" and order>=2):
 
-                * ``uint8``: yes
-                * ``uint16``: yes
-                * ``uint32``: no (1)
-                * ``uint64``: no (2)
-                * ``int8``: no (2)
-                * ``int16``: yes
-                * ``int32``: no (2)
-                * ``int64``: no (2)
-                * ``float16``: yes
-                * ``float32``: yes
-                * ``float64``: yes
-                * ``float128``: no (3)
-                * ``bool``: no (4)
+            * ``uint8``: yes
+            * ``uint16``: yes
+            * ``uint32``: no (1)
+            * ``uint64``: no (2)
+            * ``int8``: no (2)
+            * ``int16``: yes
+            * ``int32``: no (2)
+            * ``int64``: no (2)
+            * ``float16``: yes
+            * ``float32``: yes
+            * ``float64``: yes
+            * ``float128``: no (3)
+            * ``bool``: no (4)
 
-                - (1) causes: src data type = 6 is not supported
-                - (2) causes: OpenCV(3.4.5) (...)/imgwarp.cpp:1805:
-                      error: (-215:Assertion failed) ifunc != 0 in function
-                      'remap'
-                - (3) causes: src data type = 13 is not supported
-                - (4) causes: src data type = 0 is not supported
+            - (1) causes: src data type = 6 is not supported
+            - (2) causes: OpenCV(3.4.5) (...)/imgwarp.cpp:1805:
+                  error: (-215:Assertion failed) ifunc != 0 in function
+                  'remap'
+            - (3) causes: src data type = 13 is not supported
+            - (4) causes: src data type = 0 is not supported
 
         """
         # pylint: disable=invalid-name
@@ -4590,30 +4604,31 @@ class Rot90(meta.Augmenter):
     This could also be achieved using ``Affine``, but ``Rot90`` is
     significantly more efficient.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (keep_size=False)::
+    if (keep_size=False):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: yes; tested
-            * ``uint64``: yes; tested
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested
-            * ``int64``: yes; tested
-            * ``float16``: yes; tested
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: yes; tested
-            * ``bool``: yes; tested
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested
+        * ``uint64``: yes; tested
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested
+        * ``int64``: yes; tested
+        * ``float16``: yes; tested
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: yes; tested
+        * ``bool``: yes; tested
 
-        if (keep_size=True)::
+    if (keep_size=True):
 
-            minimum of (
-                ``imgaug.augmenters.geometric.Rot90(keep_size=False)``,
-                :func:`~imgaug.imgaug.imresize_many_images`
-            )
+        minimum of (
+            ``imgaug.augmenters.geometric.Rot90(keep_size=False)``,
+            :func:`~imgaug.imgaug.imresize_many_images`
+        )
 
     Parameters
     ----------
@@ -4862,7 +4877,8 @@ class WithPolarWarping(meta.Augmenter):
         recovery are currently ``PerspectiveTransform``, ``PiecewiseAffine``
         and ``ElasticTransformation``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -5491,9 +5507,10 @@ class Jigsaw(meta.Augmenter):
         heatmaps, segmentation maps and keypoints. Other augmentables,
         i.e. bounding boxes, polygons and line strings, will result in errors.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`apply_jigsaw`.
+    See :func:`apply_jigsaw`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -102,7 +102,8 @@ def _call_imgcorrupt_func(fname, seed, convert_to_pil, *args, **kwargs):
     The dtype support below is basically a placeholder to which the
     augmentation functions can point to decrease the amount of documentation.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; indirectly tested (1)
         * ``uint16``: no
@@ -248,9 +249,10 @@ def get_corruption_names(subset="common"):
 def apply_gaussian_noise(x, severity=1, seed=None):
     """Apply ``gaussian_noise`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -278,9 +280,10 @@ def apply_gaussian_noise(x, severity=1, seed=None):
 def apply_shot_noise(x, severity=1, seed=None):
     """Apply ``shot_noise`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -308,9 +311,10 @@ def apply_shot_noise(x, severity=1, seed=None):
 def apply_impulse_noise(x, severity=1, seed=None):
     """Apply ``impulse_noise`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -338,9 +342,10 @@ def apply_impulse_noise(x, severity=1, seed=None):
 def apply_speckle_noise(x, severity=1, seed=None):
     """Apply ``speckle_noise`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -368,9 +373,10 @@ def apply_speckle_noise(x, severity=1, seed=None):
 def apply_gaussian_blur(x, severity=1, seed=None):
     """Apply ``gaussian_blur`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -398,9 +404,10 @@ def apply_gaussian_blur(x, severity=1, seed=None):
 def apply_glass_blur(x, severity=1, seed=None):
     """Apply ``glass_blur`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -488,9 +495,10 @@ def _apply_glass_blur_imgaug(x, severity=1):
 def apply_defocus_blur(x, severity=1, seed=None):
     """Apply ``defocus_blur`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -518,9 +526,10 @@ def apply_defocus_blur(x, severity=1, seed=None):
 def apply_motion_blur(x, severity=1, seed=None):
     """Apply ``motion_blur`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -548,9 +557,10 @@ def apply_motion_blur(x, severity=1, seed=None):
 def apply_zoom_blur(x, severity=1, seed=None):
     """Apply ``zoom_blur`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -578,9 +588,10 @@ def apply_zoom_blur(x, severity=1, seed=None):
 def apply_fog(x, severity=1, seed=None):
     """Apply ``fog`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -608,9 +619,10 @@ def apply_fog(x, severity=1, seed=None):
 def apply_frost(x, severity=1, seed=None):
     """Apply ``frost`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -638,9 +650,10 @@ def apply_frost(x, severity=1, seed=None):
 def apply_snow(x, severity=1, seed=None):
     """Apply ``snow`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -668,9 +681,10 @@ def apply_snow(x, severity=1, seed=None):
 def apply_spatter(x, severity=1, seed=None):
     """Apply ``spatter`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -698,9 +712,10 @@ def apply_spatter(x, severity=1, seed=None):
 def apply_contrast(x, severity=1, seed=None):
     """Apply ``contrast`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -728,9 +743,10 @@ def apply_contrast(x, severity=1, seed=None):
 def apply_brightness(x, severity=1, seed=None):
     """Apply ``brightness`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -758,9 +774,10 @@ def apply_brightness(x, severity=1, seed=None):
 def apply_saturate(x, severity=1, seed=None):
     """Apply ``saturate`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -788,9 +805,10 @@ def apply_saturate(x, severity=1, seed=None):
 def apply_jpeg_compression(x, severity=1, seed=None):
     """Apply ``jpeg_compression`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -818,9 +836,10 @@ def apply_jpeg_compression(x, severity=1, seed=None):
 def apply_pixelate(x, severity=1, seed=None):
     """Apply ``pixelate`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -848,9 +867,10 @@ def apply_pixelate(x, severity=1, seed=None):
 def apply_elastic_transform(image, severity=1, seed=None):
     """Apply ``elastic_transform`` from ``imagecorruptions``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
+    See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
 
     Parameters
     ----------
@@ -910,9 +930,10 @@ def apply_elastic_transform(image, severity=1, seed=None):
 #     augmenter_class.__doc__ = """
 #     Wrapper around function :func:`imagecorruption.%s`.
 #
-#     dtype support::
+#     Supported dtypes
+#     ----------------
 #
-#         See :func:`~imgaug.augmenters.imgcorruptlike.apply_%s`.
+#     See :func:`~imgaug.augmenters.imgcorruptlike.apply_%s`.
 #
 #     Parameters
 #     ----------
@@ -985,10 +1006,10 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_gaussian_noise`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_gaussian_noise`.
 
     Parameters
     ----------
@@ -1031,10 +1052,10 @@ class ShotNoise(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_shot_noise`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_shot_noise`.
 
     Parameters
     ----------
@@ -1077,10 +1098,10 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_impulse_noise`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_impulse_noise`.
 
     Parameters
     ----------
@@ -1123,10 +1144,10 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_speckle_noise`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_speckle_noise`.
 
     Parameters
     ----------
@@ -1169,10 +1190,10 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_gaussian_blur`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_gaussian_blur`.
 
     Parameters
     ----------
@@ -1215,10 +1236,10 @@ class GlassBlur(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_glass_blur`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_glass_blur`.
 
     Parameters
     ----------
@@ -1261,10 +1282,10 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_defocus_blur`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_defocus_blur`.
 
     Parameters
     ----------
@@ -1307,10 +1328,10 @@ class MotionBlur(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_motion_blur`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_motion_blur`.
 
     Parameters
     ----------
@@ -1353,10 +1374,10 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_zoom_blur`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_zoom_blur`.
 
     Parameters
     ----------
@@ -1399,10 +1420,10 @@ class Fog(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_fog`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_fog`.
 
     Parameters
     ----------
@@ -1445,10 +1466,10 @@ class Frost(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_frost`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_frost`.
 
     Parameters
     ----------
@@ -1491,10 +1512,10 @@ class Snow(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_snow`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_snow`.
 
     Parameters
     ----------
@@ -1537,10 +1558,10 @@ class Spatter(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_spatter`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_spatter`.
 
     Parameters
     ----------
@@ -1583,10 +1604,10 @@ class Contrast(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_contrast`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_contrast`.
 
     Parameters
     ----------
@@ -1629,10 +1650,10 @@ class Brightness(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_brightness`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_brightness`.
 
     Parameters
     ----------
@@ -1675,10 +1696,10 @@ class Saturate(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_saturate`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_saturate`.
 
     Parameters
     ----------
@@ -1721,10 +1742,10 @@ class JpegCompression(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_jpeg_compression`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_jpeg_compression`.
 
     Parameters
     ----------
@@ -1767,10 +1788,10 @@ class Pixelate(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_pixelate`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_pixelate`.
 
     Parameters
     ----------
@@ -1813,10 +1834,10 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
 
         This augmenter only affects images. Other data is not changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See
-        :func:`~imgaug.augmenters.imgcorruptlike.apply_elastic_transform`.
+    See :func:`~imgaug.augmenters.imgcorruptlike.apply_elastic_transform`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -2991,7 +2991,8 @@ class Sequential(Augmenter, list):
         >>> aug = iaa.Fliplr(0.5)
         >>> image_aug = aug.augment_image(image)
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3150,7 +3151,8 @@ class SomeOf(Augmenter, list):
     child multiple times) due to implementation difficulties in connection
     with deterministic augmenters.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3406,9 +3408,10 @@ class SomeOf(Augmenter, list):
 class OneOf(SomeOf):
     """Augmenter that always executes exactly one of its children.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.meta.SomeOf``.
+    See :class:`imgaug.augmenters.meta.SomeOf`.
 
     Parameters
     ----------
@@ -3472,7 +3475,8 @@ class Sometimes(Augmenter):
     Let ``N`` be the number of input images (or other entities).
     Then (on average) ``p*N`` images of ``I`` will be augmented using ``C``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3620,7 +3624,8 @@ class WithChannels(Augmenter):
     The result of the augmentation will be merged back into the original
     images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3843,7 +3848,8 @@ class Identity(Augmenter):
     This augmenter is useful e.g. during validation/testing as it allows
     to re-use the training code without actually performing any augmentation.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3889,9 +3895,10 @@ class Noop(Identity):
     It is recommended to now use :class:`Identity`. :class:`Noop` might be
     deprecated in the future.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.meta.Identity`.
+    See :class:`~imgaug.augmenters.meta.Identity`.
 
     Parameters
     ----------
@@ -3915,7 +3922,8 @@ class Lambda(Augmenter):
 
     This is useful to add missing functions to a list of augmenters.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -4233,7 +4241,8 @@ class AssertLambda(Lambda):
     This is useful to ensure that generic assumption about the input data
     are actually the case and error out early otherwise.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -4374,7 +4383,8 @@ class _AssertLambdaCallback(object):
 class AssertShape(Lambda):
     """Assert that inputs have a specified shape.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -4639,7 +4649,8 @@ class _AssertShapeLineStringsCheck(object):
 class ChannelShuffle(Augmenter):
     """Randomize the order of channels in input images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -4736,7 +4747,8 @@ class ChannelShuffle(Augmenter):
 def shuffle_channels(image, random_state, channels=None):
     """Randomize the order of (color) channels in an image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; indirectly tested (1)
@@ -4752,7 +4764,7 @@ def shuffle_channels(image, random_state, channels=None):
         * ``float128``: yes; indirectly tested (1)
         * ``bool``: yes; indirectly tested (1)
 
-        - (1) Indirectly tested via ``ChannelShuffle``.
+        - (1) Indirectly tested via :class:`ChannelShuffle`.
 
     Parameters
     ----------
@@ -4809,7 +4821,8 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
     augmentable's area that is outside of the image, e.g. for a bounding box
     that has half of its area outside of the image it would be ``0.5``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; fully tested
@@ -4910,7 +4923,8 @@ class ClipCBAsToImagePlanes(Augmenter):
     it removes any single points outside of the image plane. Any augmentable
     that is completely outside of the image plane will be removed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; fully tested

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -89,9 +89,10 @@ def solarize_(image, threshold=128):
     This function has identical outputs to :func:`PIL.ImageOps.solarize`.
     It does however work in-place.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)`.
+    See ``~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)``.
 
     Parameters
     ----------
@@ -118,9 +119,10 @@ def solarize(image, threshold=128):
 
     This function has identical outputs to :func:`PIL.ImageOps.solarize`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)`.
+    See ``~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)``.
 
     Parameters
     ----------
@@ -146,9 +148,10 @@ def posterize_(image, bits):
     This function has identical outputs to :func:`PIL.ImageOps.posterize`.
     It does however work in-place.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits_.
+    See ``~imgaug.augmenters.color.quantize_uniform_to_n_bits_``.
 
     Parameters
     ----------
@@ -174,9 +177,10 @@ def posterize(image, bits):
 
     This function has identical outputs to :func:`PIL.ImageOps.posterize`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits`.
+    See ``~imgaug.augmenters.color.quantize_uniform_to_n_bits``.
 
     Parameters
     ----------
@@ -204,9 +208,10 @@ def equalize(image, mask=None):
     This function is identical in inputs and outputs to
     :func:`PIL.ImageOps.equalize`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pil.pil_equalize_`.
+    See :func:`~imgaug.augmenters.pil.pil_equalize_`.
 
     Parameters
     ----------
@@ -241,7 +246,8 @@ def equalize_(image, mask=None):
     This function has identical outputs to :func:`PIL.ImageOps.equalize`.
     It does however work in-place.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -352,7 +358,8 @@ def autocontrast(image, cutoff=0, ignore=None):
     This function has identical outputs to :func:`PIL.ImageOps.autocontrast`.
     The speed is almost identical.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -534,7 +541,8 @@ def enhance_color(image, factor):
     This function has identical outputs to
     :class:`PIL.ImageEnhance.Color`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -575,7 +583,8 @@ def enhance_contrast(image, factor):
     This function has identical outputs to
     :class:`PIL.ImageEnhance.Contrast`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -617,7 +626,8 @@ def enhance_brightness(image, factor):
     This function has identical outputs to
     :class:`PIL.ImageEnhance.Brightness`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -658,7 +668,8 @@ def enhance_sharpness(image, factor):
     This function has identical outputs to
     :class:`PIL.ImageEnhance.Sharpness`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -718,7 +729,8 @@ def _filter_by_kernel(image, kernel):
 def filter_blur(image):
     """Apply a blur filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -751,7 +763,8 @@ def filter_blur(image):
 def filter_smooth(image):
     """Apply a smoothness filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -784,7 +797,8 @@ def filter_smooth(image):
 def filter_smooth_more(image):
     """Apply a strong smoothness filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -817,7 +831,8 @@ def filter_smooth_more(image):
 def filter_edge_enhance(image):
     """Apply an edge enhancement filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -850,7 +865,8 @@ def filter_edge_enhance(image):
 def filter_edge_enhance_more(image):
     """Apply a stronger edge enhancement filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -883,7 +899,8 @@ def filter_edge_enhance_more(image):
 def filter_find_edges(image):
     """Apply an edge detection filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -916,7 +933,8 @@ def filter_find_edges(image):
 def filter_contour(image):
     """Apply a contour filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -949,7 +967,8 @@ def filter_contour(image):
 def filter_emboss(image):
     """Apply an emboss filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -982,7 +1001,8 @@ def filter_emboss(image):
 def filter_sharpen(image):
     """Apply a sharpening filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -1015,7 +1035,8 @@ def filter_sharpen(image):
 def filter_detail(image):
     """Apply a detail enhancement filter kernel to the image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no
@@ -1224,9 +1245,10 @@ class Solarize(arithmetic.Invert):
 
     The outputs are identical to PIL's ``solarize()``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.arithmetic.Invert`.
+    See :func:`~imgaug.augmenters.arithmetic.Invert`.
 
     Parameters
     ----------
@@ -1276,9 +1298,10 @@ class Posterize(colorlib.Posterize):
     i.e. all three classes are right now guarantueed to have the same
     outputs as PIL's function.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.color.Posterize`.
+    See :class:`~imgaug.augmenters.color.Posterize`.
 
     """
 
@@ -1288,9 +1311,10 @@ class Equalize(meta.Augmenter):
 
     This augmenter has identical outputs to :func:`PIL.ImageOps.equalize`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.equalize_`.
+    See :func:`~imgaug.augmenters.pillike.equalize_`.
 
     Parameters
     ----------
@@ -1335,9 +1359,10 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
 
     See :func:`~imgaug.augmenters.pillike.autocontrast` for more details.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.autocontrast`.
+    See :func:`~imgaug.augmenters.pillike.autocontrast`.
 
     Parameters
     ----------
@@ -1438,9 +1463,10 @@ class EnhanceColor(_EnhanceBase):
 
     This augmenter has identical outputs to :class:`PIL.ImageEnhance.Color`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.enhance_color`.
+    See :func:`~imgaug.augmenters.pillike.enhance_color`.
 
     Parameters
     ----------
@@ -1490,9 +1516,10 @@ class EnhanceContrast(_EnhanceBase):
 
     This augmenter has identical outputs to :class:`PIL.ImageEnhance.Contrast`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.enhance_contrast`.
+    See :func:`~imgaug.augmenters.pillike.enhance_contrast`.
 
     Parameters
     ----------
@@ -1544,9 +1571,10 @@ class EnhanceBrightness(_EnhanceBase):
     This augmenter has identical outputs to
     :class:`PIL.ImageEnhance.Brightness`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.enhance_brightness`.
+    See :func:`~imgaug.augmenters.pillike.enhance_brightness`.
 
     Parameters
     ----------
@@ -1597,9 +1625,10 @@ class EnhanceSharpness(_EnhanceBase):
     This augmenter has identical outputs to
     :class:`PIL.ImageEnhance.Sharpness`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.enhance_sharpness`.
+    See :func:`~imgaug.augmenters.pillike.enhance_sharpness`.
 
     Parameters
     ----------
@@ -1671,9 +1700,10 @@ class FilterBlur(_FilterBase):
     This augmenter has identical outputs to
     calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.BLUR``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_blur`.
+    See :func:`~imgaug.augmenters.pillike.filter_blur`.
 
     Parameters
     ----------
@@ -1707,9 +1737,10 @@ class FilterSmooth(_FilterBase):
     This augmenter has identical outputs to
     calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.SMOOTH``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_smooth`.
+    See :func:`~imgaug.augmenters.pillike.filter_smooth`.
 
     Parameters
     ----------
@@ -1743,9 +1774,10 @@ class FilterSmoothMore(_FilterBase):
     This augmenter has identical outputs to
     calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.BLUR``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_smooth_more`.
+    See :func:`~imgaug.augmenters.pillike.filter_smooth_more`.
 
     Parameters
     ----------
@@ -1781,9 +1813,10 @@ class FilterEdgeEnhance(_FilterBase):
     calling :func:`PIL.Image.filter` with kernel
     ``PIL.ImageFilter.EDGE_ENHANCE``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_edge_enhance`.
+    See :func:`~imgaug.augmenters.pillike.filter_edge_enhance`.
 
     Parameters
     ----------
@@ -1819,9 +1852,10 @@ class FilterEdgeEnhanceMore(_FilterBase):
     calling :func:`PIL.Image.filter` with kernel
     ``PIL.ImageFilter.EDGE_ENHANCE_MORE``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_edge_enhance_more`.
+    See :func:`~imgaug.augmenters.pillike.filter_edge_enhance_more`.
 
     Parameters
     ----------
@@ -1857,9 +1891,10 @@ class FilterFindEdges(_FilterBase):
     calling :func:`PIL.Image.filter` with kernel
     ``PIL.ImageFilter.FIND_EDGES``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_find_edges`.
+    See :func:`~imgaug.augmenters.pillike.filter_find_edges`.
 
     Parameters
     ----------
@@ -1893,9 +1928,10 @@ class FilterContour(_FilterBase):
     This augmenter has identical outputs to
     calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.CONTOUR``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_contour`.
+    See :func:`~imgaug.augmenters.pillike.filter_contour`.
 
     Parameters
     ----------
@@ -1930,9 +1966,10 @@ class FilterEmboss(_FilterBase):
     This augmenter has identical outputs to
     calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.EMBOSS``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_emboss`.
+    See :func:`~imgaug.augmenters.pillike.filter_emboss`.
 
     Parameters
     ----------
@@ -1966,9 +2003,10 @@ class FilterSharpen(_FilterBase):
     This augmenter has identical outputs to
     calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.SHARPEN``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_sharpen`.
+    See :func:`~imgaug.augmenters.pillike.filter_sharpen`.
 
     Parameters
     ----------
@@ -2002,9 +2040,10 @@ class FilterDetail(_FilterBase):
     This augmenter has identical outputs to
     calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.DETAIL``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.filter_detail`.
+    See :func:`~imgaug.augmenters.pillike.filter_detail`.
 
     Parameters
     ----------
@@ -2055,9 +2094,10 @@ class Affine(geometric.Affine):
         top left corner as the transformation center. To mirror that
         behaviour, use ``center=(0.0, 0.0)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.augmenters.pillike.warp_affine`.
+    See :func:`~imgaug.augmenters.pillike.warp_affine`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -207,9 +207,10 @@ class AveragePooling(_AbstractPoolingBase):
         are updated. This is because imgaug can handle maps/maks that are
         larger/smaller than their corresponding image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.avg_pool`.
+    See :func:`~imgaug.imgaug.avg_pool`.
 
     Attributes
     ----------
@@ -318,9 +319,10 @@ class MaxPooling(_AbstractPoolingBase):
         are updated. This is because imgaug can handle maps/maks that are
         larger/smaller than their corresponding image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.max_pool`.
+    See :func:`~imgaug.imgaug.max_pool`.
 
     Attributes
     ----------
@@ -431,9 +433,10 @@ class MinPooling(_AbstractPoolingBase):
         are updated. This is because imgaug can handle maps/maks that are
         larger/smaller than their corresponding image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.pool`.
+    See :func:`~imgaug.imgaug.pool`.
 
     Attributes
     ----------
@@ -544,9 +547,10 @@ class MedianPooling(_AbstractPoolingBase):
         are updated. This is because imgaug can handle maps/maks that are
         larger/smaller than their corresponding image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.pool`.
+    See :func:`~imgaug.imgaug.pool`.
 
     Attributes
     ----------

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -37,9 +37,10 @@ def _ensure_image_max_size(image, max_size, interpolation):
     This downscales to `max_size` if any side violates that maximum.
     The other side is downscaled too so that the aspect ratio is maintained.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.imresize_single_image`.
+    See :func:`~imgaug.imgaug.imresize_single_image`.
 
     Parameters
     ----------
@@ -76,36 +77,37 @@ class Superpixels(meta.Augmenter):
 
         This augmenter is fairly slow. See :ref:`performance`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (image size <= max_size)::
+    if (image size <= max_size):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: yes; tested
-            * ``uint64``: limited (1)
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested
-            * ``int64``: limited (1)
-            * ``float16``: no (2)
-            * ``float32``: no (2)
-            * ``float64``: no (3)
-            * ``float128``: no (2)
-            * ``bool``: yes; tested
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested
+        * ``uint64``: limited (1)
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested
+        * ``int64``: limited (1)
+        * ``float16``: no (2)
+        * ``float32``: no (2)
+        * ``float64``: no (3)
+        * ``float128``: no (2)
+        * ``bool``: yes; tested
 
-            - (1) Superpixel mean intensity replacement requires computing
-                  these means as float64s. This can cause inaccuracies for
-                  large integer values.
-            - (2) Error in scikit-image.
-            - (3) Loss of resolution in scikit-image.
+        - (1) Superpixel mean intensity replacement requires computing
+              these means as ``float64`` s. This can cause inaccuracies for
+              large integer values.
+        - (2) Error in scikit-image.
+        - (3) Loss of resolution in scikit-image.
 
-        if (image size > max_size)::
+    if (image size > max_size):
 
-            minimum of (
-                ``imgaug.augmenters.segmentation.Superpixels(image size <= max_size)``,
-                :func:`~imgaug.augmenters.segmentation._ensure_image_max_size`
-            )
+        minimum of (
+            ``imgaug.augmenters.segmentation.Superpixels(image size <= max_size)``,
+            :func:`~imgaug.augmenters.segmentation._ensure_image_max_size`
+        )
 
     Parameters
     ----------
@@ -454,30 +456,31 @@ class Voronoi(meta.Augmenter):
     This code is very loosely based on
     https://codegolf.stackexchange.com/questions/50299/draw-an-image-as-a-voronoi-map/50345#50345
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (image size <= max_size)::
+    if (image size <= max_size):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: no; not tested
-            * ``uint32``: no; not tested
-            * ``uint64``: no; not tested
-            * ``int8``: no; not tested
-            * ``int16``: no; not tested
-            * ``int32``: no; not tested
-            * ``int64``: no; not tested
-            * ``float16``: no; not tested
-            * ``float32``: no; not tested
-            * ``float64``: no; not tested
-            * ``float128``: no; not tested
-            * ``bool``: no; not tested
+        * ``uint8``: yes; fully tested
+        * ``uint16``: no; not tested
+        * ``uint32``: no; not tested
+        * ``uint64``: no; not tested
+        * ``int8``: no; not tested
+        * ``int16``: no; not tested
+        * ``int32``: no; not tested
+        * ``int64``: no; not tested
+        * ``float16``: no; not tested
+        * ``float32``: no; not tested
+        * ``float64``: no; not tested
+        * ``float128``: no; not tested
+        * ``bool``: no; not tested
 
-        if (image size > max_size)::
+    if (image size > max_size):
 
-            minimum of (
-                ``imgaug.augmenters.segmentation.Voronoi(image size <= max_size)``,
-                :func:`~imgaug.augmenters.segmentation._ensure_image_max_size`
-            )
+        minimum of (
+            ``imgaug.augmenters.segmentation.Voronoi(image size <= max_size)``,
+            :func:`~imgaug.augmenters.segmentation._ensure_image_max_size`
+        )
 
     Parameters
     ----------
@@ -647,9 +650,10 @@ class UniformVoronoi(Voronoi):
     each image. The cell coordinates are sampled uniformly using the image
     height and width as maxima.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.segmentation.Voronoi``.
+    See :class:`~imgaug.augmenters.segmentation.Voronoi`.
 
     Parameters
     ----------
@@ -762,9 +766,10 @@ class RegularGridVoronoi(Voronoi):
     to randomize the grid. Each image pixel then belongs to the voronoi
     cell with the closest coordinate.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.segmentation.Voronoi``.
+    See :class:`~imgaug.augmenters.segmentation.Voronoi`.
 
     Parameters
     ----------
@@ -926,9 +931,10 @@ class RelativeRegularGridVoronoi(Voronoi):
         make most use of the added points for larger images. It does however
         slow down the augmentation process.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.segmentation.Voronoi``.
+    See :class:`~imgaug.augmenters.segmentation.Voronoi`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -356,7 +356,8 @@ def pad(arr, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
 
     This function is a wrapper around :func:`numpy.pad`.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested (1)
         * ``uint16``: yes; fully tested (1)
@@ -558,9 +559,10 @@ def pad_to_aspect_ratio(arr, aspect_ratio, mode="constant", cval=0,
     explanation of how the required padding amounts are distributed per
     image axis.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.pad`.
+    See :func:`~imgaug.augmenters.size.pad`.
 
     Parameters
     ----------
@@ -624,9 +626,10 @@ def pad_to_multiples_of(arr, height_multiple, width_multiple, mode="constant",
     explanation of how the required padding amounts are distributed per
     image axis.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.pad`.
+    See :func:`~imgaug.augmenters.size.pad`.
 
     Parameters
     ----------
@@ -1104,9 +1107,10 @@ def Scale(*args, **kwargs):
 class Resize(meta.Augmenter):
     """Augmenter that resizes images to specified heights and widths.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.imresize_many_images`.
+    See :func:`~imgaug.imgaug.imresize_many_images`.
 
     Parameters
     ----------
@@ -1536,30 +1540,31 @@ class CropAndPad(meta.Augmenter):
         after it has augmented them. To deactivate this, add the
         parameter ``keep_size=False``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        if (keep_size=False)::
+    if (keep_size=False):
 
-            * ``uint8``: yes; fully tested
-            * ``uint16``: yes; tested
-            * ``uint32``: yes; tested
-            * ``uint64``: yes; tested
-            * ``int8``: yes; tested
-            * ``int16``: yes; tested
-            * ``int32``: yes; tested
-            * ``int64``: yes; tested
-            * ``float16``: yes; tested
-            * ``float32``: yes; tested
-            * ``float64``: yes; tested
-            * ``float128``: yes; tested
-            * ``bool``: yes; tested
+        * ``uint8``: yes; fully tested
+        * ``uint16``: yes; tested
+        * ``uint32``: yes; tested
+        * ``uint64``: yes; tested
+        * ``int8``: yes; tested
+        * ``int16``: yes; tested
+        * ``int32``: yes; tested
+        * ``int64``: yes; tested
+        * ``float16``: yes; tested
+        * ``float32``: yes; tested
+        * ``float64``: yes; tested
+        * ``float128``: yes; tested
+        * ``bool``: yes; tested
 
-        if (keep_size=True)::
+    if (keep_size=True):
 
-            minimum of (
-                ``imgaug.augmenters.size.CropAndPad(keep_size=False)``,
-                :func:`~imgaug.imgaug.imresize_many_images`
-            )
+        minimum of (
+            ``imgaug.augmenters.size.CropAndPad(keep_size=False)``,
+            :func:`~imgaug.imgaug.imresize_many_images`
+        )
 
     Parameters
     ----------
@@ -2124,9 +2129,10 @@ class CropAndPad(meta.Augmenter):
 class Pad(CropAndPad):
     """Pad images, i.e. adds columns/rows of pixels to them.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.size.CropAndPad``.
+    See :class:`~imgaug.augmenters.size.CropAndPad`.
 
     Parameters
     ----------
@@ -2350,9 +2356,10 @@ class Crop(CropAndPad):
 
     This augmenter will never crop images below a height or width of ``1``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See ``imgaug.augmenters.size.CropAndPad``.
+    See :class:`~imgaug.augmenters.size.CropAndPad`.
 
     Parameters
     ----------
@@ -2531,9 +2538,10 @@ class PadToFixedSize(meta.Augmenter):
     and 0px to the left and sometimes add 1px to both sides. Set `position`
     to ``center`` to prevent that.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.pad`.
+    See :func:`~imgaug.augmenters.size.pad`.
 
     Parameters
     ----------
@@ -2824,9 +2832,10 @@ class CenterPadToFixedSize(PadToFixedSize):
     all image sides, while :class:`~imgaug.augmenters.size.PadToFixedSize`
     by defaults spreads them randomly.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -2888,7 +2897,8 @@ class CropToFixedSize(meta.Augmenter):
     remove 2px from the right and 0px from the left and sometimes remove 1px
     from both sides. Set `position` to ``center`` to prevent that.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: yes; tested
@@ -3142,9 +3152,10 @@ class CenterCropToFixedSize(CropToFixedSize):
         respective axis. Hence, resulting images can be smaller than the
         provided axis sizes.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3190,9 +3201,10 @@ class CropToMultiplesOf(CropToFixedSize):
         As a result, this augmenter can still produce axis sizes that are
         not multiples of the given values.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3278,9 +3290,10 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
     :class:`~imgaug.augmenters.size.CropToMultiplesOf` by default spreads
     them randomly.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3324,9 +3337,10 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
 class PadToMultiplesOf(PadToFixedSize):
     """Pad images until their height/width is a multiple of a value.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3423,9 +3437,10 @@ class CenterPadToMultiplesOf(PadToMultiplesOf):
     :class:`~imgaug.augmenters.size.PadToMultiplesOf` by default spreads them
     randomly.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3490,9 +3505,10 @@ class CropToPowersOf(CropToFixedSize):
         to combine this augmenter with a padding augmenter that pads each
         axis up to ``B``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3580,9 +3596,10 @@ class CenterCropToPowersOf(CropToPowersOf):
     :class:`~imgaug.augmenters.size.CropToPowersOf` by default spreads them
     randomly.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3629,9 +3646,10 @@ class PadToPowersOf(PadToFixedSize):
     provided base (e.g. ``2``) and ``E`` is an exponent from the discrete
     interval ``[1 .. inf)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3729,9 +3747,10 @@ class CenterPadToPowersOf(PadToPowersOf):
     over all image sides, while :class:`~imgaug.augmenters.size.PadToPowersOf`
     by default spreads them randomly.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -3788,9 +3807,10 @@ class CropToAspectRatio(CropToFixedSize):
     side to crop reaches a size of ``1``. If any side of the image starts
     with a size of ``0``, the image will not be changed.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3872,9 +3892,10 @@ class CenterCropToAspectRatio(CropToAspectRatio):
     :class:`~imgaug.augmenters.size.CropToAspectRatio` by default spreads
     them randomly.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -3916,9 +3937,10 @@ class PadToAspectRatio(PadToFixedSize):
     This augmenter adds either rows or columns until the image reaches
     the desired aspect ratio given in ``width / height``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -4006,9 +4028,10 @@ class CenterPadToAspectRatio(PadToAspectRatio):
     :class:`~imgaug.augmenters.size.PadToAspectRatio` by default spreads them
     randomly.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -4059,9 +4082,10 @@ class CropToSquare(CropToAspectRatio):
 
     Images with axis sizes of ``0`` will not be altered.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -4112,9 +4136,10 @@ class CenterCropToSquare(CropToSquare):
 
     Images with axis sizes of ``0`` will not be altered.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.CropToFixedSize`.
+    See :class:`~imgaug.augmenters.size.CropToFixedSize`.
 
     Parameters
     ----------
@@ -4151,9 +4176,10 @@ class PadToSquare(PadToAspectRatio):
     This augmenter is identical to
     :class:`~imgaug.augmenters.size.PadToAspectRatio` with ``aspect_ratio=1.0``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -4205,9 +4231,10 @@ class CenterPadToSquare(PadToSquare):
     :class:`~imgaug.augmenters.size.PadToAspectRatio` with
     ``aspect_ratio=1.0, position="center"``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :class:`~imgaug.augmenters.size.PadToFixedSize`.
+    See :class:`~imgaug.augmenters.size.PadToFixedSize`.
 
     Parameters
     ----------
@@ -4255,9 +4282,10 @@ class KeepSizeByResize(meta.Augmenter):
     the interpolation mode and which augmentables to resize (images, heatmaps,
     segmentation maps).
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
-        See :func:`~imgaug.imgaug.imresize_many_images`.
+    See :func:`~imgaug.imgaug.imresize_many_images`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -31,7 +31,8 @@ class FastSnowyLandscape(meta.Augmenter):
     This augmenter is based on the method proposed in
     https://medium.freecodecamp.org/image-augmentation-make-it-rain-make-it-snow-how-to-modify-a-photo-with-machine-learning-163c0cb3843f?gi=bca4a13e634c
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; fully tested
         * ``uint16``: no (1)
@@ -186,7 +187,8 @@ class FastSnowyLandscape(meta.Augmenter):
 class CloudLayer(meta.Augmenter):
     """Add a single layer of clouds to an image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; indirectly tested (1)
         * ``uint16``: no
@@ -202,7 +204,7 @@ class CloudLayer(meta.Augmenter):
         * ``float128``: yes; not tested (2)
         * ``bool``: no
 
-        - (1) Indirectly tested via tests for ``Clouds`` and ``Fog``
+        - (1) Indirectly tested via tests for :class:`Clouds`` and :class:`Fog`
         - (2) Note that random values are usually sampled as ``int64`` or
               ``float64``, which ``float128`` images would exceed. Note also
               that random values might have to upscaled, which is done
@@ -486,7 +488,8 @@ class Clouds(meta.SomeOf):
     This augmenter seems to be fairly robust w.r.t. the image size. Tested
     with ``96x128``, ``192x256`` and ``960x1280``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; tested
         * ``uint16``: no (1)
@@ -576,7 +579,8 @@ class Fog(CloudLayer):
     This augmenter seems to be fairly robust w.r.t. the image size. Tested
     with ``96x128``, ``192x256`` and ``960x1280``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; tested
         * ``uint16``: no (1)
@@ -637,7 +641,8 @@ class Fog(CloudLayer):
 class SnowflakesLayer(meta.Augmenter):
     """Add a single layer of falling snowflakes to images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; indirectly tested (1)
         * ``uint16``: no
@@ -653,7 +658,7 @@ class SnowflakesLayer(meta.Augmenter):
         * ``float128``: no
         * ``bool``: no
 
-        - (1) indirectly tested via tests for ``Snowflakes``
+        - (1) indirectly tested via tests for :class:`Snowflakes`
 
     Parameters
     ----------
@@ -977,7 +982,8 @@ class Snowflakes(meta.SomeOf):
     :class:`~imgaug.augmenters.weather.SnowflakesLayer`. It executes 1 to 3
     layers per image.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; tested
         * ``uint16``: no (1)
@@ -1155,7 +1161,8 @@ class Snowflakes(meta.SomeOf):
 class RainLayer(SnowflakesLayer):
     """Add a single layer of falling raindrops to images.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; indirectly tested (1)
         * ``uint16``: no
@@ -1171,7 +1178,7 @@ class RainLayer(SnowflakesLayer):
         * ``float128``: no
         * ``bool``: no
 
-        - (1) indirectly tested via tests for ``Rain``
+        - (1) indirectly tested via tests for :class:`Rain`
 
     Parameters
     ----------
@@ -1268,7 +1275,8 @@ class Rain(meta.SomeOf):
         look like snowflakes. For larger images, you may want to increase
         the `drop_size` to e.g. ``(0.10, 0.20)``.
 
-    dtype support::
+    Supported dtypes
+    ----------------
 
         * ``uint8``: yes; tested
         * ``uint16``: no (1)


### PR DESCRIPTION
This patch improves the formatting of the 'dtype support'
blocks in docstrings. Changes:
- Change dtype support blocks to sections, similar to
  "Parameters" and "Returns". Links to classes/functions
  should therefore now be clickable in RTD.
- Change inset level of dtype support blocks.
- Add :class: and :func: where possible.
- Fix a few formatting problems.