### PR TITLE
Fix docstring problems

### DIFF
--- a/imgaug/augmenters/artistic.py
+++ b/imgaug/augmenters/artistic.py
@@ -233,6 +233,11 @@ class Cartoon(meta.Augmenter):
     edges or also too many detected edges are probably the most significant
     drawbacks.
 
+    Supported dtypes
+    ----------------
+
+    See :func:`~imgaug.augmenters.artistic.stylize_cartoon`.
+
     Parameters
     ----------
     blur_ksize : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional

--- a/imgaug/augmenters/collections.py
+++ b/imgaug/augmenters/collections.py
@@ -65,6 +65,31 @@ class RandAugment(meta.Sequential):
         transformations to ensure that outputs are as similar as possible
         to the paper's implementation.)
 
+    Supported dtypes
+    ----------------
+
+    minimum of (
+        :class:`~imgaug.augmenters.flip.Fliplr`,
+        :class:`~imgaug.augmenters.size.KeepSizeByResize`,
+        :class:`~imgaug.augmenters.size.Crop`,
+        :class:`~imgaug.augmenters.meta.Sequential`,
+        :class:`~imgaug.augmenters.meta.SomeOf`,
+        :class:`~imgaug.augmenters.meta.Identity`,
+        :class:`~imgaug.augmenters.pillike.Autocontrast`,
+        :class:`~imgaug.augmenters.pillike.Equalize`,
+        :class:`~imgaug.augmenters.arithmetic.Invert`,
+        :class:`~imgaug.augmenters.pillike.Affine`,
+        :class:`~imgaug.augmenters.pillike.Posterize`,
+        :class:`~imgaug.augmenters.pillike.Solarize`,
+        :class:`~imgaug.augmenters.pillike.EnhanceColor`,
+        :class:`~imgaug.augmenters.pillike.EnhanceContrast`,
+        :class:`~imgaug.augmenters.pillike.EnhanceBrightness`,
+        :class:`~imgaug.augmenters.pillike.EnhanceSharpness`,
+        :class:`~imgaug.augmenters.arithmetic.Cutout`,
+        :class:`~imgaug.augmenters.pillike.FilterBlur`,
+        :class:`~imgaug.augmenters.pillike.FilterSmooth`
+    )
+
     Parameters
     ----------
     n : int or tuple of int or list of int or imgaug.parameters.StochasticParameter or None, optional

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -848,7 +848,12 @@ class _KelvinToRGBTable(object):
 
 
 def change_color_temperatures_(images, kelvins, from_colorspaces=CSPACE_RGB):
-    """Change the temperature of images to given values in Kelvin.
+    """Change in-place the temperature of images to given values in Kelvin.
+
+    Supported dtypes
+    ----------------
+
+    See :class:`~imgaug.augmenters.color.change_colorspace_`.
 
     Parameters
     ----------
@@ -861,15 +866,15 @@ def change_color_temperatures_(images, kelvins, from_colorspaces=CSPACE_RGB):
         the interval ``(1000, 4000)``.
 
     from_colorspaces : str or list of str, optional
-        The source colorspace. Analogous to `to_colorspace`. Defaults
-        to ``RGB``.
+        The source colorspace.
+        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
+        Defaults to ``RGB``.
 
     Returns
     -------
     ndarray or list of ndarray
-        Images with target colorspaces. *Can* contain the same array instances
-        as were originally provided (i.e. changed inplace). Grayscale images
-        will still have three channels.
+        Images with target color temperatures.
+        The input array(s) might have been changed in-place.
 
     """
     # we return here early, because we validate below the first kelvin value
@@ -939,7 +944,34 @@ def change_color_temperatures_(images, kelvins, from_colorspaces=CSPACE_RGB):
 
 
 def change_color_temperature(image, kelvin, from_colorspace=CSPACE_RGB):
-    # TODO is image[...] a view?
+    """Change the temperature of an image to a given value in Kelvin.
+
+    Supported dtypes
+    ----------------
+
+    See :class:`~imgaug.augmenters.color.change_color_temperatures_`.
+
+    Parameters
+    ----------
+    image : ndarray
+        The image which's color temperature is supposed to be changed.
+        Expected to be of shape ``(H,W,3)`` array.
+
+    kelvin : number
+        The temperature in Kelvin. Expected value range is in
+        the interval ``(1000, 4000)``.
+
+    from_colorspace : str, optional
+        The source colorspace.
+        See :func:`~imgaug.augmenters.color.change_colorspaces_`.
+        Defaults to ``RGB``.
+
+    Returns
+    -------
+    ndarray
+        Image with target color temperature.
+
+    """
     return change_color_temperatures_(image[np.newaxis, ...],
                                       [kelvin],
                                       from_colorspaces=[from_colorspace])[0]
@@ -1972,6 +2004,11 @@ class RemoveSaturation(MultiplySaturation):
 
     This augmenter is the same as ``MultiplySaturation((0.0, 1.0))``.
 
+    Supported dtypes
+    ----------------
+
+    See :class:`~imgaug.augmenters.color.MultiplySaturation`.
+
     Parameters
     ----------
     mul : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
@@ -2815,6 +2852,11 @@ class ChangeColorTemperature(meta.Augmenter):
 
     Basic method to change color temperatures taken from
     https://stackoverflow.com/a/11888449
+
+    Supported dtypes
+    ----------------
+
+    See :func:`~imgaug.augmenters.color.change_color_temperatures_`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -310,6 +310,23 @@ def draw_debug_image(images, heatmaps=None, segmentation_maps=None,
                      line_strings=None):
     """Generate a debug image grid of a single batch and various datatypes.
 
+    Supported dtypes
+    ----------------
+
+        * ``uint8``: yes; tested
+        * ``uint16``: ?
+        * ``uint32``: ?
+        * ``uint64``: ?
+        * ``int8``: ?
+        * ``int16``: ?
+        * ``int32``: ?
+        * ``int64``: ?
+        * ``float16``: ?
+        * ``float32``: ?
+        * ``float64``: ?
+        * ``float128``: ?
+        * ``bool``: ?
+
     Parameters
     ----------
     images : ndarray or list of ndarray
@@ -1030,6 +1047,11 @@ class _SaveDebugImage(meta.Augmenter):
 
 class SaveDebugImageEveryNBatches(_SaveDebugImage):
     """Visualize data in batches and save corresponding plots to a folder.
+
+    Supported dtypes
+    ----------------
+
+    See :func:`~imgaug.augmenters.debug.draw_debug_image`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -5511,7 +5511,7 @@ class Jigsaw(meta.Augmenter):
     Supported dtypes
     ----------------
 
-    See :func:`apply_jigsaw`.
+    See :func:`~imgaug.augmenters.geometric.apply_jigsaw`.
 
     Parameters
     ----------

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -86,7 +86,7 @@ def _ensure_valid_shape(image, func_name):
 def solarize_(image, threshold=128):
     """Invert all array components above a threshold in-place.
 
-    This function has identical outputs to :func:`PIL.ImageOps.solarize`.
+    This function has identical outputs to :func:`~PIL.ImageOps.solarize`.
     It does however work in-place.
 
     Supported dtypes
@@ -117,7 +117,7 @@ def solarize_(image, threshold=128):
 def solarize(image, threshold=128):
     """Invert all array components above a threshold.
 
-    This function has identical outputs to :func:`PIL.ImageOps.solarize`.
+    This function has identical outputs to :func:`~PIL.ImageOps.solarize`.
 
     Supported dtypes
     ----------------
@@ -145,13 +145,13 @@ def solarize(image, threshold=128):
 def posterize_(image, bits):
     """Reduce the number of bits for each color channel in-place.
 
-    This function has identical outputs to :func:`PIL.ImageOps.posterize`.
+    This function has identical outputs to :func:`~PIL.ImageOps.posterize`.
     It does however work in-place.
 
     Supported dtypes
     ----------------
 
-    See ``~imgaug.augmenters.color.quantize_uniform_to_n_bits_``.
+    See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits_`.
 
     Parameters
     ----------
@@ -175,12 +175,12 @@ def posterize_(image, bits):
 def posterize(image, bits):
     """Reduce the number of bits for each color channel.
 
-    This function has identical outputs to :func:`PIL.ImageOps.posterize`.
+    This function has identical outputs to :func:`~PIL.ImageOps.posterize`.
 
     Supported dtypes
     ----------------
 
-    See ``~imgaug.augmenters.color.quantize_uniform_to_n_bits``.
+    See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits`.
 
     Parameters
     ----------
@@ -206,12 +206,12 @@ def equalize(image, mask=None):
     See :func:`~imgaug.augmenters.pillike.equalize_` for details.
 
     This function is identical in inputs and outputs to
-    :func:`PIL.ImageOps.equalize`.
+    :func:`~PIL.ImageOps.equalize`.
 
     Supported dtypes
     ----------------
 
-    See :func:`~imgaug.augmenters.pil.pil_equalize_`.
+    See :func:`~imgaug.augmenters.pillike.pil_equalize_`.
 
     Parameters
     ----------
@@ -243,7 +243,7 @@ def equalize_(image, mask=None):
     This function applies a non-linear mapping to the input image, in order
     to create a uniform distribution of grayscale values in the output image.
 
-    This function has identical outputs to :func:`PIL.ImageOps.equalize`.
+    This function has identical outputs to :func:`~PIL.ImageOps.equalize`.
     It does however work in-place.
 
     Supported dtypes
@@ -355,7 +355,7 @@ def autocontrast(image, cutoff=0, ignore=None):
     and remaps the image so that the darkest pixel becomes black (``0``), and
     the lightest becomes white (``255``).
 
-    This function has identical outputs to :func:`PIL.ImageOps.autocontrast`.
+    This function has identical outputs to :func:`~PIL.ImageOps.autocontrast`.
     The speed is almost identical.
 
     Supported dtypes
@@ -539,7 +539,7 @@ def enhance_color(image, factor):
     """Change the strength of colors in an image.
 
     This function has identical outputs to
-    :class:`PIL.ImageEnhance.Color`.
+    :class:`~PIL.ImageEnhance.Color`.
 
     Supported dtypes
     ----------------
@@ -581,7 +581,7 @@ def enhance_contrast(image, factor):
     """Change the contrast of an image.
 
     This function has identical outputs to
-    :class:`PIL.ImageEnhance.Contrast`.
+    :class:`~PIL.ImageEnhance.Contrast`.
 
     Supported dtypes
     ----------------
@@ -624,7 +624,7 @@ def enhance_brightness(image, factor):
     """Change the brightness of images.
 
     This function has identical outputs to
-    :class:`PIL.ImageEnhance.Brightness`.
+    :class:`~PIL.ImageEnhance.Brightness`.
 
     Supported dtypes
     ----------------
@@ -666,7 +666,7 @@ def enhance_sharpness(image, factor):
     """Change the sharpness of an image.
 
     This function has identical outputs to
-    :class:`PIL.ImageEnhance.Sharpness`.
+    :class:`~PIL.ImageEnhance.Sharpness`.
 
     Supported dtypes
     ----------------
@@ -729,6 +729,8 @@ def _filter_by_kernel(image, kernel):
 def filter_blur(image):
     """Apply a blur filter kernel to the image.
 
+    This is the same as using PIL's ``PIL.ImageFilter.BLUR`` kernel.
+
     Supported dtypes
     ----------------
 
@@ -762,6 +764,8 @@ def filter_blur(image):
 
 def filter_smooth(image):
     """Apply a smoothness filter kernel to the image.
+
+    This is the same as using PIL's ``PIL.ImageFilter.SMOOTH`` kernel.
 
     Supported dtypes
     ----------------
@@ -797,6 +801,8 @@ def filter_smooth(image):
 def filter_smooth_more(image):
     """Apply a strong smoothness filter kernel to the image.
 
+    This is the same as using PIL's ``PIL.ImageFilter.SMOOTH_MORE`` kernel.
+
     Supported dtypes
     ----------------
 
@@ -830,6 +836,8 @@ def filter_smooth_more(image):
 
 def filter_edge_enhance(image):
     """Apply an edge enhancement filter kernel to the image.
+
+    This is the same as using PIL's ``PIL.ImageFilter.EDGE_ENHANCE`` kernel.
 
     Supported dtypes
     ----------------
@@ -865,6 +873,9 @@ def filter_edge_enhance(image):
 def filter_edge_enhance_more(image):
     """Apply a stronger edge enhancement filter kernel to the image.
 
+    This is the same as using PIL's ``PIL.ImageFilter.EDGE_ENHANCE_MORE``
+    kernel.
+
     Supported dtypes
     ----------------
 
@@ -898,6 +909,8 @@ def filter_edge_enhance_more(image):
 
 def filter_find_edges(image):
     """Apply an edge detection filter kernel to the image.
+
+    This is the same as using PIL's ``PIL.ImageFilter.FIND_EDGES`` kernel.
 
     Supported dtypes
     ----------------
@@ -933,6 +946,8 @@ def filter_find_edges(image):
 def filter_contour(image):
     """Apply a contour filter kernel to the image.
 
+    This is the same as using PIL's ``PIL.ImageFilter.CONTOUR`` kernel.
+
     Supported dtypes
     ----------------
 
@@ -966,6 +981,8 @@ def filter_contour(image):
 
 def filter_emboss(image):
     """Apply an emboss filter kernel to the image.
+
+    This is the same as using PIL's ``PIL.ImageFilter.EMBOSS`` kernel.
 
     Supported dtypes
     ----------------
@@ -1001,6 +1018,8 @@ def filter_emboss(image):
 def filter_sharpen(image):
     """Apply a sharpening filter kernel to the image.
 
+    This is the same as using PIL's ``PIL.ImageFilter.SHARPEN`` kernel.
+
     Supported dtypes
     ----------------
 
@@ -1034,6 +1053,8 @@ def filter_sharpen(image):
 
 def filter_detail(image):
     """Apply a detail enhancement filter kernel to the image.
+
+    This is the same as using PIL's ``PIL.ImageFilter.DETAIL`` kernel.
 
     Supported dtypes
     ----------------
@@ -1143,7 +1164,24 @@ def warp_affine(image,
     """Apply an affine transformation to an image.
 
     This function has identical outputs to
-    :func:`PIL.Image.transform` with ``method=PIL.Image.AFFINE``.
+    :func:`~PIL.Image.transform` with ``method=PIL.Image.AFFINE``.
+
+    Supported dtypes
+    ----------------
+
+        * ``uint8``: yes; fully tested
+        * ``uint16``: no
+        * ``uint32``: no
+        * ``uint64``: no
+        * ``int8``: no
+        * ``int16``: no
+        * ``int32``: no
+        * ``int64``: no
+        * ``float16``: no
+        * ``float32``: no
+        * ``float64``: no
+        * ``float128``: no
+        * ``bool``: no
 
     Parameters
     ----------
@@ -1248,7 +1286,7 @@ class Solarize(arithmetic.Invert):
     Supported dtypes
     ----------------
 
-    See :func:`~imgaug.augmenters.arithmetic.Invert`.
+    See :class:`~imgaug.augmenters.arithmetic.Invert`.
 
     Parameters
     ----------
@@ -1309,7 +1347,7 @@ class Posterize(colorlib.Posterize):
 class Equalize(meta.Augmenter):
     """Equalize the image histogram.
 
-    This augmenter has identical outputs to :func:`PIL.ImageOps.equalize`.
+    This augmenter has identical outputs to :func:`~PIL.ImageOps.equalize`.
 
     Supported dtypes
     ----------------
@@ -1355,7 +1393,7 @@ class Equalize(meta.Augmenter):
 class Autocontrast(contrastlib._ContrastFuncWrapper):
     """Adjust contrast by cutting off ``p%`` of lowest/highest histogram values.
 
-    This augmenter has identical outputs to :func:`PIL.ImageOps.autocontrast`.
+    This augmenter has identical outputs to :func:`~PIL.ImageOps.autocontrast`.
 
     See :func:`~imgaug.augmenters.pillike.autocontrast` for more details.
 
@@ -1461,7 +1499,7 @@ class _EnhanceBase(meta.Augmenter):
 class EnhanceColor(_EnhanceBase):
     """Convert images to grayscale.
 
-    This augmenter has identical outputs to :class:`PIL.ImageEnhance.Color`.
+    This augmenter has identical outputs to :class:`~PIL.ImageEnhance.Color`.
 
     Supported dtypes
     ----------------
@@ -1514,7 +1552,7 @@ class EnhanceColor(_EnhanceBase):
 class EnhanceContrast(_EnhanceBase):
     """Change the contrast of images.
 
-    This augmenter has identical outputs to :class:`PIL.ImageEnhance.Contrast`.
+    This augmenter has identical outputs to :class:`~PIL.ImageEnhance.Contrast`.
 
     Supported dtypes
     ----------------
@@ -1569,7 +1607,7 @@ class EnhanceBrightness(_EnhanceBase):
     """Change the brightness of images.
 
     This augmenter has identical outputs to
-    :class:`PIL.ImageEnhance.Brightness`.
+    :class:`~PIL.ImageEnhance.Brightness`.
 
     Supported dtypes
     ----------------
@@ -1623,7 +1661,7 @@ class EnhanceSharpness(_EnhanceBase):
     """Change the sharpness of images.
 
     This augmenter has identical outputs to
-    :class:`PIL.ImageEnhance.Sharpness`.
+    :class:`~PIL.ImageEnhance.Sharpness`.
 
     Supported dtypes
     ----------------
@@ -1698,7 +1736,7 @@ class FilterBlur(_FilterBase):
     """Apply a blur filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.BLUR``.
+    calling :func:`~PIL.Image.filter` with kernel ``PIL.ImageFilter.BLUR``.
 
     Supported dtypes
     ----------------
@@ -1735,7 +1773,7 @@ class FilterSmooth(_FilterBase):
     """Apply a smoothening filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.SMOOTH``.
+    calling :func:`~PIL.Image.filter` with kernel ``PIL.ImageFilter.SMOOTH``.
 
     Supported dtypes
     ----------------
@@ -1772,7 +1810,7 @@ class FilterSmoothMore(_FilterBase):
     """Apply a strong smoothening filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.BLUR``.
+    calling :func:`~PIL.Image.filter` with kernel ``PIL.ImageFilter.BLUR``.
 
     Supported dtypes
     ----------------
@@ -1810,7 +1848,7 @@ class FilterEdgeEnhance(_FilterBase):
     """Apply an edge enhance filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel
+    calling :func:`~PIL.Image.filter` with kernel
     ``PIL.ImageFilter.EDGE_ENHANCE``.
 
     Supported dtypes
@@ -1849,7 +1887,7 @@ class FilterEdgeEnhanceMore(_FilterBase):
     """Apply a strong edge enhancement filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel
+    calling :func:`~PIL.Image.filter` with kernel
     ``PIL.ImageFilter.EDGE_ENHANCE_MORE``.
 
     Supported dtypes
@@ -1888,7 +1926,7 @@ class FilterFindEdges(_FilterBase):
     """Apply a edge detection kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel
+    calling :func:`~PIL.Image.filter` with kernel
     ``PIL.ImageFilter.FIND_EDGES``.
 
     Supported dtypes
@@ -1926,7 +1964,7 @@ class FilterContour(_FilterBase):
     """Apply a contour detection filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.CONTOUR``.
+    calling :func:`~PIL.Image.filter` with kernel ``PIL.ImageFilter.CONTOUR``.
 
     Supported dtypes
     ----------------
@@ -1964,7 +2002,7 @@ class FilterEmboss(_FilterBase):
     """Apply an emboss filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.EMBOSS``.
+    calling :func:`~PIL.Image.filter` with kernel ``PIL.ImageFilter.EMBOSS``.
 
     Supported dtypes
     ----------------
@@ -2001,7 +2039,7 @@ class FilterSharpen(_FilterBase):
     """Apply a sharpening filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.SHARPEN``.
+    calling :func:`~PIL.Image.filter` with kernel ``PIL.ImageFilter.SHARPEN``.
 
     Supported dtypes
     ----------------
@@ -2038,7 +2076,7 @@ class FilterDetail(_FilterBase):
     """Apply a detail enhancement filter kernel to images.
 
     This augmenter has identical outputs to
-    calling :func:`PIL.Image.filter` with kernel ``PIL.ImageFilter.DETAIL``.
+    calling :func:`~PIL.Image.filter` with kernel ``PIL.ImageFilter.DETAIL``.
 
     Supported dtypes
     ----------------
@@ -2076,7 +2114,7 @@ class Affine(geometric.Affine):
     """Apply PIL-like affine transformations to images.
 
     This augmenter has identical outputs to
-    :func:`PIL.Image.transform` with parameter ``method=PIL.Image.AFFINE``.
+    :func:`~PIL.Image.transform` with parameter ``method=PIL.Image.AFFINE``.
 
     .. note::
 

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -436,7 +436,7 @@ class MinPooling(_AbstractPoolingBase):
     Supported dtypes
     ----------------
 
-    See :func:`~imgaug.imgaug.pool`.
+    See :func:`~imgaug.imgaug.min_pool`.
 
     Attributes
     ----------
@@ -550,7 +550,7 @@ class MedianPooling(_AbstractPoolingBase):
     Supported dtypes
     ----------------
 
-    See :func:`~imgaug.imgaug.pool`.
+    See :func:`~imgaug.imgaug.median_pool`.
 
     Attributes
     ----------


### PR DESCRIPTION
This patch fixes various docstring errors:
- Missing dtype support sections
- Wrong `:class:` and `:func:` links
- Wrong statements from copy-paste errors