### PR TITLE
Improve default values of augmenters

### DIFF
--- a/changelogs/master/changed/20200115_changed_defaults.md
+++ b/changelogs/master/changed/20200115_changed_defaults.md
@@ -1,7 +1,7 @@
 # Better default values #582
 
 **[breaking]** Most augmenters had previously default values that
-made them equivalent to identify functions. Users had to explicitly
+made them equivalent to identity functions. Users had to explicitly
 change the defaults to proper values in order to "activate"
 augmentations. To simplify the usage of the library, the default
 values of most augmenters were changed to medium-strength
@@ -22,17 +22,17 @@ augmentations. This is the case for:
   `TotalDropout(0.1)` to drop everything for 10% of all images)
 * `Invert` (always inverts images, use `Invert(0.1)` to invert
   10% of all images)
-* `Rot90` (always rotates exactly once by 90 degrees,
-  use `Rot90((0, 4))` for any rotation)
+* `Rot90` (always rotates exactly once clockwise by 90 degrees,
+  use `Rot90((0, 3))` for any rotation)
 
 These settings seemed to better match user-expectations.
 Such maximum-strength settings however were not chosen for all
-augmenters. Some exceptions where one might expect that are e.g.
-`Superpixels` (replaces only some superpixels with cellwise average
-colors), `UniformVoronoi` (also only replaces some cells),
-`Sharpen` (alpha-blends with variable strength, the same is
-the case for `Emboss`, `EdgeDetect` and `DirectedEdgeDetect`)
-and `CLAHE` (variable clip limits).
+augmenters where one might expect them. The defaults are set to
+varying strengths for, e.g.  `Superpixels` (replaces only some
+superpixels with cellwise average colors), `UniformVoronoi` (also
+only replaces some cells), `Sharpen` (alpha-blends with variable
+strength, the same is the case for `Emboss`, `EdgeDetect` and
+`DirectedEdgeDetect`) and `CLAHE` (variable clip limits).
 
 *Note*: Some of the new default values will cause issues with
 non-`uint8` inputs.
@@ -67,25 +67,25 @@ The exact changes to default values are listed below.
     * `size_px`: `None` -> `(3, 8)`
     * `min_size`: `4` -> `3`
     * Default for `size_px` is only used if neither `size_percent`
-      not `size_px` is provided by the user.
+      nor `size_px` is provided by the user.
   * `CoarseSaltAndPepper`:
     * `p`: `0.0` -> `(0.02, 0.1)`
     * `size_px`: `None` -> `(3, 8)`
     * `min_size`: `4` -> `3`
     * Default for `size_px` is only used if neither `size_percent`
-      not `size_px` is provided by the user.
+      nor `size_px` is provided by the user.
   * `CoarseSalt`:
     * `p`: `0.0` -> `(0.02, 0.1)`
     * `size_px`: `None` -> `(3, 8)`
     * `min_size`: `4` -> `3`
     * Default for `size_px` is only used if neither `size_percent`
-      not `size_px` is provided by the user.
+      nor `size_px` is provided by the user.
   * `CoarsePepper`:
     * `p`: `0.0` -> `(0.02, 0.1)`
     * `size_px`: `None` -> `(3, 8)`
     * `min_size`: `4` -> `3`
     * Default for `size_px` is only used if neither `size_percent`
-      not `size_px` is provided by the user.
+      nor `size_px` is provided by the user.
   * `SaltAndPepper`:
     * `p`: `0.0` -> `(0.0, 0.03)`
   * `Salt`:

--- a/changelogs/master/changed/20200115_changed_defaults.md
+++ b/changelogs/master/changed/20200115_changed_defaults.md
@@ -1,0 +1,240 @@
+# Better default values #?
+
+**[breaking]** Most augmenters had previously default values that
+made them equivalent to identify functions. Users had to explicitly
+change the defaults to proper values in order to "activate"
+augmentations. To simplify the usage of the library, the default
+values of most augmenters were changed to medium-strength
+augmentations. E.g.
+`Sequential([Affine(), UniformVoronoi(), CoarseDropout()])`
+should now produce decent augmentations.
+
+A few augmenters were set to always-on, maximum-strength
+augmentations. This is the case for:
+* `Grayscale` (always fully grayscales images, use
+  `Grayscale((0.0, 1.0))` for random strengths)
+* `RemoveSaturation` (same as `Grayscale`)
+* `Fliplr` (always flips images, use `Fliplr(0.5)` for 50%
+  probability).
+* `Flipud` (same as for `Fliplr`)
+* `TotalDropout` (always drops everything, use
+  `TotalDropout(0.1)` to drop everything for 10% of all images).
+* `Invert` (always inverts images, use `Invert(0.1)` to invert
+  10% of all images)
+* `Rot90` (always rotates exactly once by 90 degrees,
+  use `Rot90((0, 4))` for any rotation)
+These settings seemed to better match user-expectations.
+Such maximum-strength settings however were not chosen for all
+augmenters. Some exceptions where one might expect that are e.g.
+`Superpixels` (replaces only some superpixels with cellwise average
+colors), `UniformVoronoi` (also only replaces some cells),
+`Sharpen` (alpha-blends with variable strength, the same is
+the case for `Emboss`, `EdgeDetect` and `DirectedEdgeDetect`)
+and `CLAHE` (variable clip limits).
+
+*Note*: Some of the new default values will cause issues with
+non-`uint8` inputs.
+
+*Note*: The defaults for `per_channel` and `keep_size` were not
+adjusted. It is currently still the default behaviour of all
+augmenters to affect all channels in the same way and to resize
+their outputs back to the input sizes.
+
+The changes to default values are listed below.
+
+**imgaug.arithmetic**
+  
+  * `Add`
+    * `value`: `0` -> `(-20, 20)`
+  * `AddElementwise`
+    * `value`: `0` -> `(-20, 20)`
+  * `AdditiveGaussianNoise`
+    * `scale`: `0` -> `(0, 15)`
+  * `AdditiveLaplaceNoise`
+    * `scale`: `0` -> `(0, 15)`
+  * `AdditivePoissonNoise`
+    * `scale`: `0` -> `(0, 15)`
+  * `Multiply`
+    * `mul`: `1.0` -> `(0.8, 1.2)`
+  * `MultiplyElementwise`:
+    * `mul`: `1.0` -> `(0.8, 1.2)`
+  * `Dropout`: 
+    * `p`: `0.0` -> `(0.0, 0.05)`
+  * `CoarseDropout`:
+    * `p`: `0.0` -> `(0.02, 0.1)`
+    * `size_px`: `None` -> `(3, 8)`
+    * `min_size`: `4` -> `3`
+    * Default for `size_px` is only used if neither `size_percent`
+      not `size_px` is provided by the user.
+  * `CoarseSaltAndPepper`:
+    * `p`: `0.0` -> `(0.02, 0.1)`
+    * `size_px`: `None` -> `(3, 8)`
+    * `min_size`: `4` -> `3`
+    * Default for `size_px` is only used if neither `size_percent`
+      not `size_px` is provided by the user.
+  * `CoarseSalt`:
+    * `p`: `0.0` -> `(0.02, 0.1)`
+    * `size_px`: `None` -> `(3, 8)`
+    * `min_size`: `4` -> `3`
+    * Default for `size_px` is only used if neither `size_percent`
+      not `size_px` is provided by the user.
+  * `CoarsePepper`:
+    * `p`: `0.0` -> `(0.02, 0.1)`
+    * `size_px`: `None` -> `(3, 8)`
+    * `min_size`: `4` -> `3`
+    * Default for `size_px` is only used if neither `size_percent`
+      not `size_px` is provided by the user.
+  * `SaltAndPepper`:
+    * `p`: `0.0` -> `(0.0, 0.03)`
+  * `Salt`:
+    * `p`: `0.0` -> `(0.0, 0.03)`
+  * `Pepper`:
+    * `p`: `0.0` -> `(0.0, 0.05)`
+  * `ImpulseNoise`:
+    * `p`: `0.0` -> `(0.0, 0.03)`
+  * `Invert`: 
+    * `p`: `0` -> `1`
+  * `JpegCompression`:
+    * `compression`: `50` -> `(0, 100)`
+
+**imgaug.blend**
+
+  * `BlendAlpha`
+    * `factor`: `0` -> `(0.0, 1.0)`
+  * `BlendAlphaElementwise`
+    * `factor`: `0` -> `(0.0, 1.0)`
+
+**imgaug.blur**
+
+  * `GaussianBlur`:
+    * `sigma`: `0` -> `(0.0, 3.0)`
+  * `AverageBlur`:
+    * `k`: `1` -> `(1, 7)`
+  * `MedianBlur`:
+    * `k`: `1` -> `(1, 7)`
+  * `BilateralBlur`:
+    * `d`: `1` -> `(1, 9)`
+  * `MotionBlur`:
+    * `k`: `5` -> `(3, 7)`
+
+**imgaug.color**
+
+  * `MultiplyHueAndSaturation`:
+    * `mul_hue`: `None` -> `(0.5, 1.5)`
+    * `mul_saturation`: `None` -> `(0.0, 1.7)`
+    * These defaults are only used if the user provided neither
+      `mul` nor `mul_hue` nor `mul_saturation`.
+  * `MultiplyHue`:
+    * `mul`: `(-1.0, 1.0)` -> `(-3.0, 3.0)`
+  * `AddToHueAndSaturation`:
+    * `value_hue`: `None` -> `(-40, 40)`
+    * `value_saturation`: `None` -> `(-40, 40)`
+    * These defaults are only used if the user provided neither
+      `value` nor `value_hue` nor `value_saturation`.
+  * `Grayscale`:
+    * `alpha`: `0` -> `1`
+
+**imgaug.contrast**
+
+  * `GammaContrast`:
+    * `gamma`: `1` -> `(0.7, 1.7)` 
+  * `SigmoidContrast`:
+    * `gain`: `10` -> `(5, 6)`
+    * `cutoff`: `0.5` -> `(0.3, 0.6)`
+  * `LogContrast`:
+    * `gain`: `1` -> `(0.4, 1.6)`
+  * `LinearContrast`:
+    * `alpha`: `1` -> `(0.6, 1.4)`
+  * `AllChannelsCLAHE`:
+    * `clip_limit`: `40` -> `(0.1, 8)`
+    * `tile_grid_size_px`: `8` -> `(3, 12)`
+  * `CLAHE`: 
+    * `clip_limit`: `40` -> `(0.1, 8)`
+    * `tile_grid_size_px`: `8` -> `(3, 12)`
+
+**convolutional**
+
+  * `Sharpen`:
+    * `alpha`: `0` -> `(0.0, 0.2)`
+    * `lightness`: `1` -> `(0.8, 1.2)`
+  * `Emboss`:
+    * `alpha`: `0` -> `(0.0, 1.0)`
+    * `strength`: `1` -> `(0.25, 1.0)`
+  * `EdgeDetect`:
+    * `alpha`: `0` -> `(0.0, 0.75)`
+  * `DirectedEdgeDetect`:
+    * `alpha`: `0` -> `(0.0, 0.75)`
+
+**imgaug.flip**
+
+  * `Fliplr`:
+    * `p`: `0` -> `1`
+  * `Flipud`:
+    * `p`: `0` -> `1`
+
+**imgaug.geometric**
+
+  * `Affine`:
+    * `scale`: `1` -> `{"x": (0.9, 1.1), "y": (0.9, 1.1)}`
+    * `translate_percent`: None -> `{"x": (-0.1, 0.1), "y": (-0.1, 0.1)}`
+    * `rotate`: `0` -> `(-15, 15)`
+    * `shear`: `0` -> `shear={"x": (-10, 10), "y": (-10, 10)}`
+    * These defaults are only used if no affine transformation
+      parameter was set by the user. Otherwise the not-set
+      parameters default again towards the identity function.
+  * `PiecewiseAffine`:
+    * `scale`: `0` -> `(0.0, 0.04)`
+    * `nb_rows`: `4` -> `(2, 4)`
+    * `nb_cols`: `4` -> `(2, 4)`
+  * `PerspectiveTransform`:
+    * `scale`: `0` -> `(0.0, 0.06)`
+  * `ElasticTransformation`:
+    * `alpha`: `0` -> `(0.0, 40.0)`
+    * `sigma`: `0` -> `(4.0, 8.0)`
+  * `Rot90`:
+    * `k`: `(no default)` -> `k=1`
+
+**imgaug.pooling**
+
+  * `AveragePooling`:
+    * `k`: `(no default)` -> `(1, 5)`
+  * `MaxPooling`:
+    * `k`: `(no default)` -> `(1, 5)`
+  * `MinPooling`:
+    * `k`: `(no default)` -> `(1, 5)`
+  * `MedianPooling`:
+    * `k`: `(no default)` -> `(1, 5)`
+
+**imgaug.segmentation**
+ 
+  * `Superpixels`:
+    * `p_replace`: `0.0` -> `(0.5, 1.0)`
+    * `n_segments`: `100` -> `(50, 120)`
+  * `UniformVoronoi`:
+    * `n_points`: `(no default)` -> `(50, 500)`
+    * `p_replace`: `1.0` -> `(0.5, 1.0)`.
+  * `RegularGridVoronoi`:
+    * `n_rows`: `(no default)` -> `(10, 30)`
+    * `n_cols`: `(no default)` -> `(10, 30)`
+    * `p_drop_points`: `0.4` -> `(0.0, 0.5)`
+    * `p_replace`: `1.0` -> `(0.5, 1.0)`
+  * `RelativeRegularGridVoronoi`: Changed defaults from
+    * `n_rows_frac`: `(no default)` -> `(0.05, 0.15)`
+    * `n_cols_frac`: `(no default)` -> `(0.05, 0.15)`
+    * `p_drop_points`: `0.4` -> `(0.0, 0.5)`
+    * `p_replace`: `1.0` -> `(0.5, 1.0)`
+
+**imgaug.size**
+
+  * `CropAndPad`:
+    * `percent`: `None` -> `(-0.1, 0.1)`
+    * This default is only used if the user has provided
+      neither `px` nor `percent`.
+  * `Pad`:
+    * `percent`: `None` -> `(0.0, 0.1)`
+    * This default is only used if the user has provided
+      neither `px` nor `percent`.
+  * `Crop`:
+    * `percent`: `None` -> `(0.0, 0.1)`
+    * This default is only used if the user has provided
+      neither `px` nor `percent`.

--- a/changelogs/master/changed/20200115_changed_defaults.md
+++ b/changelogs/master/changed/20200115_changed_defaults.md
@@ -1,4 +1,4 @@
-# Better default values #?
+# Better default values #582
 
 **[breaking]** Most augmenters had previously default values that
 made them equivalent to identify functions. Users had to explicitly
@@ -11,18 +11,20 @@ should now produce decent augmentations.
 
 A few augmenters were set to always-on, maximum-strength
 augmentations. This is the case for:
+
 * `Grayscale` (always fully grayscales images, use
   `Grayscale((0.0, 1.0))` for random strengths)
 * `RemoveSaturation` (same as `Grayscale`)
 * `Fliplr` (always flips images, use `Fliplr(0.5)` for 50%
-  probability).
-* `Flipud` (same as for `Fliplr`)
+  probability)
+* `Flipud` (same as `Fliplr`)
 * `TotalDropout` (always drops everything, use
-  `TotalDropout(0.1)` to drop everything for 10% of all images).
+  `TotalDropout(0.1)` to drop everything for 10% of all images)
 * `Invert` (always inverts images, use `Invert(0.1)` to invert
   10% of all images)
 * `Rot90` (always rotates exactly once by 90 degrees,
   use `Rot90((0, 4))` for any rotation)
+
 These settings seemed to better match user-expectations.
 Such maximum-strength settings however were not chosen for all
 augmenters. Some exceptions where one might expect that are e.g.
@@ -40,7 +42,7 @@ adjusted. It is currently still the default behaviour of all
 augmenters to affect all channels in the same way and to resize
 their outputs back to the input sizes.
 
-The changes to default values are listed below.
+The exact changes to default values are listed below.
 
 **imgaug.arithmetic**
   

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -3930,7 +3930,7 @@ class Pepper(ReplaceElementwise):
 
     """
 
-    def __init__(self, p=0, per_channel=False,
+    def __init__(self, p=(0.0, 0.05), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         replacement01 = iap.ForceSign(
             iap.Beta(0.5, 0.5) - 0.5,

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -3639,8 +3639,8 @@ class CoarseSaltAndPepper(ReplaceElementwise):
     independently per image channel.
 
     """
-    def __init__(self, p=0, size_px=None, size_percent=None,
-                 per_channel=False, min_size=4,
+    def __init__(self, p=(0.02, 0.1), size_px=None, size_percent=None,
+                 per_channel=False, min_size=3,
                  seed=None, name=None, **old_kwargs):
         mask = iap.handle_probability_param(
             p, "p", tuple_to_uniform=True, list_to_choice=True)
@@ -3652,7 +3652,8 @@ class CoarseSaltAndPepper(ReplaceElementwise):
             mask_low = iap.FromLowerResolution(
                 other_param=mask, size_percent=size_percent, min_size=min_size)
         else:
-            raise Exception("Either size_px or size_percent must be set.")
+            mask_low = iap.FromLowerResolution(
+                other_param=mask, size_px=(3, 8), min_size=min_size)
 
         replacement = iap.Beta(0.5, 0.5) * 255
 

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -3169,7 +3169,7 @@ class TotalDropout(meta.Augmenter):
 
     """
 
-    def __init__(self, p, seed=None, name=None, **old_kwargs):
+    def __init__(self, p=1, seed=None, name=None, **old_kwargs):
         super(TotalDropout, self).__init__(
             seed=seed, name=name, **old_kwargs)
         self.p = _handle_dropout_probability_param(p, "p")

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -3841,8 +3841,8 @@ class CoarseSalt(ReplaceElementwise):
 
     """
 
-    def __init__(self, p=0, size_px=None, size_percent=None, per_channel=False,
-                 min_size=4,
+    def __init__(self, p=(0.02, 0.1), size_px=None, size_percent=None,
+                 per_channel=False, min_size=3,
                  seed=None, name=None, **old_kwargs):
         mask = iap.handle_probability_param(
             p, "p", tuple_to_uniform=True, list_to_choice=True)
@@ -3854,7 +3854,8 @@ class CoarseSalt(ReplaceElementwise):
             mask_low = iap.FromLowerResolution(
                 other_param=mask, size_percent=size_percent, min_size=min_size)
         else:
-            raise Exception("Either size_px or size_percent must be set.")
+            mask_low = iap.FromLowerResolution(
+                other_param=mask, size_px=(3, 8), min_size=min_size)
 
         replacement01 = iap.ForceSign(
             iap.Beta(0.5, 0.5) - 0.5,

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -3721,7 +3721,7 @@ class Salt(ReplaceElementwise):
 
     """
 
-    def __init__(self, p=0, per_channel=False,
+    def __init__(self, p=(0.0, 0.03), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         replacement01 = iap.ForceSign(
             iap.Beta(0.5, 0.5) - 0.5,

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -2996,7 +2996,7 @@ class Dropout2d(meta.Augmenter):
 
     """
 
-    def __init__(self, p, nb_keep_channels=1,
+    def __init__(self, p=0.1, nb_keep_channels=1,
                  seed=None, name=None, **old_kwargs):
         super(Dropout2d, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -3456,7 +3456,7 @@ class SaltAndPepper(ReplaceElementwise):
     noise.
 
     """
-    def __init__(self, p=0, per_channel=False,
+    def __init__(self, p=(0.0, 0.03), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         super(SaltAndPepper, self).__init__(
             mask=p,

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -3510,7 +3510,7 @@ class ImpulseNoise(SaltAndPepper):
     Replace ``10%`` of all pixels with impulse noise.
 
     """
-    def __init__(self, p=0, seed=None, name=None, **old_kwargs):
+    def __init__(self, p=(0.0, 0.03), seed=None, name=None, **old_kwargs):
         super(ImpulseNoise, self).__init__(
             p=p,
             per_channel=True,

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -4048,8 +4048,8 @@ class CoarsePepper(ReplaceElementwise):
 
     """
 
-    def __init__(self, p=0, size_px=None, size_percent=None, per_channel=False,
-                 min_size=4,
+    def __init__(self, p=(0.02, 0.1), size_px=None, size_percent=None,
+                 per_channel=False, min_size=3,
                  seed=None, name=None, **old_kwargs):
         mask = iap.handle_probability_param(
             p, "p", tuple_to_uniform=True, list_to_choice=True)
@@ -4061,7 +4061,8 @@ class CoarsePepper(ReplaceElementwise):
             mask_low = iap.FromLowerResolution(
                 other_param=mask, size_percent=size_percent, min_size=min_size)
         else:
-            raise Exception("Either size_px or size_percent must be set.")
+            mask_low = iap.FromLowerResolution(
+                other_param=mask, size_px=(3, 8), min_size=min_size)
 
         replacement01 = iap.ForceSign(
             iap.Beta(0.5, 0.5) - 0.5,

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -4487,7 +4487,7 @@ class JpegCompression(meta.Augmenter):
     setting of ``1`` to ``30``.
 
     """
-    def __init__(self, compression=50,
+    def __init__(self, compression=(0, 100),
                  seed=None, name=None, **old_kwargs):
         super(JpegCompression, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -2697,7 +2697,7 @@ class Dropout(MultiplyElementwise):
     active for ``50`` percent of all images.
 
     """
-    def __init__(self, p=0, per_channel=False,
+    def __init__(self, p=(0.0, 0.05), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         p_param = _handle_dropout_probability_param(p, "p")
 

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -2742,8 +2742,7 @@ def _handle_dropout_probability_param(p, name):
     return p_param
 
 
-# TODO add similar cutout augmenter
-# TODO invert size_p and size_percent so that larger values denote larger
+# TODO invert size_px and size_percent so that larger values denote larger
 #      areas being dropped instead of the opposite way around
 class CoarseDropout(MultiplyElementwise):
     """
@@ -2888,8 +2887,8 @@ class CoarseDropout(MultiplyElementwise):
     for ``50`` percent of all images.
 
     """
-    def __init__(self, p=0, size_px=None, size_percent=None, per_channel=False,
-                 min_size=4,
+    def __init__(self, p=(0.02, 0.1), size_px=None, size_percent=None,
+                 per_channel=False, min_size=3,
                  seed=None, name=None, **old_kwargs):
         p_param = _handle_dropout_probability_param(p, "p")
 
@@ -2902,7 +2901,11 @@ class CoarseDropout(MultiplyElementwise):
                                               size_percent=size_percent,
                                               min_size=min_size)
         else:
-            raise Exception("Either size_px or size_percent must be set.")
+            # default if neither size_px nor size_percent is provided
+            # is size_px=(3, 8)
+            p_param = iap.FromLowerResolution(other_param=p_param,
+                                              size_px=(3, 8),
+                                              min_size=min_size)
 
         super(CoarseDropout, self).__init__(
             p_param,

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -4345,7 +4345,7 @@ class Solarize(Invert):
     per image. The thresholding operation happens per channel.
 
     """
-    def __init__(self, p, per_channel=False, min_value=None, max_value=None,
+    def __init__(self, p=1, per_channel=False, min_value=None, max_value=None,
                  threshold=(128-64, 128+64), invert_above_threshold=True,
                  seed=None, name=None, **old_kwargs):
         super(Solarize, self).__init__(

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -2237,7 +2237,7 @@ class MultiplyElementwise(meta.Augmenter):
 
     """
 
-    def __init__(self, mul=1.0, per_channel=False,
+    def __init__(self, mul=(0.8, 1.2), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         super(MultiplyElementwise, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -4195,7 +4195,7 @@ class Invert(meta.Augmenter):
         ]
     ]
 
-    def __init__(self, p=0, per_channel=False, min_value=None, max_value=None,
+    def __init__(self, p=1, per_channel=False, min_value=None, max_value=None,
                  threshold=None, invert_above_threshold=0.5,
                  seed=None, name=None, **old_kwargs):
         super(Invert, self).__init__(

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -2103,7 +2103,7 @@ class Multiply(meta.Augmenter):
 
     """
 
-    def __init__(self, mul=1.0, per_channel=False,
+    def __init__(self, mul=(0.8, 1.2), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         super(Multiply, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -385,7 +385,7 @@ class BlendAlpha(meta.Augmenter):
 
     """
 
-    def __init__(self, factor=0, foreground=None, background=None,
+    def __init__(self, factor=(0.0, 1.0), foreground=None, background=None,
                  per_channel=False,
                  seed=None, name=None, **old_kwargs):
         super(BlendAlpha, self).__init__(

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -889,7 +889,7 @@ class BlendAlphaElementwise(BlendAlphaMask):
 
     """
 
-    def __init__(self, factor=0, foreground=None, background=None,
+    def __init__(self, factor=(0.0, 1.0), foreground=None, background=None,
                  per_channel=False,
                  seed=None, name=None, **old_kwargs):
         factor = iap.handle_continuous_param(

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -1019,7 +1019,7 @@ class MotionBlur(iaa_convolutional.Convolve):
 
     """
 
-    def __init__(self, k=5, angle=(0, 360), direction=(-1.0, 1.0), order=1,
+    def __init__(self, k=(3, 7), angle=(0, 360), direction=(-1.0, 1.0), order=1,
                  seed=None, name=None, **old_kwargs):
         # TODO allow (1, None) and set to identity matrix if k == 1
         k_param = iap.handle_discrete_param(

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -547,7 +547,7 @@ class AverageBlur(meta.Augmenter):
 
     """
 
-    def __init__(self, k=1, seed=None, name=None, **old_kwargs):
+    def __init__(self, k=(1, 7), seed=None, name=None, **old_kwargs):
         super(AverageBlur, self).__init__(
             seed=seed, name=name, **old_kwargs)
 

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -433,7 +433,7 @@ class GaussianBlur(meta.Augmenter):
 
     """
 
-    def __init__(self, sigma=0,
+    def __init__(self, sigma=(0.0, 3.0),
                  seed=None, name=None, **old_kwargs):
         super(GaussianBlur, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -734,7 +734,7 @@ class MedianBlur(meta.Augmenter):
 
     """
 
-    def __init__(self, k=1, seed=None, name=None, **old_kwargs):
+    def __init__(self, k=(1, 7), seed=None, name=None, **old_kwargs):
         super(MedianBlur, self).__init__(
             seed=seed, name=name, **old_kwargs)
 

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -886,7 +886,7 @@ class BilateralBlur(meta.Augmenter):
 
     """
 
-    def __init__(self, d=1, sigma_color=(10, 250), sigma_space=(10, 250),
+    def __init__(self, d=(1, 9), sigma_color=(10, 250), sigma_space=(10, 250),
                  seed=None, name=None, **old_kwargs):
         # pylint: disable=invalid-name
         super(BilateralBlur, self).__init__(

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -2202,6 +2202,9 @@ class AddToHueAndSaturation(meta.Augmenter):
                  seed=None, name=None, **old_kwargs):
         super(AddToHueAndSaturation, self).__init__(
             seed=seed, name=name, **old_kwargs)
+        if value is None and value_hue is None and value_saturation is None:
+            value_hue = (-40, 40)
+            value_saturation = (-40, 40)
 
         self.value = self._handle_value_arg(value, value_hue, value_saturation)
         self.value_hue = self._handle_value_hue_arg(value_hue)

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -2007,7 +2007,7 @@ class RemoveSaturation(MultiplySaturation):
     Examples
     --------
     >>> import imgaug.augmenters as iaa
-    >>> aug = iaa.RemoveSaturation()
+    >>> aug = iaa.RemoveSaturation((0.0, 1.0))
 
     Create an augmenter that decreases saturation by varying degrees.
 
@@ -2023,7 +2023,7 @@ class RemoveSaturation(MultiplySaturation):
 
     """
 
-    def __init__(self, mul=(0.0, 1.0), from_colorspace=CSPACE_RGB,
+    def __init__(self, mul=1, from_colorspace=CSPACE_RGB,
                  seed=None, name=None, **old_kwargs):
         mul = iap.Subtract(
             1.0,

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -1759,6 +1759,10 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
     def __init__(self, mul=None, mul_hue=None, mul_saturation=None,
                  per_channel=False, from_colorspace="RGB",
                  seed=None, name=None, **old_kwargs):
+        if mul is None and mul_hue is None and mul_saturation is None:
+            mul_hue = (0.5, 1.5)
+            mul_saturation = (0.0, 1.7)
+
         if mul is not None:
             assert mul_hue is None, (
                 "`mul_hue` may not be set if `mul` is set. "

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -2801,7 +2801,7 @@ class Grayscale(ChangeColorspace):
 
     """
 
-    def __init__(self, alpha=0, from_colorspace=CSPACE_RGB,
+    def __init__(self, alpha=1, from_colorspace=CSPACE_RGB,
                  seed=None, name=None, **old_kwargs):
         super(Grayscale, self).__init__(
             to_colorspace=CSPACE_GRAY,

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -1901,7 +1901,7 @@ class MultiplyHue(MultiplyHueAndSaturation):
 
     """
 
-    def __init__(self, mul=(-1.0, 1.0), from_colorspace="RGB",
+    def __init__(self, mul=(-3.0, 3.0), from_colorspace="RGB",
                  seed=None, name=None, **old_kwargs):
         super(MultiplyHue, self).__init__(
             mul_hue=mul,

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -499,6 +499,9 @@ class SigmoidContrast(_ContrastFuncWrapper):
     Values in the range ``gain=(5, 20)`` and ``cutoff=(0.25, 0.75)`` seem to
     be sensible.
 
+    A combination of ``gain=5.5`` and ``cutof=0.45`` is fairly close to
+    the identity function.
+
     Supported dtypes
     ----------------
 
@@ -564,7 +567,7 @@ class SigmoidContrast(_ContrastFuncWrapper):
     sampled once per image *and* channel.
 
     """
-    def __init__(self, gain=10, cutoff=0.5, per_channel=False,
+    def __init__(self, gain=(5, 6), cutoff=(0.3, 0.6), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         # TODO add inv parameter?
         params1d = [

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -952,7 +952,7 @@ class AllChannelsCLAHE(meta.Augmenter):
 
     """
 
-    def __init__(self, clip_limit=40, tile_grid_size_px=8,
+    def __init__(self, clip_limit=(0.1, 8), tile_grid_size_px=(3, 12),
                  tile_grid_size_px_min=3, per_channel=False,
                  seed=None, name=None, **old_kwargs):
         super(AllChannelsCLAHE, self).__init__(

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -715,7 +715,7 @@ class LinearContrast(_ContrastFuncWrapper):
     *and* channel.
 
     """
-    def __init__(self, alpha=1, per_channel=False,
+    def __init__(self, alpha=(0.6, 1.4), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         params1d = [
             iap.handle_continuous_param(

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -1204,7 +1204,7 @@ class CLAHE(meta.Augmenter):
     HLS = color_lib.CSPACE_HLS
     Lab = color_lib.CSPACE_Lab
 
-    def __init__(self, clip_limit=40, tile_grid_size_px=8,
+    def __init__(self, clip_limit=(0.1, 8), tile_grid_size_px=(3, 12),
                  tile_grid_size_px_min=3,
                  from_colorspace=color_lib.CSPACE_RGB,
                  to_colorspace=color_lib.CSPACE_Lab,

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -477,7 +477,7 @@ class GammaContrast(_ContrastFuncWrapper):
 
     """
 
-    def __init__(self, gamma=1, per_channel=False,
+    def __init__(self, gamma=(0.7, 1.7), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         params1d = [iap.handle_continuous_param(
             gamma, "gamma", value_range=None, tuple_to_uniform=True,

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -645,7 +645,7 @@ class LogContrast(_ContrastFuncWrapper):
     *and* channel.
 
     """
-    def __init__(self, gain=1, per_channel=False,
+    def __init__(self, gain=(0.4, 1.6), per_channel=False,
                  seed=None, name=None, **old_kwargs):
         # TODO add inv parameter?
         params1d = [iap.handle_continuous_param(

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -480,7 +480,7 @@ class EdgeDetect(Convolve):
     blending factor between ``0%`` and ``100%``.
 
     """
-    def __init__(self, alpha=0,
+    def __init__(self, alpha=(0.0, 0.75),
                  seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -392,7 +392,7 @@ class Emboss(Convolve):
     using a random blending factor between ``0%`` and ``100%``.
 
     """
-    def __init__(self, alpha=0, strength=1,
+    def __init__(self, alpha=(0.0, 1.0), strength=(0.25, 1.0),
                  seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -604,7 +604,7 @@ class DirectedEdgeDetect(Convolve):
     and ``30%``.
 
     """
-    def __init__(self, alpha=0, direction=(0.0, 1.0),
+    def __init__(self, alpha=(0.0, 0.75), direction=(0.0, 1.0),
                  seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -290,7 +290,7 @@ class Sharpen(Convolve):
     (as in the above example).
 
     """
-    def __init__(self, alpha=0, lightness=1,
+    def __init__(self, alpha=(0.0, 0.2), lightness=(0.8, 1.2),
                  seed=None, name=None, **old_kwargs):
         alpha_param = iap.handle_continuous_param(
             alpha, "alpha",

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -861,7 +861,7 @@ class Fliplr(meta.Augmenter):
 
     """
 
-    def __init__(self, p=0, seed=None, name=None, **old_kwargs):
+    def __init__(self, p=1, seed=None, name=None, **old_kwargs):
         super(Fliplr, self).__init__(
             seed=seed, name=name, **old_kwargs)
         self.p = iap.handle_probability_param(p, "p")
@@ -962,7 +962,7 @@ class Flipud(meta.Augmenter):
 
     """
 
-    def __init__(self, p=0, seed=None, name=None, **old_kwargs):
+    def __init__(self, p=1, seed=None, name=None, **old_kwargs):
         super(Flipud, self).__init__(
             seed=seed, name=name, **old_kwargs)
         self.p = iap.handle_probability_param(p, "p")

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -3380,8 +3380,8 @@ class PerspectiveTransform(meta.Augmenter):
         "constant": cv2.BORDER_CONSTANT
     }
 
-    def __init__(self, scale=0, cval=0, mode="constant", keep_size=True,
-                 fit_output=False, polygon_recoverer="auto",
+    def __init__(self, scale=(0.0, 0.06), cval=0, mode="constant",
+                 keep_size=True, fit_output=False, polygon_recoverer="auto",
                  seed=None, name=None, **old_kwargs):
         super(PerspectiveTransform, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1702,11 +1702,9 @@ class TranslateX(Affine):
     def __init__(self, percent=None, px=None, order=1,
                  cval=0, mode="constant", fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
-        # we don't test here if both are not-None at the same time, because
-        # that is already checked in Affine
-        assert percent is not None or px is not None, (
-            "Expected either `percent` to be not-None or "
-            "`px` to be not-None, but both were None.")
+        if percent is None and px is None:
+            percent = (-0.25, 0.25)
+
         super(TranslateX, self).__init__(
             translate_percent=({"x": percent} if percent is not None else None),
             translate_px=({"x": px} if px is not None else None),
@@ -1783,11 +1781,9 @@ class TranslateY(Affine):
     def __init__(self, percent=None, px=None, order=1,
                  cval=0, mode="constant", fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
-        # we don't test here if both are not-None at the same time, because
-        # that is already checked in Affine
-        assert percent is not None or px is not None, (
-            "Expected either `percent` to be not-None or "
-            "`px` to be not-None, but both were None.")
+        if percent is None and px is None:
+            percent = (-0.25, 0.25)
+
         super(TranslateY, self).__init__(
             translate_percent=({"y": percent} if percent is not None else None),
             translate_px=({"y": px} if px is not None else None),

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1845,7 +1845,7 @@ class Rotate(Affine):
 
     """
 
-    def __init__(self, rotate, order=1, cval=0, mode="constant",
+    def __init__(self, rotate=(-30, 30), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
         super(Rotate, self).__init__(

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1559,7 +1559,7 @@ class ScaleX(Affine):
 
     """
 
-    def __init__(self, scale, order=1, cval=0, mode="constant",
+    def __init__(self, scale=(0.5, 1.5), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
         super(ScaleX, self).__init__(
@@ -1624,7 +1624,7 @@ class ScaleY(Affine):
 
     """
 
-    def __init__(self, scale, order=1, cval=0, mode="constant",
+    def __init__(self, scale=(0.5, 1.5), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
         super(ScaleY, self).__init__(

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -5513,7 +5513,7 @@ class Jigsaw(meta.Augmenter):
 
     Parameters
     ----------
-    nb_rows : int or list of int or tuple of int or imgaug.parameters.StochasticParameter
+    nb_rows : int or list of int or tuple of int or imgaug.parameters.StochasticParameter, optional
         How many rows the jigsaw pattern should have.
 
             * If a single ``int``, then that value will be used for all images.
@@ -5524,7 +5524,7 @@ class Jigsaw(meta.Augmenter):
             * If ``StochasticParameter``, then that parameter is queried per
               image to sample the value to use.
 
-    nb_cols : int or list of int or tuple of int or imgaug.parameters.StochasticParameter
+    nb_cols : int or list of int or tuple of int or imgaug.parameters.StochasticParameter, optional
         How many cols the jigsaw pattern should have.
 
             * If a single ``int``, then that value will be used for all images.
@@ -5580,7 +5580,8 @@ class Jigsaw(meta.Augmenter):
 
     """
 
-    def __init__(self, nb_rows, nb_cols, max_steps=2, allow_pad=True,
+    def __init__(self, nb_rows=(3, 10), nb_cols=(3, 10), max_steps=1,
+                 allow_pad=True,
                  seed=None, name=None, **old_kwargs):
         super(Jigsaw, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -4690,7 +4690,7 @@ class Rot90(meta.Augmenter):
 
     """
 
-    def __init__(self, k, keep_size=True,
+    def __init__(self, k=1, keep_size=True,
                  seed=None, name=None, **old_kwargs):
         super(Rot90, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1149,12 +1149,23 @@ class Affine(meta.Augmenter):
 
     """
 
-    def __init__(self, scale=1.0, translate_percent=None, translate_px=None,
-                 rotate=0.0, shear=0.0, order=1, cval=0, mode="constant",
+    def __init__(self, scale=None, translate_percent=None, translate_px=None,
+                 rotate=None, shear=None, order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
         super(Affine, self).__init__(
             seed=seed, name=name, **old_kwargs)
+
+        params = [scale, translate_percent, translate_px, rotate, shear]
+        if all([p is None for p in params]):
+            scale = {"x": (0.9, 1.1), "y": (0.9, 1.1)}
+            translate_percent = {"x": (-0.1, 0.1), "y": (-0.1, 0.1)}
+            rotate = (-15, 15)
+            shear = {"x": (-10, 10), "y": (-10, 10)}
+        else:
+            scale = scale if scale is not None else 1.0
+            rotate = rotate if rotate is not None else 0.0
+            shear = shear if shear is not None else 0.0
 
         assert backend in ["auto", "skimage", "cv2"], (
             "Expected 'backend' to be \"auto\", \"skimage\" or \"cv2\", "

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -2852,8 +2852,9 @@ class PiecewiseAffine(meta.Augmenter):
 
     """
 
-    def __init__(self, scale=0, nb_rows=4, nb_cols=4, order=1, cval=0,
-                 mode="constant", absolute_scale=False, polygon_recoverer=None,
+    def __init__(self, scale=(0.0, 0.04), nb_rows=(2, 4), nb_cols=(2, 4),
+                 order=1, cval=0, mode="constant", absolute_scale=False,
+                 polygon_recoverer=None,
                  seed=None, name=None, **old_kwargs):
         super(PiecewiseAffine, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -4042,7 +4042,8 @@ class ElasticTransformation(meta.Augmenter):
         5: cv2.INTER_CUBIC
     }
 
-    def __init__(self, alpha=0, sigma=0, order=3, cval=0, mode="constant",
+    def __init__(self, alpha=(0.0, 40.0), sigma=(4.0, 8.0), order=3, cval=0,
+                 mode="constant",
                  polygon_recoverer="auto",
                  seed=None, name=None, **old_kwargs):
         super(ElasticTransformation, self).__init__(

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -1900,7 +1900,7 @@ class ShearX(Affine):
 
     """
 
-    def __init__(self, shear, order=1, cval=0, mode="constant",
+    def __init__(self, shear=(-30, 30), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
         super(ShearX, self).__init__(
@@ -1955,7 +1955,7 @@ class ShearY(Affine):
 
     """
 
-    def __init__(self, shear, order=1, cval=0, mode="constant",
+    def __init__(self, shear=(-30, 30), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None, **old_kwargs):
         super(ShearY, self).__init__(

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -1037,7 +1037,7 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(GaussianNoise, self).__init__(
             apply_gaussian_noise, severity,
@@ -1083,7 +1083,7 @@ class ShotNoise(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(ShotNoise, self).__init__(
             apply_shot_noise, severity,
@@ -1129,7 +1129,7 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(ImpulseNoise, self).__init__(
             apply_impulse_noise, severity,
@@ -1175,7 +1175,7 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(SpeckleNoise, self).__init__(
             apply_speckle_noise, severity,
@@ -1221,7 +1221,7 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(GaussianBlur, self).__init__(
             apply_gaussian_blur, severity,
@@ -1267,7 +1267,7 @@ class GlassBlur(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(GlassBlur, self).__init__(
             apply_glass_blur, severity,
@@ -1313,7 +1313,7 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(DefocusBlur, self).__init__(
             apply_defocus_blur, severity,
@@ -1359,7 +1359,7 @@ class MotionBlur(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(MotionBlur, self).__init__(
             apply_motion_blur, severity,
@@ -1405,7 +1405,7 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(ZoomBlur, self).__init__(
             apply_zoom_blur, severity,
@@ -1451,7 +1451,7 @@ class Fog(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Fog, self).__init__(
             apply_fog, severity,
@@ -1497,7 +1497,7 @@ class Frost(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Frost, self).__init__(
             apply_frost, severity,
@@ -1543,7 +1543,7 @@ class Snow(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Snow, self).__init__(
             apply_snow, severity,
@@ -1589,7 +1589,7 @@ class Spatter(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Spatter, self).__init__(
             apply_spatter, severity,
@@ -1635,7 +1635,7 @@ class Contrast(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Contrast, self).__init__(
             apply_contrast, severity,
@@ -1681,7 +1681,7 @@ class Brightness(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Brightness, self).__init__(
             apply_brightness, severity,
@@ -1727,7 +1727,7 @@ class Saturate(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Saturate, self).__init__(
             apply_saturate, severity,
@@ -1773,7 +1773,7 @@ class JpegCompression(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(JpegCompression, self).__init__(
             apply_jpeg_compression, severity,
@@ -1819,7 +1819,7 @@ class Pixelate(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(Pixelate, self).__init__(
             apply_pixelate, severity,
@@ -1865,7 +1865,7 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
 
     """
 
-    def __init__(self, severity=1,
+    def __init__(self, severity=(1, 5),
                  seed=None, name=None, **old_kwargs):
         super(ElasticTransform, self).__init__(
             apply_elastic_transform, severity,

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -628,7 +628,7 @@ class MedianPooling(_AbstractPoolingBase):
 
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
-    def __init__(self, kernel_size, keep_size=True,
+    def __init__(self, kernel_size=(1, 5), keep_size=True,
                  seed=None, name=None, **old_kwargs):
         super(MedianPooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -400,7 +400,7 @@ class MaxPooling(_AbstractPoolingBase):
 
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
-    def __init__(self, kernel_size, keep_size=True,
+    def __init__(self, kernel_size=(1, 5), keep_size=True,
                  seed=None, name=None, **old_kwargs):
         super(MaxPooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -514,7 +514,7 @@ class MinPooling(_AbstractPoolingBase):
 
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
-    def __init__(self, kernel_size, keep_size=True,
+    def __init__(self, kernel_size=(1, 5), keep_size=True,
                  seed=None, name=None, **old_kwargs):
         super(MinPooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -288,7 +288,7 @@ class AveragePooling(_AbstractPoolingBase):
 
     # TODO add floats as ksize denoting fractions of image sizes
     #      (note possible overlap with fractional kernel sizes here)
-    def __init__(self, kernel_size, keep_size=True,
+    def __init__(self, kernel_size=(1, 5), keep_size=True,
                  seed=None, name=None, **old_kwargs):
         super(AveragePooling, self).__init__(
             kernel_size=kernel_size, keep_size=keep_size,

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -743,7 +743,7 @@ class UniformVoronoi(Voronoi):
 
     """
 
-    def __init__(self, n_points, p_replace=1.0, max_size=128,
+    def __init__(self, n_points=(50, 500), p_replace=(0.5, 1.0), max_size=128,
                  interpolation="linear",
                  seed=None, name=None, **old_kwargs):
         super(UniformVoronoi, self).__init__(

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -199,8 +199,8 @@ class Superpixels(meta.Augmenter):
 
     """
 
-    def __init__(self, p_replace=0, n_segments=100, max_size=128,
-                 interpolation="linear",
+    def __init__(self, p_replace=(0.5, 1.0), n_segments=(50, 120),
+                 max_size=128, interpolation="linear",
                  seed=None, name=None, **old_kwargs):
         super(Superpixels, self).__init__(
             seed=seed, name=name, **old_kwargs)

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -929,8 +929,8 @@ class RelativeRegularGridVoronoi(Voronoi):
         In contrast to the other voronoi augmenters, this one uses
         ``None`` as the default value for `max_size`, i.e. the color averaging
         is always performed at full resolution. This enables the augmenter to
-        make most use of the added points for larger images. It does however
-        slow down the augmentation process.
+        make use of the additional points on larger images. It does
+        however slow down the augmentation process.
 
     Supported dtypes
     ----------------
@@ -1070,8 +1070,9 @@ class RelativeRegularGridVoronoi(Voronoi):
 
     """
 
-    def __init__(self, n_rows_frac, n_cols_frac, p_drop_points=0.4,
-                 p_replace=1.0, max_size=None, interpolation="linear",
+    def __init__(self, n_rows_frac=(0.05, 0.15), n_cols_frac=(0.05, 0.15),
+                 p_drop_points=(0.0, 0.5), p_replace=(0.5, 1.0),
+                 max_size=None, interpolation="linear",
                  seed=None, name=None, **old_kwargs):
         super(RelativeRegularGridVoronoi, self).__init__(
             points_sampler=DropoutPointsSampler(

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -897,7 +897,8 @@ class RegularGridVoronoi(Voronoi):
 
     """
 
-    def __init__(self, n_rows, n_cols, p_drop_points=0.4, p_replace=1.0,
+    def __init__(self, n_rows=(10, 30), n_cols=(10, 30),
+                 p_drop_points=(0.0, 0.5), p_replace=(0.5, 1.0),
                  max_size=128, interpolation="linear",
                  seed=None, name=None, **old_kwargs):
         super(RegularGridVoronoi, self).__init__(

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -2514,6 +2514,9 @@ class Crop(CropAndPad):
                 "Expected None or int or float or StochasticParameter or "
                 "list or tuple, got %s." % (type(value),))
 
+        if px is None and percent is None:
+            percent = (0.0, 0.1)
+
         px = recursive_negate(px)
         percent = recursive_negate(percent)
 

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -2337,6 +2337,9 @@ class Pad(CropAndPad):
                 "Expected None or int or float or StochasticParameter or "
                 "list or tuple, got %s." % (type(value),))
 
+        if px is None and percent is None:
+            percent = (0.0, 0.1)
+
         px = recursive_validate(px)
         percent = recursive_validate(percent)
 

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -1764,6 +1764,9 @@ class CropAndPad(meta.Augmenter):
         super(CropAndPad, self).__init__(
             seed=seed, name=name, **old_kwargs)
 
+        if px is None and percent is None:
+            percent = (-0.1, 0.1)
+
         self.mode, self.all_sides, self.top, self.right, self.bottom, \
             self.left = self._handle_px_and_percent_args(px, percent)
 

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -4822,13 +4822,10 @@ class TestCoarsePepper(unittest.TestCase):
             got_exception = True
         assert got_exception
 
-    def test_size_px_or_size_percent_not_none(self):
-        got_exception = False
-        try:
-            _ = iaa.CoarsePepper(p=0.5, size_px=None, size_percent=None)
-        except Exception:
-            got_exception = True
-        assert got_exception
+    def test___init___size_px_and_size_percent_both_none(self):
+        aug = iaa.CoarsePepper(p=0.5, size_px=None, size_percent=None)
+        assert np.isclose(aug.mask.size_px.a.value, 3)
+        assert np.isclose(aug.mask.size_px.b.value, 8)
 
     def test_heatmaps_dont_change(self):
         # test heatmaps (not affected by augmenter)

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -4705,13 +4705,10 @@ class TestCoarseSalt(unittest.TestCase):
             got_exception = True
         assert got_exception
 
-    def test_size_px_or_size_percent_not_none(self):
-        got_exception = False
-        try:
-            _ = iaa.CoarseSalt(p=0.5, size_px=None, size_percent=None)
-        except Exception:
-            got_exception = True
-        assert got_exception
+    def test___init___size_px_and_size_percent_both_none(self):
+        aug = iaa.CoarseSalt(p=0.5, size_px=None, size_percent=None)
+        assert np.isclose(aug.mask.size_px.a.value, 3)
+        assert np.isclose(aug.mask.size_px.b.value, 8)
 
     def test_heatmaps_dont_change(self):
         # test heatmaps (not affected by augmenter)

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -4587,12 +4587,10 @@ class TestCoarseSaltAndPepper(unittest.TestCase):
             got_exception = True
         assert got_exception
 
-        got_exception = False
-        try:
-            _ = iaa.CoarseSaltAndPepper(p=0.5, size_px=None, size_percent=None)
-        except Exception:
-            got_exception = True
-        assert got_exception
+    def test___init___size_px_and_size_percent_both_none(self):
+        aug = iaa.CoarseSaltAndPepper(p=0.5, size_px=None, size_percent=None)
+        assert np.isclose(aug.mask.size_px.a.value, 3)
+        assert np.isclose(aug.mask.size_px.b.value, 8)
 
     def test_heatmaps_dont_change(self):
         # test heatmaps (not affected by augmenter)

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -2472,9 +2472,9 @@ class TestDropout2d(unittest.TestCase):
         reseed()
 
     def test___init___defaults(self):
-        aug = iaa.Dropout2d(p=0)
+        aug = iaa.Dropout2d()
         assert isinstance(aug.p, iap.Binomial)
-        assert np.isclose(aug.p.p.value, 1.0)
+        assert np.isclose(aug.p.p.value, 1-0.1)
         assert aug.nb_keep_channels == 1
 
     def test___init___p_is_float(self):

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -2450,12 +2450,9 @@ class TestCoarseDropout(unittest.TestCase):
         assert got_exception
 
     def test___init___size_px_and_size_percent_both_none(self):
-        got_exception = False
-        try:
-            _ = iaa.CoarseDropout(p=0.5, size_px=None, size_percent=None)
-        except Exception:
-            got_exception = True
-        assert got_exception
+        aug = iaa.CoarseDropout(p=0.5, size_px=None, size_percent=None)
+        assert np.isclose(aug.mul.size_px.a.value, 3)
+        assert np.isclose(aug.mul.size_px.b.value, 8)
 
     def test_heatmaps_dont_change(self):
         # test heatmaps (not affected by augmenter)

--- a/test/augmenters/test_color.py
+++ b/test/augmenters/test_color.py
@@ -1335,8 +1335,7 @@ class TestRemoveSaturation(unittest.TestCase):
         multiply = aug.children[0].children[0]
         assert isinstance(multiply.mul, iap.Subtract)
         assert np.isclose(multiply.mul.other_param.value, 1.0)
-        assert np.isclose(multiply.mul.val.a.value, 0.0)
-        assert np.isclose(multiply.mul.val.b.value, 1.0)
+        assert np.isclose(multiply.mul.val.value, 1.0)
         assert aug.from_colorspace == iaa.CSPACE_RGB
 
     def test___init___custom(self):
@@ -1462,8 +1461,8 @@ class TestAddToHueAndSaturation(unittest.TestCase):
     def test___init___per_channel(self):
         aug = iaa.AddToHueAndSaturation(per_channel=0.5)
         assert aug.value is None
-        assert aug.value_hue is None
-        assert aug.value_saturation is None
+        assert aug.value_hue is not None
+        assert aug.value_saturation is not None
         assert isinstance(aug.per_channel, iap.Binomial)
         assert np.isclose(aug.per_channel.p.value, 0.5)
 

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -3122,9 +3122,9 @@ class TestTranslateX(unittest.TestCase):
         assert aug.fit_output is False
 
     def test___init___both_none(self):
-        with self.assertRaises(AssertionError) as ctx:
-            _aug = iaa.TranslateX()
-        assert "but both were None" in str(ctx.exception)
+        aug = iaa.TranslateX()
+        assert np.isclose(aug.translate[0].a.value, -0.25)
+        assert np.isclose(aug.translate[0].b.value, 0.25)
 
     def test_integrationtest_translate_percent(self):
         image = np.full((50, 50), 255, dtype=np.uint8)
@@ -3172,9 +3172,9 @@ class TestTranslateY(unittest.TestCase):
         assert aug.fit_output is False
 
     def test___init___both_none(self):
-        with self.assertRaises(AssertionError) as ctx:
-            _aug = iaa.TranslateY()
-        assert "but both were None" in str(ctx.exception)
+        aug = iaa.TranslateY()
+        assert np.isclose(aug.translate[1].a.value, -0.25)
+        assert np.isclose(aug.translate[1].b.value, 0.25)
 
     def test_integrationtest_translate_percent(self):
         image = np.full((50, 50), 255, dtype=np.uint8)
@@ -9714,7 +9714,7 @@ class TestJigsaw(unittest.TestCase):
         aug = iaa.Jigsaw(nb_rows=1, nb_cols=2)
         assert aug.nb_rows.value == 1
         assert aug.nb_cols.value == 2
-        assert aug.max_steps.value == 2
+        assert aug.max_steps.value == 1
         assert aug.allow_pad is True
 
     def test___init___custom(self):

--- a/test/augmenters/test_segmentation.py
+++ b/test/augmenters/test_segmentation.py
@@ -866,7 +866,6 @@ class TestRegularGridVoronoi(unittest.TestCase):
             seed=rs,
             name=None
         )
-        assert np.isclose(aug.points_sampler.p_drop.p.value, 1-0.4)
         assert aug.points_sampler.other_points_sampler.n_rows.value == 10
         assert isinstance(aug.points_sampler.other_points_sampler.n_cols,
                           iap.DiscreteUniform)
@@ -931,7 +930,6 @@ class TestRelativeRegularGridVoronoi(unittest.TestCase):
         )
 
         ps = aug.points_sampler
-        assert np.isclose(aug.points_sampler.p_drop.p.value, 1-0.4)
         assert np.isclose(ps.other_points_sampler.n_rows_frac.value, 0.1)
         assert isinstance(ps.other_points_sampler.n_cols_frac, iap.Uniform)
         assert np.isclose(ps.other_points_sampler.n_cols_frac.a.value, 0.1)


### PR DESCRIPTION
This should resolve #315.

**[breaking]** Most augmenters had previously default values that
made them equivalent to identify functions. Users had to explicitly
change the defaults to proper values in order to "activate"
augmentations. To simplify the usage of the library, the default
values of most augmenters were changed to medium-strength
augmentations. E.g.
`Sequential([Affine(), UniformVoronoi(), CoarseDropout()])`
should now produce decent augmentations.

A few augmenters were set to always-on, maximum-strength
augmentations. This is the case for:
* `Grayscale` (always fully grayscales images, use
  `Grayscale((0.0, 1.0))` for random strengths)
* `RemoveSaturation` (same as `Grayscale`)
* `Fliplr` (always flips images, use `Fliplr(0.5)` for 50%
  probability).
* `Flipud` (same as for `Fliplr`)
* `TotalDropout` (always drops everything, use
  `TotalDropout(0.1)` to drop everything for 10% of all images).
* `Invert` (always inverts images, use `Invert(0.1)` to invert
  10% of all images)
* `Rot90` (always rotates exactly once by 90 degrees,
  use `Rot90((0, 4))` for any rotation)
These settings seemed to better match user-expectations.
Such maximum-strength settings however were not chosen for all
augmenters. Some exceptions where one might expect that are e.g.
`Superpixels` (replaces only some superpixels with cellwise average
colors), `UniformVoronoi` (also only replaces some cells),
`Sharpen` (alpha-blends with variable strength, the same is
the case for `Emboss`, `EdgeDetect` and `DirectedEdgeDetect`)
and `CLAHE` (variable clip limits).

*Note*: Some of the new default values will cause issues with
non-`uint8` inputs.

*Note*: The defaults for `per_channel` and `keep_size` were not
adjusted. It is currently still the default behaviour of all
augmenters to affect all channels in the same way and to resize
their outputs back to the input sizes.

The changes to default values are listed below.

**imgaug.arithmetic**
  
  * `Add`
    * `value`: `0` -> `(-20, 20)`
  * `AddElementwise`
    * `value`: `0` -> `(-20, 20)`
  * `AdditiveGaussianNoise`
    * `scale`: `0` -> `(0, 15)`
  * `AdditiveLaplaceNoise`
    * `scale`: `0` -> `(0, 15)`
  * `AdditivePoissonNoise`
    * `scale`: `0` -> `(0, 15)`
  * `Multiply`
    * `mul`: `1.0` -> `(0.8, 1.2)`
  * `MultiplyElementwise`:
    * `mul`: `1.0` -> `(0.8, 1.2)`
  * `Dropout`: 
    * `p`: `0.0` -> `(0.0, 0.05)`
  * `CoarseDropout`:
    * `p`: `0.0` -> `(0.02, 0.1)`
    * `size_px`: `None` -> `(3, 8)`
    * `min_size`: `4` -> `3`
    * Default for `size_px` is only used if neither `size_percent`
      not `size_px` is provided by the user.
  * `CoarseSaltAndPepper`:
    * `p`: `0.0` -> `(0.02, 0.1)`
    * `size_px`: `None` -> `(3, 8)`
    * `min_size`: `4` -> `3`
    * Default for `size_px` is only used if neither `size_percent`
      not `size_px` is provided by the user.
  * `CoarseSalt`:
    * `p`: `0.0` -> `(0.02, 0.1)`
    * `size_px`: `None` -> `(3, 8)`
    * `min_size`: `4` -> `3`
    * Default for `size_px` is only used if neither `size_percent`
      not `size_px` is provided by the user.
  * `CoarsePepper`:
    * `p`: `0.0` -> `(0.02, 0.1)`
    * `size_px`: `None` -> `(3, 8)`
    * `min_size`: `4` -> `3`
    * Default for `size_px` is only used if neither `size_percent`
      not `size_px` is provided by the user.
  * `SaltAndPepper`:
    * `p`: `0.0` -> `(0.0, 0.03)`
  * `Salt`:
    * `p`: `0.0` -> `(0.0, 0.03)`
  * `Pepper`:
    * `p`: `0.0` -> `(0.0, 0.05)`
  * `ImpulseNoise`:
    * `p`: `0.0` -> `(0.0, 0.03)`
  * `Invert`: 
    * `p`: `0` -> `1`
  * `JpegCompression`:
    * `compression`: `50` -> `(0, 100)`

**imgaug.blend**

  * `BlendAlpha`
    * `factor`: `0` -> `(0.0, 1.0)`
  * `BlendAlphaElementwise`
    * `factor`: `0` -> `(0.0, 1.0)`

**imgaug.blur**

  * `GaussianBlur`:
    * `sigma`: `0` -> `(0.0, 3.0)`
  * `AverageBlur`:
    * `k`: `1` -> `(1, 7)`
  * `MedianBlur`:
    * `k`: `1` -> `(1, 7)`
  * `BilateralBlur`:
    * `d`: `1` -> `(1, 9)`
  * `MotionBlur`:
    * `k`: `5` -> `(3, 7)`

**imgaug.color**

  * `MultiplyHueAndSaturation`:
    * `mul_hue`: `None` -> `(0.5, 1.5)`
    * `mul_saturation`: `None` -> `(0.0, 1.7)`
    * These defaults are only used if the user provided neither
      `mul` nor `mul_hue` nor `mul_saturation`.
  * `MultiplyHue`:
    * `mul`: `(-1.0, 1.0)` -> `(-3.0, 3.0)`
  * `AddToHueAndSaturation`:
    * `value_hue`: `None` -> `(-40, 40)`
    * `value_saturation`: `None` -> `(-40, 40)`
    * These defaults are only used if the user provided neither
      `value` nor `value_hue` nor `value_saturation`.
  * `Grayscale`:
    * `alpha`: `0` -> `1`

**imgaug.contrast**

  * `GammaContrast`:
    * `gamma`: `1` -> `(0.7, 1.7)` 
  * `SigmoidContrast`:
    * `gain`: `10` -> `(5, 6)`
    * `cutoff`: `0.5` -> `(0.3, 0.6)`
  * `LogContrast`:
    * `gain`: `1` -> `(0.4, 1.6)`
  * `LinearContrast`:
    * `alpha`: `1` -> `(0.6, 1.4)`
  * `AllChannelsCLAHE`:
    * `clip_limit`: `40` -> `(0.1, 8)`
    * `tile_grid_size_px`: `8` -> `(3, 12)`
  * `CLAHE`: 
    * `clip_limit`: `40` -> `(0.1, 8)`
    * `tile_grid_size_px`: `8` -> `(3, 12)`

**convolutional**

  * `Sharpen`:
    * `alpha`: `0` -> `(0.0, 0.2)`
    * `lightness`: `1` -> `(0.8, 1.2)`
  * `Emboss`:
    * `alpha`: `0` -> `(0.0, 1.0)`
    * `strength`: `1` -> `(0.25, 1.0)`
  * `EdgeDetect`:
    * `alpha`: `0` -> `(0.0, 0.75)`
  * `DirectedEdgeDetect`:
    * `alpha`: `0` -> `(0.0, 0.75)`

**imgaug.flip**

  * `Fliplr`:
    * `p`: `0` -> `1`
  * `Flipud`:
    * `p`: `0` -> `1`

**imgaug.geometric**

  * `Affine`:
    * `scale`: `1` -> `{"x": (0.9, 1.1), "y": (0.9, 1.1)}`
    * `translate_percent`: None -> `{"x": (-0.1, 0.1), "y": (-0.1, 0.1)}`
    * `rotate`: `0` -> `(-15, 15)`
    * `shear`: `0` -> `shear={"x": (-10, 10), "y": (-10, 10)}`
    * These defaults are only used if no affine transformation
      parameter was set by the user. Otherwise the not-set
      parameters default again towards the identity function.
  * `PiecewiseAffine`:
    * `scale`: `0` -> `(0.0, 0.04)`
    * `nb_rows`: `4` -> `(2, 4)`
    * `nb_cols`: `4` -> `(2, 4)`
  * `PerspectiveTransform`:
    * `scale`: `0` -> `(0.0, 0.06)`
  * `ElasticTransformation`:
    * `alpha`: `0` -> `(0.0, 40.0)`
    * `sigma`: `0` -> `(4.0, 8.0)`
  * `Rot90`:
    * `k`: `(no default)` -> `k=1`

**imgaug.pooling**

  * `AveragePooling`:
    * `k`: `(no default)` -> `(1, 5)`
  * `MaxPooling`:
    * `k`: `(no default)` -> `(1, 5)`
  * `MinPooling`:
    * `k`: `(no default)` -> `(1, 5)`
  * `MedianPooling`:
    * `k`: `(no default)` -> `(1, 5)`

**imgaug.segmentation**
 
  * `Superpixels`:
    * `p_replace`: `0.0` -> `(0.5, 1.0)`
    * `n_segments`: `100` -> `(50, 120)`
  * `UniformVoronoi`:
    * `n_points`: `(no default)` -> `(50, 500)`
    * `p_replace`: `1.0` -> `(0.5, 1.0)`.
  * `RegularGridVoronoi`:
    * `n_rows`: `(no default)` -> `(10, 30)`
    * `n_cols`: `(no default)` -> `(10, 30)`
    * `p_drop_points`: `0.4` -> `(0.0, 0.5)`
    * `p_replace`: `1.0` -> `(0.5, 1.0)`
  * `RelativeRegularGridVoronoi`: Changed defaults from
    * `n_rows_frac`: `(no default)` -> `(0.05, 0.15)`
    * `n_cols_frac`: `(no default)` -> `(0.05, 0.15)`
    * `p_drop_points`: `0.4` -> `(0.0, 0.5)`
    * `p_replace`: `1.0` -> `(0.5, 1.0)`

**imgaug.size**

  * `CropAndPad`:
    * `percent`: `None` -> `(-0.1, 0.1)`
    * This default is only used if the user has provided
      neither `px` nor `percent`.
  * `Pad`:
    * `percent`: `None` -> `(0.0, 0.1)`
    * This default is only used if the user has provided
      neither `px` nor `percent`.
  * `Crop`:
    * `percent`: `None` -> `(0.0, 0.1)`
    * This default is only used if the user has provided
      neither `px` nor `percent`.
