### PR TITLE
 Fix PerspectiveTransform not affecting RNG 

### DIFF
--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -2942,6 +2942,10 @@ class _AbstractColorQuantization(meta.Augmenter):
                 # TODO quite hacky to recover the sampled to_colorspace here
                 #      by accessing _draw_samples(). Would be better to have
                 #      an inverse augmentation method in ChangeColorspace.
+
+                # We use random_state.copy() in this method, but that is not
+                # expected to cause unchanged an random_state, because
+                # _augment_batch_() uses an un-copied one for _draw_samples()
                 cs = ChangeColorspace(
                     from_colorspace=self.from_colorspace,
                     to_colorspace=self.to_colorspace,

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -3461,6 +3461,12 @@ class PerspectiveTransform(meta.Augmenter):
                 type(mode),))
 
     def _augment_batch_(self, batch, random_state, parents, hooks):
+        # Advance once, because below we always use random_state.copy() and
+        # hence the sampling calls actually don't change random_state's state.
+        # Without this, every call of the augmenter would produce the same
+        # results.
+        random_state.advance_()
+
         samples_images = self._draw_samples(batch.get_rowwise_shapes(),
                                             random_state.copy())
 

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -5596,6 +5596,18 @@ class TestPerspectiveTransform(unittest.TestCase):
         same = np.sum(img_aug_mask == segmaps_aug_mask[:, :, 0])
         assert (same / img_aug_mask.size) >= 0.99
 
+    def test_consecutive_calls_produce_different_results(self):
+        # PerspectiveTransform works with random_state.copy(), so we
+        # test explicitly that it doesn't always use the same samples
+        aug = iaa.PerspectiveTransform((0.0, 0.2))
+        image = np.mod(np.arange(16*16), 255).astype(np.uint8).reshape((16, 16))
+        nb_same = 0
+        last_image = aug(image=image)
+        for _ in np.arange(100):
+            image_aug = aug(image=image)
+            nb_same += int(np.array_equal(image_aug, last_image))
+        assert nb_same <= 1
+
     def test_heatmaps_smaller_than_image_without_keep_size(self):
         # without keep_size, different heatmap size
         aug = iaa.PerspectiveTransform(scale=0.2, keep_size=False)


### PR DESCRIPTION
This patch fixes an issue in PerspectiveTransform, where
consecutive calls of the augmenter would not affect its
RNG. This would lead to every call producing the same outputs.

This issue should not have affected the 0.3.0 release.