### PR TITLE
Allow opencv-python as requirement if alread present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = """A library for image augmentation in machine learning exper
 neural networks. Supports the augmentation of images, keypoints/landmarks, bounding boxes, heatmaps and segmentation
 maps in a variety of different ways."""
 
-install_requires = [
+INSTALL_REQUIRES = [
     "six",
     "numpy>=1.15",
     "scipy",
@@ -19,7 +19,7 @@ install_requires = [
     "Shapely",
 ]
 
-alternative_install_requires = {"opencv-python-headless": "opencv-python"}
+ALT_INSTALL_REQUIRES = {"opencv-python-headless": "opencv-python"}
 
 
 def check_alternative_installation(install_require, alternative_install_require):
@@ -48,7 +48,7 @@ def get_install_requirements(main_requires, alternative_requires):
     return new_install_requires
 
 
-install_requires = get_install_requirements(install_requires, alternative_install_requires)
+INSTALL_REQUIRES = get_install_requirements(INSTALL_REQUIRES, ALT_INSTALL_REQUIRES)
 
 setup(
     name="imgaug",
@@ -57,7 +57,7 @@ setup(
     author_email="kontakt@ajung.name",
     url="https://github.com/aleju/imgaug",
     download_url="https://github.com/aleju/imgaug/archive/0.3.0.tar.gz",
-    install_requires=install_requires,
+    install_requires=INSTALL_REQUIRES,
     packages=find_packages(),
     include_package_data=True,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# pylint: disable=C0114
 import re
 
 from pkg_resources import get_distribution, DistributionNotFound

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,54 @@
+import re
+
+from pkg_resources import get_distribution, DistributionNotFound
 from setuptools import setup, find_packages
 
 long_description = """A library for image augmentation in machine learning experiments, particularly convolutional
 neural networks. Supports the augmentation of images, keypoints/landmarks, bounding boxes, heatmaps and segmentation
 maps in a variety of different ways."""
+
+install_requires = [
+    "six",
+    "numpy>=1.15",
+    "scipy",
+    "Pillow",
+    "matplotlib",
+    "scikit-image>=0.14.2",
+    "opencv-python-headless",
+    "imageio",
+    "Shapely",
+]
+
+alternative_install_requires = {"opencv-python-headless": "opencv-python"}
+
+
+def check_alternative_installation(install_require, alternative_install_require):
+    """If some version version of alternative requirement installed, return alternative,
+    else return main.
+    """
+    try:
+        alternative_pkg_name = re.split(r"[!<>=]", alternative_install_require)[0]
+        get_distribution(alternative_pkg_name)
+    except DistributionNotFound:
+        return install_require
+
+    return str(alternative_install_require)
+
+
+def get_install_requirements(main_requires, alternative_requires):
+    """Iterates over all install requires
+    If an install require has an alternative option, check if this option is installed
+    If that is the case, replace the install require by the alternative to not install dual package"""
+    new_install_requires = []
+    for main_require in main_requires:
+        if main_require in alternative_requires.keys():
+            main_require = check_alternative_installation(main_require, alternative_requires.get(main_require))
+        new_install_requires.append(main_require)
+
+    return new_install_requires
+
+
+install_requires = get_install_requirements(install_requires, alternative_install_requires)
 
 setup(
     name="imgaug",
@@ -11,17 +57,7 @@ setup(
     author_email="kontakt@ajung.name",
     url="https://github.com/aleju/imgaug",
     download_url="https://github.com/aleju/imgaug/archive/0.3.0.tar.gz",
-    install_requires=[
-        "six",
-        "numpy>=1.15",
-        "scipy",
-        "Pillow",
-        "matplotlib",
-        "scikit-image>=0.14.2",
-        "opencv-python-headless",
-        "imageio",
-        "Shapely",
-    ],
+    install_requires=install_requires,
     packages=find_packages(),
     include_package_data=True,
     package_data={


### PR DESCRIPTION
Referencing https://github.com/aleju/imgaug/issues/473

This is a proposal, heavily inspired by [a similar solution in albumentations](https://github.com/albumentations-team/albumentations/blob/master/setup.py) that checks if `opencv-python` is installed when listing requirements and replaces `opencv-python-headless` if this is the case.

This is not the most "elegant" alternative, however I don't know any solution without resorting to extra requires and mandating the installation of imgaug with `pip install imgaug[opencv-python]` or `pip install imgaug[opencv-python-headless]`

Maybe extra_require installation would be preferred ? If so I can submit the PR again