### PR TITLE
Fix outdated class name in error message

### DIFF
--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -2225,8 +2225,8 @@ class Affine(geometric.Affine):
     def _augment_batch_(self, batch, random_state, parents, hooks):
         cols = batch.get_column_names()
         assert len(cols) == 0 or (len(cols) == 1 and "images" in cols), (
-            "PILAffine can currently only process image data. Got a batch "
-            "containing: %s. Use imgaug.augmenters.geometric.Affine for "
+            "pillike.Affine can currently only process image data. Got a "
+            "batch containing: %s. Use imgaug.augmenters.geometric.Affine for "
             "batches containing non-image data." % (", ".join(cols),))
 
         return super(Affine, self)._augment_batch_(


### PR DESCRIPTION
`pillike.Affine` used an the outdated classname `PILAffine` in
one of its error messages. It should be `pillike.Affine`.
This patch fixes the issue.