### PR TITLE
Fix KeepSizeByResize crashing

### DIFF
--- a/changelogs/master/fixed/20200122_fix_keepsizebyresize.md
+++ b/changelogs/master/fixed/20200122_fix_keepsizebyresize.md
@@ -1,0 +1,3 @@
+* Fixed `KeepSizeByResize` potentially crashing if a single numpy array
+  was provided as the input for an iterable of images (as opposed to
+  a list of numpy arrays). #590

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -4479,7 +4479,9 @@ class KeepSizeByResize(meta.Augmenter):
             # note here that NO_RESIZE can have led to different shapes
             nb_shapes = len({image.shape for image in result})
             if nb_shapes == 1:
-                result = np.array(result, dtype=images.dtype)
+                # images.dtype does not necessarily work anymore, children
+                # might have turned 'images' into list
+                result = np.array(result, dtype=result[0].dtype)
 
         return result
 

--- a/test/augmenters/test_size.py
+++ b/test/augmenters/test_size.py
@@ -6707,6 +6707,17 @@ class TestKeepSizeByResize(unittest.TestCase):
         assert observed.dtype.type == np.uint8
         assert np.allclose(observed, expected)
 
+    def test_images_input_is_single_array(self):
+        # input is single array, children turn in into list of arrays()
+        # => must be combined to a single output array
+        images = np.zeros((10, 100, 100), dtype=np.uint8)
+        aug = iaa.KeepSizeByResize(iaa.Crop((0, 40), keep_size=False))
+
+        images_aug = aug(images=images)
+
+        assert images.dtype.name == "uint8"
+        assert images.shape == (10, 100, 100)
+
     def test_keypoints_interpolation_is_cubic(self):
         aug = iaa.KeepSizeByResize(self.children, interpolation="cubic")
         kpsoi = self.kpsoi


### PR DESCRIPTION
This patch fixes `KeepSizeByResize` potentially crashing if a
single numpy array was provided as the input for an iterable
of images (as opposed to a list of numpy arrays).