### PR TITLE
Mark BatchInAugmentation as private

### DIFF
--- a/imgaug/augmentables/batches.py
+++ b/imgaug/augmentables/batches.py
@@ -423,11 +423,11 @@ class Batch(object):
         return self
 
     def to_batch_in_augmentation(self):
-        """Convert this batch to a :class:`BatchInAugmentation` instance.
+        """Convert this batch to a :class:`_BatchInAugmentation` instance.
 
         Returns
         -------
-        imgaug.augmentables.batches.BatchInAugmentation
+        imgaug.augmentables.batches._BatchInAugmentation
             The converted batch.
 
         """
@@ -437,7 +437,7 @@ class Batch(object):
                 return utils.copy_augmentables(var)
             return var
 
-        return BatchInAugmentation(
+        return _BatchInAugmentation(
             images=_copy(self.images_unaug),
             heatmaps=_copy(self.heatmaps_unaug),
             segmentation_maps=_copy(self.segmentation_maps_unaug),
@@ -454,7 +454,7 @@ class Batch(object):
 
         Parameters
         ----------
-        batch_in_augmentation : BatchInAugmentation
+        batch_in_augmentation : _BatchInAugmentation
             Batch of which to use the column values.
             The values are *not* copied. Only their references are used.
 
@@ -618,7 +618,7 @@ class _BatchInAugmentationPropagationContext(object):
                 self.batch.invert_apply_propagation_hooks_(self.noned_info)
 
 
-class BatchInAugmentation(object):
+class _BatchInAugmentation(object):
     """
     Class encapsulating a batch during the augmentation process.
 
@@ -654,7 +654,7 @@ class BatchInAugmentation(object):
     def __init__(self, images=None, heatmaps=None, segmentation_maps=None,
                  keypoints=None, bounding_boxes=None, polygons=None,
                  line_strings=None, data=None):
-        """Create a new :class:`BatchInAugmentation` instance."""
+        """Create a new :class:`_BatchInAugmentation` instance."""
         self.images = images
         self.heatmaps = heatmaps
         self.segmentation_maps = segmentation_maps
@@ -768,7 +768,7 @@ class BatchInAugmentation(object):
 
         Returns
         -------
-        BatchInAugmentation
+        _BatchInAugmentation
             Batch containing only a subselection of rows.
 
         """
@@ -785,13 +785,13 @@ class BatchInAugmentation(object):
                     rows = None
             kwargs[augm_name] = rows
 
-        return BatchInAugmentation(**kwargs)
+        return _BatchInAugmentation(**kwargs)
 
     def invert_subselect_rows_by_indices_(self, indices, batch_subselected):
         """Reverse the subselection of rows in-place.
 
         This is the inverse of
-        :func:`BatchInAugmentation.subselect_rows_by_indices`.
+        :func:`_BatchInAugmentation.subselect_rows_by_indices`.
 
         This method has to be executed on the batch *before* subselection.
 
@@ -800,21 +800,21 @@ class BatchInAugmentation(object):
         indices : iterable of int
             Row indices that were selected. (This is the input to
 
-        batch_subselected : BatchInAugmentation
+        batch_subselected : _BatchInAugmentation
             The batch after
-            :func:`BatchInAugmentation.subselect_rows_by_indices` was called.
+            :func:`_BatchInAugmentation.subselect_rows_by_indices` was called.
 
         Returns
         -------
-        BatchInAugmentation
+        _BatchInAugmentation
             The updated batch. (Modified in-place.)
 
         Examples
         --------
         >>> import numpy as np
-        >>> from imgaug.augmentables.batches import BatchInAugmentation
+        >>> from imgaug.augmentables.batches import _BatchInAugmentation
         >>> images = np.zeros((2, 10, 20, 3), dtype=np.uint8)
-        >>> batch = BatchInAugmentation(images=images)
+        >>> batch = _BatchInAugmentation(images=images)
         >>> batch_sub = batch.subselect_rows_by_indices([0])
         >>> batch_sub.images += 1
         >>> batch = batch.invert_subselect_rows_by_indices_([0], batch_sub)
@@ -903,7 +903,7 @@ class BatchInAugmentation(object):
             Each tuple contains
             ``(column attribute name, column value before setting it to None)``.
             This information is required when calling
-            :func:`BatchInAugmentation.invert_apply_propagation_hooks_`.
+            :func:`_BatchInAugmentation.invert_apply_propagation_hooks_`.
 
         """
         if hooks is None:
@@ -923,7 +923,7 @@ class BatchInAugmentation(object):
         """Set columns from ``None`` back to their original values.
 
         This is the inverse of
-        :func:`BatchInAugmentation.apply_propagation_hooks_`.
+        :func:`_BatchInAugmentation.apply_propagation_hooks_`.
 
         This method works in-place.
 
@@ -932,11 +932,11 @@ class BatchInAugmentation(object):
         noned_info : list of tuple of str
             Information about which columns were set to ``None`` and their
             original values. This is the output of
-            :func:`BatchInAugmentation.apply_propagation_hooks_`.
+            :func:`_BatchInAugmentation.apply_propagation_hooks_`.
 
         Returns
         -------
-        BatchInAugmentation
+        _BatchInAugmentation
             The updated batch. (Modified in-place.)
 
         """
@@ -945,14 +945,14 @@ class BatchInAugmentation(object):
         return self
 
     def to_batch_in_augmentation(self):
-        """Convert this batch to a :class:`BatchInAugmentation` instance.
+        """Convert this batch to a :class:`_BatchInAugmentation` instance.
 
         This method simply returns the batch itself. It exists for consistency
         with the other batch classes.
 
         Returns
         -------
-        imgaug.augmentables.batches.BatchInAugmentation
+        imgaug.augmentables.batches._BatchInAugmentation
             The batch itself. (Not copied.)
 
         """
@@ -965,13 +965,13 @@ class BatchInAugmentation(object):
 
         Parameters
         ----------
-        batch_in_augmentation : BatchInAugmentation
+        batch_in_augmentation : _BatchInAugmentation
             Batch of which to use the column values.
             The values are *not* copied. Only their references are used.
 
         Returns
         -------
-        BatchInAugmentation
+        _BatchInAugmentation
             The updated batch. (Modified in-place.)
 
         """
@@ -1002,7 +1002,7 @@ class BatchInAugmentation(object):
         -------
         imgaug.augmentables.batches.Batch
             Batch, with original unaugmented inputs from `batch_before_aug`
-            and augmented outputs from this :class:`BatchInAugmentation`
+            and augmented outputs from this :class:`_BatchInAugmentation`
             instance.
 
         """
@@ -1030,11 +1030,11 @@ class BatchInAugmentation(object):
 
         Returns
         -------
-        BatchInAugmentation
+        _BatchInAugmentation
             Deep copy of this batch.
 
         """
-        batch = BatchInAugmentation(data=utils.deepcopy_fast(self.data))
+        batch = _BatchInAugmentation(data=utils.deepcopy_fast(self.data))
 
         for augm_name in _AUGMENTABLE_NAMES:
             value = getattr(self, augm_name)

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -2181,7 +2181,7 @@ class IBatchwiseMaskGenerator(object):
 
         Parameters
         ----------
-        batch : imgaug.augmentables.batches.BatchInAugmentation
+        batch : imgaug.augmentables.batches._BatchInAugmentation
             Shape of the mask to sample.
 
         random_state : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -26,7 +26,7 @@ from . import meta
 from . import color as color_lib
 from .. import parameters as iap
 from .. import dtypes as iadt
-from ..augmentables import batches as iabatches
+from ..augmentables.batches import _BatchInAugmentation
 
 
 class _ContrastFuncWrapper(meta.Augmenter):
@@ -1238,7 +1238,8 @@ class CLAHE(meta.Augmenter):
                                         random_state_derived):
             # pylint: disable=protected-access
             # TODO would .augment_batch() be sufficient here?
-            batch_imgs = iabatches.BatchInAugmentation(images=images_normalized)
+            batch_imgs = _BatchInAugmentation(
+                images=images_normalized)
             return self.all_channel_clahe._augment_batch_(
                 batch_imgs, random_state_derived, parents + [self],
                 hooks
@@ -1491,7 +1492,8 @@ class HistogramEqualization(meta.Augmenter):
                                                          random_state_derived):
             # pylint: disable=protected-access
             # TODO would .augment_batch() be sufficient here
-            batch_imgs = iabatches.BatchInAugmentation(images=images_normalized)
+            batch_imgs = _BatchInAugmentation(
+                images=images_normalized)
             return self.all_channel_histogram_equalization._augment_batch_(
                 batch_imgs, random_state_derived, parents + [self],
                 hooks

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -907,7 +907,7 @@ class _IImageDestination(object):
 
         Parameters
         ----------
-        batch : imgaug.augmentables.batches.BatchInAugmentation
+        batch : imgaug.augmentables.batches._BatchInAugmentation
             A batch to which the next ``receive()`` call may correspond.
 
         """
@@ -968,7 +968,7 @@ class _IBatchwiseSchedule(object):
 
         Parameters
         ----------
-        batch : BatchInAugmentation
+        batch : _BatchInAugmentation
             Batch for which to evaluate the condition.
 
         Returns

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -35,7 +35,7 @@ import six.moves as sm
 
 import imgaug as ia
 from imgaug.augmentables.batches import (Batch, UnnormalizedBatch,
-                                         BatchInAugmentation)
+                                         _BatchInAugmentation)
 from .. import parameters as iap
 from .. import random as iarandom
 
@@ -559,14 +559,14 @@ class Augmenter(object):
 
         Parameters
         ----------
-        batch : imgaug.augmentables.batches.Batch or imgaug.augmentables.batches.UnnormalizedBatch or imgaug.augmentables.batch.BatchInAugmentation
+        batch : imgaug.augmentables.batches.Batch or imgaug.augmentables.batches.UnnormalizedBatch or imgaug.augmentables.batch._BatchInAugmentation
             A single batch to augment.
 
             If :class:`imgaug.augmentables.batches.UnnormalizedBatch`
             or :class:`imgaug.augmentables.batches.Batch`, then the ``*_aug``
             attributes may be modified in-place, while the ``*_unaug``
             attributes will not be modified.
-            If :class:`imgaug.augmentables.batches.BatchInAugmentation`,
+            If :class:`imgaug.augmentables.batches._BatchInAugmentation`,
             then all attributes may be modified in-place.
 
         parents : None or list of imgaug.augmenters.Augmenter, optional
@@ -586,11 +586,11 @@ class Augmenter(object):
         """
         # this chain of if/elses would be more beautiful if it was
         # (1st) UnnormalizedBatch, (2nd) Batch, (3rd) BatchInAugmenation.
-        # We check for BatchInAugmentation first as it is expected to be the
+        # We check for _BatchInAugmentation first as it is expected to be the
         # most common input (due to child calls).
         batch_unnorm = None
         batch_norm = None
-        if isinstance(batch, BatchInAugmentation):
+        if isinstance(batch, _BatchInAugmentation):
             batch_inaug = batch
         elif isinstance(batch, UnnormalizedBatch):
             batch_unnorm = batch
@@ -601,7 +601,7 @@ class Augmenter(object):
             batch_inaug = batch_norm.to_batch_in_augmentation()
         else:
             raise ValueError(
-                "Expected UnnormalizedBatch, Batch or BatchInAugmentation, "
+                "Expected UnnormalizedBatch, Batch or _BatchInAugmentation, "
                 "got %s." % (type(batch).__name__,))
 
         columns = batch_inaug.columns
@@ -684,7 +684,7 @@ class Augmenter(object):
 
         Parameters
         ----------
-        batch : imgaug.augmentables.batches.BatchInAugmentation
+        batch : imgaug.augmentables.batches._BatchInAugmentation
             The normalized batch to augment. May be changed in-place.
 
         random_state : imgaug.random.RNG
@@ -699,7 +699,7 @@ class Augmenter(object):
 
         Returns
         ----------
-        imgaug.augmentables.batches.BatchInAugmentation
+        imgaug.augmentables.batches._BatchInAugmentation
             The augmented batch.
 
         """

--- a/test/augmentables/test_batches.py
+++ b/test/augmentables/test_batches.py
@@ -20,6 +20,7 @@ import numpy as np
 import imgaug as ia
 import imgaug.augmenters as iaa
 from imgaug.testutils import reseed
+from imgaug.augmentables.batches import _BatchInAugmentation
 
 
 ATTR_NAMES = ["images", "heatmaps", "segmentation_maps", "keypoints",
@@ -270,7 +271,7 @@ class TestBatch(unittest.TestCase):
 
         batch_inaug = batch.to_batch_in_augmentation()
 
-        assert isinstance(batch_inaug, ia.BatchInAugmentation)
+        assert isinstance(batch_inaug, _BatchInAugmentation)
         assert ia.is_np_array(batch_inaug.images)
         assert batch_inaug.images.shape == (1, 2, 2, 3)
         assert batch_inaug.get_column_names() == ["images"]
@@ -318,7 +319,7 @@ class TestBatch(unittest.TestCase):
 
         batch_inaug = batch.to_batch_in_augmentation()
 
-        assert isinstance(batch_inaug, ia.BatchInAugmentation)
+        assert isinstance(batch_inaug, _BatchInAugmentation)
         assert ia.is_np_array(batch_inaug.images)
         assert batch_inaug.images.shape == (1, 2, 2, 3)
         assert isinstance(batch_inaug.heatmaps[0], ia.HeatmapsOnImage)
@@ -335,7 +336,7 @@ class TestBatch(unittest.TestCase):
 
     def test_fill_from_batch_in_augmentation(self):
         batch = ia.Batch(images=1)
-        batch_inaug = ia.BatchInAugmentation(
+        batch_inaug = _BatchInAugmentation(
             images=2,
             heatmaps=3,
             segmentation_maps=4,
@@ -479,9 +480,9 @@ class TestBatch(unittest.TestCase):
 # TODO test __init__
 #      test apply_propagation_hooks_
 #      test invert_apply_propagation_hooks_
-class TestBatchInAugmentation(unittest.TestCase):
+class Test_BatchInAugmentation(unittest.TestCase):
     def test_empty__all_columns_none(self):
-        batch = ia.BatchInAugmentation()
+        batch = _BatchInAugmentation()
         assert batch.empty
 
     def test_empty__with_columns_set(self):
@@ -495,15 +496,15 @@ class TestBatchInAugmentation(unittest.TestCase):
             {"line_strings": [8]}
         ]
         for kwargs_i in kwargs:
-            batch = ia.BatchInAugmentation(**kwargs_i)
+            batch = _BatchInAugmentation(**kwargs_i)
             assert not batch.empty
 
     def test_nb_rows__when_empty(self):
-        batch = ia.BatchInAugmentation()
+        batch = _BatchInAugmentation()
         assert batch.nb_rows == 0
 
     def test_nb_rows__with_empty_column(self):
-        batch = ia.BatchInAugmentation(images=[])
+        batch = _BatchInAugmentation(images=[])
         assert batch.nb_rows == 0
 
     def test_nb_rows__with_columns_set(self):
@@ -517,19 +518,19 @@ class TestBatchInAugmentation(unittest.TestCase):
             {"line_strings": [0]}
         ]
         for kwargs_i in kwargs:
-            batch = ia.BatchInAugmentation(**kwargs_i)
+            batch = _BatchInAugmentation(**kwargs_i)
             assert batch.nb_rows == 1
 
     def test_nb_rows__with_two_columns(self):
-        batch = ia.BatchInAugmentation(images=[0, 0], keypoints=[0, 0])
+        batch = _BatchInAugmentation(images=[0, 0], keypoints=[0, 0])
         assert batch.nb_rows == 2
 
     def test_columns__when_empty(self):
-        batch = ia.BatchInAugmentation()
+        batch = _BatchInAugmentation()
         assert len(batch.columns) == 0
 
     def test_columns__with_empty_column(self):
-        batch = ia.BatchInAugmentation(images=[])
+        batch = _BatchInAugmentation(images=[])
 
         columns = batch.columns
 
@@ -546,13 +547,13 @@ class TestBatchInAugmentation(unittest.TestCase):
             {"line_strings": [0]}
         ]
         for kwargs_i in kwargs:
-            batch = ia.BatchInAugmentation(**kwargs_i)
+            batch = _BatchInAugmentation(**kwargs_i)
             columns = batch.columns
             assert len(columns) == 1
             assert columns[0].name == list(kwargs_i.keys())[0]
 
     def test_columns__with_two_columns(self):
-        batch = ia.BatchInAugmentation(images=[0, 0], keypoints=[1, 1])
+        batch = _BatchInAugmentation(images=[0, 0], keypoints=[1, 1])
 
         columns = batch.columns
 
@@ -563,16 +564,16 @@ class TestBatchInAugmentation(unittest.TestCase):
         assert columns[1].value == [1, 1]
 
     def test_get_column_names__with_two_columns(self):
-        batch = ia.BatchInAugmentation(images=[0, 0], keypoints=[1, 1])
+        batch = _BatchInAugmentation(images=[0, 0], keypoints=[1, 1])
         assert batch.get_column_names() == ["images", "keypoints"]
 
     def test_get_rowwise_shapes__images_is_single_array(self):
-        batch = ia.BatchInAugmentation(images=np.zeros((2, 3, 4, 1)))
+        batch = _BatchInAugmentation(images=np.zeros((2, 3, 4, 1)))
         shapes = batch.get_rowwise_shapes()
         assert shapes == [(3, 4, 1), (3, 4, 1)]
 
     def test_get_rowwise_shapes__images_is_multiple_arrays(self):
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=[np.zeros((3, 4, 1)), np.zeros((4, 5, 1))]
         )
         shapes = batch.get_rowwise_shapes()
@@ -622,12 +623,12 @@ class TestBatchInAugmentation(unittest.TestCase):
             {"line_strings": line_strings}
         ]
         for kwargs_i in kwargs:
-            batch = ia.BatchInAugmentation(**kwargs_i)
+            batch = _BatchInAugmentation(**kwargs_i)
             shapes = batch.get_rowwise_shapes()
             assert shapes == [(1, 2, 3)]
 
     def test_subselect_rows_by_indices__none_selected(self):
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=np.zeros((3, 3, 4, 1)),
             keypoints=[
                 ia.KeypointsOnImage(
@@ -651,7 +652,7 @@ class TestBatchInAugmentation(unittest.TestCase):
         assert batch_sub.keypoints is None
 
     def test_subselect_rows_by_indices__two_of_three_selected(self):
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=np.zeros((3, 3, 4, 1)),
             keypoints=[
                 ia.KeypointsOnImage(
@@ -682,7 +683,7 @@ class TestBatchInAugmentation(unittest.TestCase):
         images[0, ...] = 0
         images[1, ...] = 1
         images[2, ...] = 2
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=images,
             keypoints=[
                 ia.KeypointsOnImage(
@@ -719,7 +720,7 @@ class TestBatchInAugmentation(unittest.TestCase):
         images[0, ...] = 0
         images[1, ...] = 1
         images[2, ...] = 2
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=images,
             keypoints=[
                 ia.KeypointsOnImage(
@@ -763,7 +764,7 @@ class TestBatchInAugmentation(unittest.TestCase):
 
         hooks = ia.HooksImages(propagator=propagator)
 
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=np.zeros((3, 3, 4, 1), dtype=np.uint8),
             keypoints=[
                 ia.KeypointsOnImage(
@@ -794,13 +795,13 @@ class TestBatchInAugmentation(unittest.TestCase):
         assert batch.keypoints[0].keypoints[0].x == 10
 
     def test_to_batch_in_augmentation(self):
-        batch = ia.BatchInAugmentation(images=1)
+        batch = _BatchInAugmentation(images=1)
         batch_inaug = batch.to_batch_in_augmentation()
         assert batch_inaug is batch
 
     def test_fill_from_batch_in_augmentation(self):
-        batch = ia.BatchInAugmentation(images=1)
-        batch_inaug = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(images=1)
+        batch_inaug = _BatchInAugmentation(
             images=2,
             heatmaps=3,
             segmentation_maps=4,
@@ -830,7 +831,7 @@ class TestBatchInAugmentation(unittest.TestCase):
         batch_before_aug.polygons_unaug = 5
         batch_before_aug.line_strings_unaug = 6
 
-        batch_inaug = ia.BatchInAugmentation(
+        batch_inaug = _BatchInAugmentation(
             images=10,
             heatmaps=20,
             segmentation_maps=30,
@@ -859,7 +860,7 @@ class TestBatchInAugmentation(unittest.TestCase):
         assert batch.line_strings_aug == 70
 
     def test_deepcopy(self):
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=np.full((1,), 0, dtype=np.uint8),
             heatmaps=np.full((1,), 1, dtype=np.uint8),
             segmentation_maps=np.full((1,), 2, dtype=np.uint8),

--- a/test/augmenters/test_blend.py
+++ b/test/augmenters/test_blend.py
@@ -32,6 +32,7 @@ from imgaug.testutils import (
     runtest_pickleable_uint8_img)
 from imgaug.augmentables.heatmaps import HeatmapsOnImage
 from imgaug.augmentables.segmaps import SegmentationMapsOnImage
+from imgaug.augmentables.batches import _BatchInAugmentation
 
 
 class Test_blend_alpha(unittest.TestCase):
@@ -2222,7 +2223,7 @@ class TestBlendAlphaBoundingBoxes(unittest.TestCase):
 class TestStochasticParameterMaskGen(unittest.TestCase):
     @classmethod
     def _test_draw_masks_nhwc(cls, shape):
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             images=np.zeros(shape, dtype=np.uint8)
         )
         values = np.float32([
@@ -2251,7 +2252,7 @@ class TestStochasticParameterMaskGen(unittest.TestCase):
         bb = ia.BoundingBox(x1=1, y1=2, x2=3, y2=4)
         bbsoi1 = ia.BoundingBoxesOnImage([bb], shape=(2, 3, 3))
         bbsoi2 = ia.BoundingBoxesOnImage([], shape=(3, 3, 3))
-        batch = ia.BatchInAugmentation(
+        batch = _BatchInAugmentation(
             bounding_boxes=[bbsoi1, bbsoi2]
         )
         # sampling for shape of bbsoi1 will cover row1 and row2, then
@@ -2276,7 +2277,7 @@ class TestStochasticParameterMaskGen(unittest.TestCase):
 
     def test_per_channel(self):
         for per_channel in [True, iap.Deterministic(0.51)]:
-            batch = ia.BatchInAugmentation(
+            batch = _BatchInAugmentation(
                 images=np.zeros((1, 2, 3, 2), dtype=np.uint8)
             )
             values = np.float32([
@@ -2308,7 +2309,7 @@ class TestStochasticParameterMaskGen(unittest.TestCase):
         for per_channel in [False, True]:
             for shape in shapes:
                 with self.subTest(per_channel=per_channel, shape=shape):
-                    batch = ia.BatchInAugmentation(
+                    batch = _BatchInAugmentation(
                         images=[np.zeros(shape, dtype=np.uint8)]
                     )
                     param = iap.Deterministic(1.0)
@@ -2364,7 +2365,7 @@ class TestSomeColorsMaskGen(unittest.TestCase):
             [128, 128, 255]
         ]).reshape((9, 1, 3))
         image = np.tile(image, (9, 50, 1))
-        batch = ia.BatchInAugmentation(images=[image])
+        batch = _BatchInAugmentation(images=[image])
         gen = iaa.SomeColorsMaskGen(nb_bins=256, smoothness=0,
                                     alpha=[0, 1])
         expected_mask_sums = np.arange(1 + image.shape[0]) * image.shape[1]
@@ -2401,7 +2402,7 @@ class TestSomeColorsMaskGen(unittest.TestCase):
             [128, 255, 128],
             [128, 128, 255]
         ]).reshape((1, 9, 3))
-        batch = ia.BatchInAugmentation(images=[image])
+        batch = _BatchInAugmentation(images=[image])
         gen = iaa.SomeColorsMaskGen(alpha=0.0)
 
         mask = gen.draw_masks(batch)[0]
@@ -2420,7 +2421,7 @@ class TestSomeColorsMaskGen(unittest.TestCase):
             [128, 255, 128],
             [128, 128, 255]
         ]).reshape((1, 9, 3))
-        batch = ia.BatchInAugmentation(images=[image])
+        batch = _BatchInAugmentation(images=[image])
         gen = iaa.SomeColorsMaskGen(alpha=1.0)
 
         mask = gen.draw_masks(batch)[0]
@@ -2440,7 +2441,7 @@ class TestSomeColorsMaskGen(unittest.TestCase):
             [128, 255, 128],
             [128, 128, 255]
         ]).reshape((1, 9, 3))
-        batch = ia.BatchInAugmentation(images=[image])
+        batch = _BatchInAugmentation(images=[image])
         mock_cc.return_value = np.copy(image)
         gen = iaa.SomeColorsMaskGen(alpha=1.0, from_colorspace=iaa.CSPACE_BGR)
 
@@ -2585,7 +2586,7 @@ class TestSomeColorsMaskGen(unittest.TestCase):
         for shape in shapes:
             with self.subTest(shape=shape):
                 image = np.zeros(shape, dtype=np.uint8)
-                batch = ia.BatchInAugmentation(images=[image])
+                batch = _BatchInAugmentation(images=[image])
                 gen = iaa.SomeColorsMaskGen()
 
                 mask = gen.draw_masks(batch)[0]
@@ -2596,7 +2597,7 @@ class TestSomeColorsMaskGen(unittest.TestCase):
     def test_batch_contains_no_images(self):
         hms = ia.HeatmapsOnImage(np.zeros((5, 5), dtype=np.float32),
                                  shape=(10, 10, 3))
-        batch = ia.BatchInAugmentation(heatmaps=[hms])
+        batch = _BatchInAugmentation(heatmaps=[hms])
         gen = iaa.SomeColorsMaskGen()
 
         with self.assertRaises(AssertionError):
@@ -2621,7 +2622,7 @@ class TestHorizontalLinearGradientMaskGen(unittest.TestCase):
     def test_draw_masks(self):
         image1 = np.zeros((5, 100, 3), dtype=np.uint8)
         image2 = np.zeros((7, 200, 3), dtype=np.uint8)
-        batch = ia.BatchInAugmentation(images=[image1, image2])
+        batch = _BatchInAugmentation(images=[image1, image2])
 
         gen = iaa.HorizontalLinearGradientMaskGen(min_value=0.1,
                                                   max_value=0.75,
@@ -2709,7 +2710,7 @@ class TestHorizontalLinearGradientMaskGen(unittest.TestCase):
         for shape in shapes:
             with self.subTest(shape=shape):
                 image = np.zeros(shape, dtype=np.uint8)
-                batch = ia.BatchInAugmentation(images=[image])
+                batch = _BatchInAugmentation(images=[image])
                 gen = iaa.HorizontalLinearGradientMaskGen()
 
                 mask = gen.draw_masks(batch)[0]
@@ -2720,7 +2721,7 @@ class TestHorizontalLinearGradientMaskGen(unittest.TestCase):
     def test_batch_contains_no_images(self):
         hms = ia.HeatmapsOnImage(np.zeros((5, 5), dtype=np.float32),
                                  shape=(10, 10, 3))
-        batch = ia.BatchInAugmentation(heatmaps=[hms])
+        batch = _BatchInAugmentation(heatmaps=[hms])
         gen = iaa.HorizontalLinearGradientMaskGen(min_value=0.25,
                                                   max_value=0.75,
                                                   start_at=0.5,
@@ -2753,7 +2754,7 @@ class TestVerticalLinearGradientMaskGen(unittest.TestCase):
         image2 = np.zeros((7, 200, 3), dtype=np.uint8)
         image1 = image1.transpose((1, 0, 2))
         image2 = image2.transpose((1, 0, 2))
-        batch = ia.BatchInAugmentation(images=[image1, image2])
+        batch = _BatchInAugmentation(images=[image1, image2])
 
         gen = iaa.VerticalLinearGradientMaskGen(min_value=0.1,
                                                 max_value=0.75,
@@ -2794,7 +2795,7 @@ class TestRegularGridMaskGen(unittest.TestCase):
             alpha=iap.DeterministicList([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7,
                                          0.8, 0.9, 1.0]))
         image = np.zeros((6, 8, 3), dtype=np.uint8)
-        batch = ia.BatchInAugmentation(images=[image, image])
+        batch = _BatchInAugmentation(images=[image, image])
 
         masks = gen.draw_masks(batch, random_state=1)
 
@@ -2820,7 +2821,7 @@ class TestRegularGridMaskGen(unittest.TestCase):
             nb_cols=2,
             alpha=[0.1, 0.9])
         image = np.zeros((2, 4, 3), dtype=np.uint8)
-        batch = ia.BatchInAugmentation(images=[image, image])
+        batch = _BatchInAugmentation(images=[image, image])
 
         expected1 = np.full((2, 4), 0.1, dtype=np.float32)
         expected2 = np.full((2, 4), 0.1, dtype=np.float32)
@@ -2979,7 +2980,7 @@ class TestRegularGridMaskGen(unittest.TestCase):
         for shape in shapes:
             with self.subTest(shape=shape):
                 image = np.zeros(shape, dtype=np.uint8)
-                batch = ia.BatchInAugmentation(images=[image])
+                batch = _BatchInAugmentation(images=[image])
                 gen = iaa.RegularGridMaskGen(2, 2)
 
                 mask = gen.draw_masks(batch)[0]
@@ -2990,7 +2991,7 @@ class TestRegularGridMaskGen(unittest.TestCase):
     def test_batch_contains_no_images(self):
         hms = ia.HeatmapsOnImage(np.zeros((5, 5), dtype=np.float32),
                                  shape=(6, 8, 3))
-        batch = ia.BatchInAugmentation(heatmaps=[hms])
+        batch = _BatchInAugmentation(heatmaps=[hms])
         gen = iaa.CheckerboardMaskGen(nb_rows=3, nb_cols=2)
         mask = gen.draw_masks(batch, random_state=1)[0]
 
@@ -3014,7 +3015,7 @@ class TestCheckerboardMaskGen(unittest.TestCase):
         gen = iaa.CheckerboardMaskGen(nb_rows=2,
                                       nb_cols=iap.DeterministicList([1, 4]))
         image = np.zeros((6, 8, 3), dtype=np.uint8)
-        batch = ia.BatchInAugmentation(images=[image, image])
+        batch = _BatchInAugmentation(images=[image, image])
 
         masks = gen.draw_masks(batch, random_state=1)
 
@@ -3123,7 +3124,7 @@ class TestCheckerboardMaskGen(unittest.TestCase):
         for shape in shapes:
             with self.subTest(shape=shape):
                 image = np.zeros(shape, dtype=np.uint8)
-                batch = ia.BatchInAugmentation(images=[image])
+                batch = _BatchInAugmentation(images=[image])
                 gen = iaa.CheckerboardMaskGen(2, 2)
 
                 mask = gen.draw_masks(batch)[0]
@@ -3134,7 +3135,7 @@ class TestCheckerboardMaskGen(unittest.TestCase):
     def test_batch_contains_no_images(self):
         hms = ia.HeatmapsOnImage(np.zeros((5, 5), dtype=np.float32),
                                  shape=(6, 8, 3))
-        batch = ia.BatchInAugmentation(heatmaps=[hms])
+        batch = _BatchInAugmentation(heatmaps=[hms])
         gen = iaa.CheckerboardMaskGen(nb_rows=3, nb_cols=2)
         mask = gen.draw_masks(batch, random_state=1)[0]
 
@@ -3175,7 +3176,7 @@ class TestSegMapClassIdsMaskGen(unittest.TestCase):
         segmap_arr[0, 0, 1] = 3
         segmap_arr[1, 1, 1] = 3
         segmap = ia.SegmentationMapsOnImage(segmap_arr, shape=(3, 2, 3))
-        batch = ia.BatchInAugmentation(segmentation_maps=[segmap])
+        batch = _BatchInAugmentation(segmentation_maps=[segmap])
         gen = iaa.SegMapClassIdsMaskGen([2, 3])
 
         mask = gen.draw_masks(batch, random_state=1)[0]
@@ -3196,7 +3197,7 @@ class TestSegMapClassIdsMaskGen(unittest.TestCase):
         segmap_arr[0, 0, 1] = 3
         segmap_arr[1, 1, 1] = 3
         segmap = ia.SegmentationMapsOnImage(segmap_arr, shape=(3, 2, 3))
-        batch = ia.BatchInAugmentation(segmentation_maps=[segmap])
+        batch = _BatchInAugmentation(segmentation_maps=[segmap])
         gen = iaa.SegMapClassIdsMaskGen([2, 3], nb_sample_classes=1)
 
         expected_class_2 = np.float32([
@@ -3285,7 +3286,7 @@ class TestSegMapClassIdsMaskGen(unittest.TestCase):
                     segmap_arr = np.zeros(segmap_shape, dtype=np.int32)
                     segmap = ia.SegmentationMapsOnImage(segmap_arr,
                                                         shape=image_shape)
-                    batch = ia.BatchInAugmentation(segmentation_maps=[segmap])
+                    batch = _BatchInAugmentation(segmentation_maps=[segmap])
 
                     gen = iaa.SegMapClassIdsMaskGen(1)
                     mask = gen.draw_masks(batch)[0]
@@ -3296,7 +3297,7 @@ class TestSegMapClassIdsMaskGen(unittest.TestCase):
     def test_batch_contains_no_segmaps(self):
         hms = ia.HeatmapsOnImage(np.zeros((5, 5), dtype=np.float32),
                                  shape=(10, 10, 3))
-        batch = ia.BatchInAugmentation(heatmaps=[hms])
+        batch = _BatchInAugmentation(heatmaps=[hms])
         gen = iaa.SegMapClassIdsMaskGen(class_ids=[1])
 
         with self.assertRaises(AssertionError):
@@ -3333,7 +3334,7 @@ class TestBoundingBoxesMaskGen(unittest.TestCase):
                ia.BoundingBox(x1=2, y1=2, x2=10, y2=10, label="bb3")]
         bbsoi = ia.BoundingBoxesOnImage(bbs, shape=(10, 14, 3))
 
-        batch = ia.BatchInAugmentation(bounding_boxes=[bbsoi])
+        batch = _BatchInAugmentation(bounding_boxes=[bbsoi])
         gen = iaa.BoundingBoxesMaskGen()
 
         mask = gen.draw_masks(batch, random_state=1)[0]
@@ -3352,7 +3353,7 @@ class TestBoundingBoxesMaskGen(unittest.TestCase):
                ia.BoundingBox(x1=2, y1=2, x2=10, y2=10, label="bb3")]
         bbsoi = ia.BoundingBoxesOnImage(bbs, shape=(10, 14, 3))
 
-        batch = ia.BatchInAugmentation(bounding_boxes=[bbsoi])
+        batch = _BatchInAugmentation(bounding_boxes=[bbsoi])
         gen = iaa.BoundingBoxesMaskGen(["bb1", "bb2"])
 
         mask = gen.draw_masks(batch, random_state=1)[0]
@@ -3370,7 +3371,7 @@ class TestBoundingBoxesMaskGen(unittest.TestCase):
                ia.BoundingBox(x1=2, y1=2, x2=10, y2=10, label="bb3")]
         bbsoi = ia.BoundingBoxesOnImage(bbs, shape=(10, 14, 3))
 
-        batch = ia.BatchInAugmentation(bounding_boxes=[bbsoi])
+        batch = _BatchInAugmentation(bounding_boxes=[bbsoi])
         gen = iaa.BoundingBoxesMaskGen(
             iap.DeterministicList(["bb1", "bb2"]),
             nb_sample_labels=3)
@@ -3416,7 +3417,7 @@ class TestBoundingBoxesMaskGen(unittest.TestCase):
                        ia.BoundingBox(x1=-3, y1=4, x2=20, y2=8, label="bb2"),
                        ia.BoundingBox(x1=2, y1=2, x2=10, y2=10, label="bb3")]
                 bbsoi = ia.BoundingBoxesOnImage(bbs, shape=shape)
-                batch = ia.BatchInAugmentation(bounding_boxes=[bbsoi])
+                batch = _BatchInAugmentation(bounding_boxes=[bbsoi])
                 gen = iaa.BoundingBoxesMaskGen("bb1")
 
                 mask = gen.draw_masks(batch)[0]
@@ -3428,7 +3429,7 @@ class TestBoundingBoxesMaskGen(unittest.TestCase):
     def test_batch_contains_no_bounding_boxes(self):
         hms = ia.HeatmapsOnImage(np.zeros((5, 5), dtype=np.float32),
                                  shape=(10, 10, 3))
-        batch = ia.BatchInAugmentation(heatmaps=[hms])
+        batch = _BatchInAugmentation(heatmaps=[hms])
         gen = iaa.SegMapClassIdsMaskGen(class_ids=[1])
 
         with self.assertRaises(AssertionError):
@@ -3447,7 +3448,7 @@ class InvertMaskGen(unittest.TestCase):
 
     def test_draw_masks(self):
         image = np.zeros((1, 20), dtype=np.uint8)
-        batch = ia.BatchInAugmentation(images=[image] * 200)
+        batch = _BatchInAugmentation(images=[image] * 200)
 
         child = iaa.HorizontalLinearGradientMaskGen(min_value=0.0,
                                                     max_value=1.0,
@@ -3487,7 +3488,7 @@ class InvertMaskGen(unittest.TestCase):
         for shape in shapes:
             with self.subTest(shape=shape):
                 image = np.zeros(shape, dtype=np.uint8)
-                batch = ia.BatchInAugmentation(images=[image])
+                batch = _BatchInAugmentation(images=[image])
                 child = iaa.HorizontalLinearGradientMaskGen()
                 gen = iaa.InvertMaskGen(0.5, child)
 

--- a/test/augmenters/test_contrast.py
+++ b/test/augmenters/test_contrast.py
@@ -33,6 +33,7 @@ from imgaug.augmenters import contrast as contrast_lib
 from imgaug.augmentables import batches as iabatches
 from imgaug.testutils import (ArgCopyingMagicMock, keypoints_equal, reseed,
                               runtest_pickleable_uint8_img)
+from imgaug.augmentables.batches import _BatchInAugmentation
 
 
 class TestGammaContrast(unittest.TestCase):
@@ -1300,7 +1301,7 @@ class TestCLAHE(unittest.TestCase):
         ]
         img = np.uint8(img)
 
-        mocked_batch = iabatches.BatchInAugmentation(
+        mocked_batch = _BatchInAugmentation(
             images=[img[..., np.newaxis] + 2])
 
         def _side_effect(image, _to_colorspace, _from_colorspace):
@@ -1584,7 +1585,7 @@ class TestCLAHE(unittest.TestCase):
                 mock_all_channel_clahe
                 ._augment_batch_
                 .call_args_list[0][0][0],
-                iabatches.BatchInAugmentation)
+                _BatchInAugmentation)
 
             assert (
                 len(mock_all_channel_clahe
@@ -1697,7 +1698,7 @@ class TestCLAHE(unittest.TestCase):
                 mock_all_channel_clahe
                 ._augment_batch_
                 .call_args_list[0][0][0],
-                iabatches.BatchInAugmentation)
+                _BatchInAugmentation)
 
             assert (
                 len(

--- a/test/augmenters/test_meta.py
+++ b/test/augmenters/test_meta.py
@@ -44,6 +44,7 @@ from imgaug.augmentables.heatmaps import HeatmapsOnImage
 from imgaug.augmentables.segmaps import SegmentationMapsOnImage
 from imgaug.augmentables.lines import LineString, LineStringsOnImage
 from imgaug.augmentables.polys import _ConcavePolygonRecoverer
+from imgaug.augmentables.batches import _BatchInAugmentation
 
 
 IS_PY36_OR_HIGHER = (sys.version_info[0] == 3 and sys.version_info[1] >= 6)
@@ -3074,7 +3075,7 @@ class TestAugmenter_augment_batch_(unittest.TestCase):
 
         aug = _InplaceDummyAugmenterImgsArray(1)
 
-        batch = ia.BatchInAugmentation(images=images)
+        batch = _BatchInAugmentation(images=images)
         batch_aug = aug.augment_batch_(batch)
         image_aug = batch_aug.images[0, :, :, :]
 


### PR DESCRIPTION
This patch renames `BatchInAugmentation` to `_BatchInAugmentation`.
The average user is currently not expected to need it, as `Batch`
and `UnnormalizedBatch` provide the same features, just a bit
slower.