### PR TITLE
Improve Warnings on Probably-Wrong Image Inputs

### DIFF
--- a/changelogs/master/added/20200125_image_warnings.md
+++ b/changelogs/master/added/20200125_image_warnings.md
@@ -1,0 +1,28 @@
+# Improved Warnings on Probably-Wrong Image Inputs #594
+
+Improved the errors and warnings on image augmentation calls.
+`augment_image()` will now produce a more self-explanatory error
+message when calling it as in `augment_image(list of images)`.
+Calls of single-image augmentation functions (e.g.
+`augment(image=...)`) with inputs that look like multiple images
+will now produce warnings. This is the case for `(H, W, C)`
+inputs when `C>=32` (as that indicates that `(N, H, W)` was
+actually provided).
+Calls of multi-image augmentation functions (e.g.
+`augment(images=...)`) with inputs that look like single images
+will now produce warnings. This is the case for `(N, H, W)`
+inputs when `W=1` or `W=3` (as that indicates that `(H, W, C)`
+was actually provided.)
+
+* Added an assert in `augment_image()` to verify that inputs are
+  arrays.
+* Added warnings for probably-wrong image inputs in
+  `augment_image()`, `augment_images()`, `augment()` (and its
+  alias `__call__()`).
+* Added module `imgaug.augmenters.base`.
+* Added warning
+  `imgaug.augmenters.base.SuspiciousMultiImageShapeWarning`.
+* Added warning
+  `imgaug.augmenters.base.SuspiciousSingleImageShapeWarning`.
+* Added `imgaug.testutils.assertWarns`, similar to `unittest`'s
+  `assertWarns`, but available in python <3.2.

--- a/imgaug/augmenters/__init__.py
+++ b/imgaug/augmenters/__init__.py
@@ -1,6 +1,7 @@
 """Combination of all augmenters, related classes and related functions."""
 # pylint: disable=unused-import
 from __future__ import absolute_import
+from imgaug.augmenters.base import *
 from imgaug.augmenters.arithmetic import *
 from imgaug.augmenters.artistic import *
 from imgaug.augmenters.blend import *

--- a/imgaug/augmenters/base.py
+++ b/imgaug/augmenters/base.py
@@ -8,3 +8,7 @@ in the future.
 
 class SuspiciousMultiImageShapeWarning(UserWarning):
     """Warning multi-image inputs that look like a single image."""
+
+
+class SuspiciousSingleImageShapeWarning(UserWarning):
+    """Warning for single-image inputs that look like multiple images."""

--- a/imgaug/augmenters/base.py
+++ b/imgaug/augmenters/base.py
@@ -4,3 +4,7 @@ This module is planned to contain :class:`imgaug.augmenters.meta.Augmenter`
 in the future.
 
 """
+
+
+class SuspiciousMultiImageShapeWarning(UserWarning):
+    """Warning multi-image inputs that look like a single image."""

--- a/imgaug/augmenters/base.py
+++ b/imgaug/augmenters/base.py
@@ -1,0 +1,6 @@
+"""Base classes and functions used by all/most augmenters.
+
+This module is planned to contain :class:`imgaug.augmenters.meta.Augmenter`
+in the future.
+
+"""

--- a/imgaug/augmenters/base.py
+++ b/imgaug/augmenters/base.py
@@ -34,3 +34,24 @@ def _warn_on_suspicious_multi_image_shapes(images):
                 "will be interpreted as multiple images of shape (H, W) "
                 "during augmentation." % (images.shape,),
                 category=SuspiciousMultiImageShapeWarning)
+
+
+def _warn_on_suspicious_single_image_shape(image):
+    if image is None:
+        return
+
+    # Check if it looks like (N, H, W) instead of (H, W, C).
+    # We don't react to (1, 1, C) though, mostly because that is used in many
+    # unittests.
+    if image.ndim == 3 and image.shape[-1] >= 32 and image.shape[0:2] != (1, 1):
+        ia.warn(
+            "You provided a numpy array of shape %s as a "
+            "single-image augmentation input, which was interpreted as "
+            "(H, W, C). The last dimension however has a size of >=32, "
+            "which indicates that you provided a multi-image array "
+            "with shape (N, H, W) instead. If that is the case, "
+            "you should use e.g. augmenter(imageS=<your input>) or "
+            "augment_imageS(<your input>). Otherwise your multi-image "
+            "input will be interpreted as a single image during "
+            "augmentation." % (image.shape,),
+            category=SuspiciousSingleImageShapeWarning)

--- a/imgaug/augmenters/base.py
+++ b/imgaug/augmenters/base.py
@@ -4,6 +4,7 @@ This module is planned to contain :class:`imgaug.augmenters.meta.Augmenter`
 in the future.
 
 """
+import imgaug as ia
 
 
 class SuspiciousMultiImageShapeWarning(UserWarning):
@@ -12,3 +13,24 @@ class SuspiciousMultiImageShapeWarning(UserWarning):
 
 class SuspiciousSingleImageShapeWarning(UserWarning):
     """Warning for single-image inputs that look like multiple images."""
+
+
+def _warn_on_suspicious_multi_image_shapes(images):
+    if images is None:
+        return
+
+    # check if it looks like (H, W, C) instead of (N, H, W)
+    if ia.is_np_array(images):
+        if images.ndim == 3 and images.shape[-1] in [1, 3]:
+            ia.warn(
+                "You provided a numpy array of shape %s as a "
+                "multi-image augmentation input, which was interpreted as "
+                "(N, H, W). The last dimension however has value 1 or "
+                "3, which indicates that you provided a single image "
+                "with shape (H, W, C) instead. If that is the case, "
+                "you should use e.g. augmenter(image=<your input>) or "
+                "augment_image(<your input>) -- note the singular 'image' "
+                "instead of 'imageS'. Otherwise your single input image "
+                "will be interpreted as multiple images of shape (H, W) "
+                "during augmentation." % (images.shape,),
+                category=SuspiciousMultiImageShapeWarning)

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -38,6 +38,7 @@ from imgaug.augmentables.batches import (Batch, UnnormalizedBatch,
                                          _BatchInAugmentation)
 from .. import parameters as iap
 from .. import random as iarandom
+from . import base as iabase
 
 
 @ia.deprecated("imgaug.dtypes.clip_")
@@ -766,6 +767,7 @@ class Augmenter(object):
         assert image.ndim in [2, 3], (
             "Expected image to have shape (height, width, [channels]), "
             "got shape %s." % (image.shape,))
+        iabase._warn_on_suspicious_single_image_shape(image)
         return self.augment_images([image], hooks=hooks)[0]
 
     def augment_images(self, images, parents=None, hooks=None):
@@ -816,19 +818,7 @@ class Augmenter(object):
         gaussian blurring to them.
 
         """
-        # TODO place that warning somehow in augment_batch()
-        if ia.is_np_array(images):
-            if images.ndim == 3 and images.shape[-1] in [1, 3]:
-                ia.warn(
-                    "You provided a numpy array of shape %s as input to "
-                    "augment_images(), which was interpreted as "
-                    "(N, H, W). The last dimension however has value 1 or "
-                    "3, which indicates that you provided a single image "
-                    "with shape (H, W, C) instead. If that is the case, "
-                    "you should use augment_image(image) or "
-                    "augment_images([image]), otherwise you will not get "
-                    "the expected augmentations." % (images.shape,))
-
+        iabase._warn_on_suspicious_multi_image_shapes(images)
         return self.augment_batch_(
             UnnormalizedBatch(images=images),
             parents=parents,
@@ -1928,8 +1918,10 @@ class Augmenter(object):
                 "You may only provide the argument 'image' OR 'images' to "
                 "augment(), not both of them.")
             images = [kwargs["image"]]
+            iabase._warn_on_suspicious_single_image_shape(images[0])
         else:
             images = kwargs.get("images", None)
+            iabase._warn_on_suspicious_multi_image_shapes(images)
 
         # Decide whether to return the final tuple in the order of the kwargs
         # keys or the default order based on python version. Only 3.6+ uses

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -758,6 +758,11 @@ class Augmenter(object):
             The corresponding augmented image.
 
         """
+        assert ia.is_np_array(image), (
+            "Expected to get a single numpy array of shape (H,W) or (H,W,C) "
+            "for `image`. Got instead type %d. Use `augment_images(images)` "
+            "to augment a list of multiple images." % (
+                type(image).__name__),)
         assert image.ndim in [2, 3], (
             "Expected image to have shape (height, width, [channels]), "
             "got shape %s." % (image.shape,))

--- a/imgaug/testutils.py
+++ b/imgaug/testutils.py
@@ -10,6 +10,8 @@ import copy
 import warnings
 import tempfile
 import shutil
+import re
+import sys
 
 import numpy as np
 import six.moves as sm
@@ -191,3 +193,145 @@ class TemporaryDirectory(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         shutil.rmtree(self.name)
+
+
+# Copied from
+# https://github.com/python/cpython/blob/master/Lib/unittest/case.py
+# at commit 293dd23 (Nov 19, 2019).
+# Required at least to enable assertWarns() in python <3.2.
+def _is_subtype(expected, basetype):
+    if isinstance(expected, tuple):
+        return all(_is_subtype(e, basetype) for e in expected)
+    return isinstance(expected, type) and issubclass(expected, basetype)
+
+
+# Copied from
+# https://github.com/python/cpython/blob/master/Lib/unittest/case.py
+# at commit 293dd23 (Nov 19, 2019).
+# Required at least to enable assertWarns() in python <3.2.
+class _BaseTestCaseContext:
+    def __init__(self, test_case):
+        self.test_case = test_case
+
+    def _raiseFailure(self, standardMsg):
+        msg = self.test_case._formatMessage(self.msg, standardMsg)
+        raise self.test_case.failureException(msg)
+
+
+# Copied from
+# https://github.com/python/cpython/blob/master/Lib/unittest/case.py
+# at commit 293dd23 (Nov 19, 2019).
+# Required at least to enable assertWarns() in python <3.2.
+class _AssertRaisesBaseContext(_BaseTestCaseContext):
+
+    def __init__(self, expected, test_case, expected_regex=None):
+        _BaseTestCaseContext.__init__(self, test_case)
+        self.expected = expected
+        self.test_case = test_case
+        if expected_regex is not None:
+            expected_regex = re.compile(expected_regex)
+        self.expected_regex = expected_regex
+        self.obj_name = None
+        self.msg = None
+
+    def handle(self, name, args, kwargs):
+        """
+        If args is empty, assertRaises/Warns is being used as a
+        context manager, so check for a 'msg' kwarg and return self.
+        If args is not empty, call a callable passing positional and keyword
+        arguments.
+        """
+        try:
+            if not _is_subtype(self.expected, self._base_type):
+                raise TypeError('%s() arg 1 must be %s' %
+                                (name, self._base_type_str))
+            if not args:
+                self.msg = kwargs.pop('msg', None)
+                if kwargs:
+                    raise TypeError('%r is an invalid keyword argument for '
+                                    'this function' % (next(iter(kwargs)),))
+                return self
+
+            callable_obj = args[0]
+            args = args[1:]
+
+            try:
+                self.obj_name = callable_obj.__name__
+            except AttributeError:
+                self.obj_name = str(callable_obj)
+            with self:
+                callable_obj(*args, **kwargs)
+        finally:
+            # bpo-23890: manually break a reference cycle
+            self = None
+
+
+# Copied from
+# https://github.com/python/cpython/blob/master/Lib/unittest/case.py
+# at commit 293dd23 (Nov 19, 2019).
+# Required at least to enable assertWarns() in python <3.2.
+class _AssertWarnsContext(_AssertRaisesBaseContext):
+    """A context manager used to implement TestCase.assertWarns* methods."""
+
+    _base_type = Warning
+    _base_type_str = 'a warning type or tuple of warning types'
+
+    def __enter__(self):
+        # The __warningregistry__'s need to be in a pristine state for tests
+        # to work properly.
+        for v in sys.modules.values():
+            if getattr(v, '__warningregistry__', None):
+                v.__warningregistry__ = {}
+        self.warnings_manager = warnings.catch_warnings(record=True)
+        self.warnings = self.warnings_manager.__enter__()
+        warnings.simplefilter("always", self.expected)
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self.warnings_manager.__exit__(exc_type, exc_value, tb)
+        if exc_type is not None:
+            # let unexpected exceptions pass through
+            return
+        try:
+            exc_name = self.expected.__name__
+        except AttributeError:
+            exc_name = str(self.expected)
+        first_matching = None
+        for m in self.warnings:
+            w = m.message
+            if not isinstance(w, self.expected):
+                continue
+            if first_matching is None:
+                first_matching = w
+            if (self.expected_regex is not None and
+                not self.expected_regex.search(str(w))):
+                continue
+            # store warning for later retrieval
+            self.warning = w
+            self.filename = m.filename
+            self.lineno = m.lineno
+            return
+        # Now we simply try to choose a helpful failure message
+        if first_matching is not None:
+            self._raiseFailure('"{}" does not match "{}"'.format(
+                     self.expected_regex.pattern, str(first_matching)))
+        if self.obj_name:
+            self._raiseFailure("{} not triggered by {}".format(exc_name,
+                                                               self.obj_name))
+        else:
+            self._raiseFailure("{} not triggered".format(exc_name))
+
+
+# Partially copied from
+# https://github.com/python/cpython/blob/master/Lib/unittest/case.py
+# at commit 293dd23 (Nov 19, 2019).
+# Required at least to enable assertWarns() in python <3.2.
+def assertWarns(testcase, expected_warning, *args, **kwargs):
+    """Context with same functionality as ``assertWarns`` in ``unittest``.
+
+    Note that ``assertWarns`` is only available in python 3.2+.
+
+    """
+    # pylint: disable=invalid-name
+    context = _AssertWarnsContext(expected_warning, testcase)
+    return context.handle('assertWarns', args, kwargs)

--- a/imgaug/testutils.py
+++ b/imgaug/testutils.py
@@ -214,6 +214,7 @@ class _BaseTestCaseContext:
         self.test_case = test_case
 
     def _raiseFailure(self, standardMsg):
+        # pylint: disable=invalid-name, protected-access, no-member
         msg = self.test_case._formatMessage(self.msg, standardMsg)
         raise self.test_case.failureException(msg)
 
@@ -234,6 +235,7 @@ class _AssertRaisesBaseContext(_BaseTestCaseContext):
         self.obj_name = None
         self.msg = None
 
+    # pylint: disable=inconsistent-return-statements
     def handle(self, name, args, kwargs):
         """
         If args is empty, assertRaises/Warns is being used as a
@@ -241,6 +243,7 @@ class _AssertRaisesBaseContext(_BaseTestCaseContext):
         If args is not empty, call a callable passing positional and keyword
         arguments.
         """
+        # pylint: disable=no-member, self-cls-assignment, not-context-manager
         try:
             if not _is_subtype(self.expected, self._base_type):
                 raise TypeError('%s() arg 1 must be %s' %
@@ -264,6 +267,7 @@ class _AssertRaisesBaseContext(_BaseTestCaseContext):
         finally:
             # bpo-23890: manually break a reference cycle
             self = None
+    # pylint: enable=inconsistent-return-statements
 
 
 # Copied from
@@ -279,6 +283,7 @@ class _AssertWarnsContext(_AssertRaisesBaseContext):
     def __enter__(self):
         # The __warningregistry__'s need to be in a pristine state for tests
         # to work properly.
+        # pylint: disable=invalid-name, attribute-defined-outside-init
         for v in sys.modules.values():
             if getattr(v, '__warningregistry__', None):
                 v.__warningregistry__ = {}
@@ -288,6 +293,7 @@ class _AssertWarnsContext(_AssertRaisesBaseContext):
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
+        # pylint: disable=invalid-name, attribute-defined-outside-init
         self.warnings_manager.__exit__(exc_type, exc_value, tb)
         if exc_type is not None:
             # let unexpected exceptions pass through
@@ -304,7 +310,7 @@ class _AssertWarnsContext(_AssertRaisesBaseContext):
             if first_matching is None:
                 first_matching = w
             if (self.expected_regex is not None and
-                not self.expected_regex.search(str(w))):
+                    not self.expected_regex.search(str(w))):
                 continue
             # store warning for later retrieval
             self.warning = w
@@ -314,7 +320,7 @@ class _AssertWarnsContext(_AssertRaisesBaseContext):
         # Now we simply try to choose a helpful failure message
         if first_matching is not None:
             self._raiseFailure('"{}" does not match "{}"'.format(
-                     self.expected_regex.pattern, str(first_matching)))
+                self.expected_regex.pattern, str(first_matching)))
         if self.obj_name:
             self._raiseFailure("{} not triggered by {}".format(exc_name,
                                                                self.obj_name))

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -25,7 +25,7 @@ from imgaug import parameters as iap
 from imgaug import dtypes as iadt
 from imgaug import random as iarandom
 from imgaug.testutils import (array_equal_lists, keypoints_equal, reseed,
-                              runtest_pickleable_uint8_img)
+                              runtest_pickleable_uint8_img, assertWarns)
 import imgaug.augmenters.arithmetic as arithmetic_lib
 import imgaug.augmenters.contrast as contrast_lib
 
@@ -3047,25 +3047,26 @@ class TestTotalDropout(unittest.TestCase):
                 assert images_aug.shape == shape
 
     def test_zero_sized_axes(self):
-        shapes = [
-            (5, 0, 0),
-            (5, 0, 1),
-            (5, 1, 0),
-            (5, 0, 1, 0),
-            (5, 1, 0, 0),
-            (5, 0, 1, 1),
-            (5, 1, 0, 1)
-        ]
+        with assertWarns(self, iaa.SuspiciousMultiImageShapeWarning):
+            shapes = [
+                (5, 0, 0),
+                (5, 0, 1),
+                (5, 1, 0),
+                (5, 0, 1, 0),
+                (5, 1, 0, 0),
+                (5, 0, 1, 1),
+                (5, 1, 0, 1)
+            ]
 
-        for shape in shapes:
-            with self.subTest(shape=shape):
-                images = np.full(shape, 255, dtype=np.uint8)
-                aug = iaa.TotalDropout(1.0)
+            for shape in shapes:
+                with self.subTest(shape=shape):
+                    images = np.full(shape, 255, dtype=np.uint8)
+                    aug = iaa.TotalDropout(1.0)
 
-                images_aug = aug(images=images)
+                    images_aug = aug(images=images)
 
-                assert images_aug.dtype.name == "uint8"
-                assert images_aug.shape == images.shape
+                    assert images_aug.dtype.name == "uint8"
+                    assert images_aug.shape == images.shape
 
     def test_other_dtypes_bool(self):
         image = np.full((1, 1, 10), 1, dtype=bool)

--- a/test/augmenters/test_contrast.py
+++ b/test/augmenters/test_contrast.py
@@ -32,7 +32,7 @@ from imgaug import random as iarandom
 from imgaug.augmenters import contrast as contrast_lib
 from imgaug.augmentables import batches as iabatches
 from imgaug.testutils import (ArgCopyingMagicMock, keypoints_equal, reseed,
-                              runtest_pickleable_uint8_img)
+                              runtest_pickleable_uint8_img, assertWarns)
 from imgaug.augmentables.batches import _BatchInAugmentation
 
 
@@ -1058,7 +1058,8 @@ class TestAllChannelsCLAHE(unittest.TestCase):
         img1000d[0, 1, :] = 100
         img1000d[0, 2, :] = 110
         for _ in sm.xrange(100):
-            img_aug = aug.augment_image(img1000d)
+            with assertWarns(self, iaa.SuspiciousSingleImageShapeWarning):
+                img_aug = aug.augment_image(img1000d)
             assert img_aug.dtype.name == "uint8"
 
             maxs = np.max(img_aug, axis=(0, 1))

--- a/test/augmenters/test_mixed_files.py
+++ b/test/augmenters/test_mixed_files.py
@@ -1,5 +1,17 @@
 from __future__ import print_function, division, absolute_import
 
+import sys
+# unittest only added in 3.4 self.subTest()
+if sys.version_info[0] < 3 or sys.version_info[1] < 4:
+    import unittest2 as unittest
+else:
+    import unittest
+# unittest.mock is not available in 2.7 (though unittest2 might contain it?)
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
 import matplotlib
 matplotlib.use('Agg')  # fix execution of tests involving matplotlib on travis
 import numpy as np
@@ -10,7 +22,7 @@ import six.moves as sm
 import imgaug as ia
 from imgaug import augmenters as iaa
 from imgaug.testutils import (create_random_images, array_equal_lists,
-                              keypoints_equal, reseed)
+                              keypoints_equal, reseed, assertWarns)
 
 
 # TODO this should probably be tested just once for Augmenter
@@ -121,101 +133,104 @@ def test_determinism():
             "Keypoints (1, 3) expected to be different for %s" % (aug.name,)
 
 
-def test_keypoint_augmentation():
-    reseed()
+class TestKeypointAugmentation(unittest.TestCase):
+    def setUp(self):
+        reseed()
 
-    keypoints = []
-    for y in sm.xrange(40//5):
-        for x in sm.xrange(60//5):
-            keypoints.append(ia.Keypoint(y=y*5, x=x*5))
+    def test_many_augmenters(self):
+        keypoints = []
+        for y in sm.xrange(40//5):
+            for x in sm.xrange(60//5):
+                keypoints.append(ia.Keypoint(y=y*5, x=x*5))
 
-    keypoints_oi = ia.KeypointsOnImage(keypoints, shape=(40, 60, 3))
-    keypoints_oi_empty = ia.KeypointsOnImage([], shape=(40, 60, 3))
+        keypoints_oi = ia.KeypointsOnImage(keypoints, shape=(40, 60, 3))
+        keypoints_oi_empty = ia.KeypointsOnImage([], shape=(40, 60, 3))
 
-    augs = [
-        iaa.Add((-5, 5), name="Add"),
-        iaa.AddElementwise((-5, 5), name="AddElementwise"),
-        iaa.AdditiveGaussianNoise(0.01*255, name="AdditiveGaussianNoise"),
-        iaa.Multiply((0.95, 1.05), name="Multiply"),
-        iaa.Dropout(0.01, name="Dropout"),
-        iaa.CoarseDropout(0.01, size_px=6, name="CoarseDropout"),
-        iaa.Invert(0.01, per_channel=True, name="Invert"),
-        iaa.GaussianBlur(sigma=(0.95, 1.05), name="GaussianBlur"),
-        iaa.AverageBlur((3, 5), name="AverageBlur"),
-        iaa.MedianBlur((3, 5), name="MedianBlur"),
-        iaa.Sharpen((0.0, 0.1), lightness=(1.0, 1.2), name="Sharpen"),
-        iaa.Emboss(alpha=(0.0, 0.1), strength=(0.5, 1.5), name="Emboss"),
-        iaa.EdgeDetect(alpha=(0.0, 0.1), name="EdgeDetect"),
-        iaa.DirectedEdgeDetect(alpha=(0.0, 0.1), direction=0,
-                               name="DirectedEdgeDetect"),
-        iaa.Fliplr(0.5, name="Fliplr"),
-        iaa.Flipud(0.5, name="Flipud"),
-        iaa.Affine(translate_px=(-5, 5), name="Affine-translate-px"),
-        iaa.Affine(translate_percent=(-0.05, 0.05),
-                   name="Affine-translate-percent"),
-        iaa.Affine(rotate=(-20, 20), name="Affine-rotate"),
-        iaa.Affine(shear=(-20, 20), name="Affine-shear"),
-        iaa.Affine(scale=(0.9, 1.1), name="Affine-scale"),
-        iaa.PiecewiseAffine(scale=(0.001, 0.005), name="PiecewiseAffine"),
-        iaa.ElasticTransformation(alpha=(0.1, 0.2), sigma=(0.1, 0.2),
-                                  name="ElasticTransformation"),
-        iaa.BlendAlpha((0.0, 0.1), iaa.Add(10), name="BlendAlpha"),
-        iaa.BlendAlphaElementwise((0.0, 0.1), iaa.Add(10),
-                                  name="BlendAlphaElementwise"),
-        iaa.BlendAlphaSimplexNoise(iaa.Add(10), name="BlendAlphaSimplexNoise"),
-        iaa.BlendAlphaFrequencyNoise(exponent=(-2, 2), foreground=iaa.Add(10),
-                                     name="BlendAlphaSimplexNoise"),
-        iaa.Superpixels(p_replace=0.01, n_segments=64),
-        iaa.Resize(0.5, name="Resize"),
-        iaa.CropAndPad(px=(-10, 10), name="CropAndPad"),
-        iaa.Pad(px=(0, 10), name="Pad"),
-        iaa.Crop(px=(0, 10), name="Crop")
-    ]
+        augs = [
+            iaa.Add((-5, 5), name="Add"),
+            iaa.AddElementwise((-5, 5), name="AddElementwise"),
+            iaa.AdditiveGaussianNoise(0.01*255, name="AdditiveGaussianNoise"),
+            iaa.Multiply((0.95, 1.05), name="Multiply"),
+            iaa.Dropout(0.01, name="Dropout"),
+            iaa.CoarseDropout(0.01, size_px=6, name="CoarseDropout"),
+            iaa.Invert(0.01, per_channel=True, name="Invert"),
+            iaa.GaussianBlur(sigma=(0.95, 1.05), name="GaussianBlur"),
+            iaa.AverageBlur((3, 5), name="AverageBlur"),
+            iaa.MedianBlur((3, 5), name="MedianBlur"),
+            iaa.Sharpen((0.0, 0.1), lightness=(1.0, 1.2), name="Sharpen"),
+            iaa.Emboss(alpha=(0.0, 0.1), strength=(0.5, 1.5), name="Emboss"),
+            iaa.EdgeDetect(alpha=(0.0, 0.1), name="EdgeDetect"),
+            iaa.DirectedEdgeDetect(alpha=(0.0, 0.1), direction=0,
+                                   name="DirectedEdgeDetect"),
+            iaa.Fliplr(0.5, name="Fliplr"),
+            iaa.Flipud(0.5, name="Flipud"),
+            iaa.Affine(translate_px=(-5, 5), name="Affine-translate-px"),
+            iaa.Affine(translate_percent=(-0.05, 0.05),
+                       name="Affine-translate-percent"),
+            iaa.Affine(rotate=(-20, 20), name="Affine-rotate"),
+            iaa.Affine(shear=(-20, 20), name="Affine-shear"),
+            iaa.Affine(scale=(0.9, 1.1), name="Affine-scale"),
+            iaa.PiecewiseAffine(scale=(0.001, 0.005), name="PiecewiseAffine"),
+            iaa.ElasticTransformation(alpha=(0.1, 0.2), sigma=(0.1, 0.2),
+                                      name="ElasticTransformation"),
+            iaa.BlendAlpha((0.0, 0.1), iaa.Add(10), name="BlendAlpha"),
+            iaa.BlendAlphaElementwise((0.0, 0.1), iaa.Add(10),
+                                      name="BlendAlphaElementwise"),
+            iaa.BlendAlphaSimplexNoise(iaa.Add(10), name="BlendAlphaSimplexNoise"),
+            iaa.BlendAlphaFrequencyNoise(exponent=(-2, 2), foreground=iaa.Add(10),
+                                         name="BlendAlphaSimplexNoise"),
+            iaa.Superpixels(p_replace=0.01, n_segments=64),
+            iaa.Resize(0.5, name="Resize"),
+            iaa.CropAndPad(px=(-10, 10), name="CropAndPad"),
+            iaa.Pad(px=(0, 10), name="Pad"),
+            iaa.Crop(px=(0, 10), name="Crop")
+        ]
 
-    for aug in augs:
-        dss = []
-        for i in sm.xrange(10):
-            aug_det = aug.to_deterministic()
+        for aug in augs:
+            dss = []
+            for i in sm.xrange(10):
+                aug_det = aug.to_deterministic()
 
-            kp_fully_empty_aug = aug_det.augment_keypoints([])
-            assert kp_fully_empty_aug == []
+                kp_fully_empty_aug = aug_det.augment_keypoints([])
+                assert kp_fully_empty_aug == []
 
-            kp_first_empty_aug = aug_det.augment_keypoints(keypoints_oi_empty)
-            assert len(kp_first_empty_aug.keypoints) == 0
+                kp_first_empty_aug = aug_det.augment_keypoints(keypoints_oi_empty)
+                assert len(kp_first_empty_aug.keypoints) == 0
 
-            kp_image = keypoints_oi.to_keypoint_image(size=5)
-            kp_image_aug = aug_det.augment_image(kp_image)
-            kp_image_aug_rev = ia.KeypointsOnImage.from_keypoint_image(
-                kp_image_aug,
-                if_not_found_coords={"x": -9999, "y": -9999},
-                nb_channels=1
-            )
-            kp_aug = aug_det.augment_keypoints([keypoints_oi])[0]
-            ds = []
-            assert len(kp_image_aug_rev.keypoints) == len(kp_aug.keypoints), (
-                "Lost keypoints for '%s' (%d vs expected %d)" % (
-                    aug.name,
-                    len(kp_aug.keypoints),
-                    len(kp_image_aug_rev.keypoints))
-            )
+                kp_image = keypoints_oi.to_keypoint_image(size=5)
+                with assertWarns(self, iaa.SuspiciousSingleImageShapeWarning):
+                    kp_image_aug = aug_det.augment_image(kp_image)
+                kp_image_aug_rev = ia.KeypointsOnImage.from_keypoint_image(
+                    kp_image_aug,
+                    if_not_found_coords={"x": -9999, "y": -9999},
+                    nb_channels=1
+                )
+                kp_aug = aug_det.augment_keypoints([keypoints_oi])[0]
+                ds = []
+                assert len(kp_image_aug_rev.keypoints) == len(kp_aug.keypoints), (
+                    "Lost keypoints for '%s' (%d vs expected %d)" % (
+                        aug.name,
+                        len(kp_aug.keypoints),
+                        len(kp_image_aug_rev.keypoints))
+                )
 
-            gen = zip(kp_aug.keypoints, kp_image_aug_rev.keypoints)
-            for kp_pred, kp_pred_img in gen:
-                kp_pred_lost = (kp_pred.x == -9999 and kp_pred.y == -9999)
-                kp_pred_img_lost = (kp_pred_img.x == -9999
-                                    and kp_pred_img.y == -9999)
+                gen = zip(kp_aug.keypoints, kp_image_aug_rev.keypoints)
+                for kp_pred, kp_pred_img in gen:
+                    kp_pred_lost = (kp_pred.x == -9999 and kp_pred.y == -9999)
+                    kp_pred_img_lost = (kp_pred_img.x == -9999
+                                        and kp_pred_img.y == -9999)
 
-                if not kp_pred_lost and not kp_pred_img_lost:
-                    d = np.sqrt((kp_pred.x - kp_pred_img.x) ** 2
-                                + (kp_pred.y - kp_pred_img.y) ** 2)
-                    ds.append(d)
-            dss.extend(ds)
-            if len(ds) == 0:
-                print("[INFO] No valid keypoints found for '%s' "
-                      "in test_keypoint_augmentation()" % (str(aug),))
-        assert np.average(dss) < 5.0, \
-            "Average distance too high (%.2f, with ds: %s)" \
-            % (np.average(dss), str(dss))
+                    if not kp_pred_lost and not kp_pred_img_lost:
+                        d = np.sqrt((kp_pred.x - kp_pred_img.x) ** 2
+                                    + (kp_pred.y - kp_pred_img.y) ** 2)
+                        ds.append(d)
+                dss.extend(ds)
+                if len(ds) == 0:
+                    print("[INFO] No valid keypoints found for '%s' "
+                          "in test_keypoint_augmentation()" % (str(aug),))
+            assert np.average(dss) < 5.0, \
+                "Average distance too high (%.2f, with ds: %s)" \
+                % (np.average(dss), str(dss))
 
 
 # TODO move these tests to the individual augmenters?

--- a/test/augmenters/test_pillike.py
+++ b/test/augmenters/test_pillike.py
@@ -24,7 +24,7 @@ import PIL.ImageFilter
 import imgaug as ia
 from imgaug import augmenters as iaa
 from imgaug import random as iarandom
-from imgaug.testutils import reseed, runtest_pickleable_uint8_img
+from imgaug.testutils import reseed, runtest_pickleable_uint8_img, assertWarns
 
 
 def _test_shape_hw(func):
@@ -1059,7 +1059,8 @@ class TestAutocontrast(unittest.TestCase):
         mock_auto.return_value = image[..., 0]
         aug = iaa.pillike.Autocontrast((0, 30), per_channel=True)
 
-        _image_aug = aug(image=image)
+        with assertWarns(self, iaa.SuspiciousSingleImageShapeWarning):
+            _image_aug = aug(image=image)
 
         assert mock_auto.call_count == 100
         cutoffs = []
@@ -1084,7 +1085,8 @@ class TestAutocontrast(unittest.TestCase):
         image = image.astype(np.uint8)
         aug = iaa.pillike.Autocontrast(10, per_channel=True)
 
-        image_aug = aug(image=image)
+        with assertWarns(self, iaa.SuspiciousSingleImageShapeWarning):
+            image_aug = aug(image=image)
 
         assert np.min(image_aug) < 50
         assert np.max(image_aug) > 150


### PR DESCRIPTION
Improve the errors and warnings on image augmentation calls.
`augment_image()` will now produce a more self-explanatory error
message when calling it as in `augment_image(list of images)`.
Calls of single-image augmentation functions (e.g.
`augment(image=...)`) with inputs that look like multiple images
will now produce warnings. This is the case for `(H, W, C)`
inputs when `C>=32` (as that indicates that `(N, H, W)` was
actually provided).
Calls of multi-image augmentation functions (e.g.
`augment(images=...)`) with inputs that look like single images
will now produce warnings. This is the case for `(N, H, W)`
inputs when `W=1` or `W=3` (as that indicates that `(H, W, C)`
was actually provided.)

* Add an assert in `augment_image()` to verify that inputs are
  arrays.
* Add warnings for probably-wrong image inputs in
  `augment_image()`, `augment_images()`, `augment()` (and its
  alias `__call__()`).
* Add module `imgaug.augmenters.base`.
* Add warning
  `imgaug.augmenters.base.SuspiciousMultiImageShapeWarning`.
* Add warning
  `imgaug.augmenters.base.SuspiciousSingleImageShapeWarning`.
* Add `imgaug.testutils.assertWarns`, similar to `unittest`'s
  `assertWarns`, but available in python <3.2.