### PR TITLE
Fix missing class in module class list

### DIFF
--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -19,6 +19,7 @@ List of augmenters:
     * :class:`AddToSaturation`
     * :class:`ChangeColorspace`
     * :class:`Grayscale`
+    * :class:`ChangeColorTemperature`
     * :class:`KMeansColorQuantization`
     * :class:`UniformColorQuantization`
     * :class:`Posterize`


### PR DESCRIPTION
Add `ChangeColorTemperature` to the class list in the module docstring of module `imgaug.augmenters.color`.