### PR TITLE
Add 'deprecated since'/'added in' markers

### DIFF
--- a/imgaug/augmentables/base.py
+++ b/imgaug/augmentables/base.py
@@ -1,4 +1,8 @@
-"""Interfaces used by augmentable objects."""
+"""Interfaces used by augmentable objects.
+
+Added in 0.4.0.
+
+"""
 from __future__ import print_function, division, absolute_import
 
 
@@ -11,5 +15,7 @@ class IAugmentable(object):
     Currently, only ``*OnImage`` clases are marked as augmentable.
     Non-OnImage objects are normalized to OnImage-objects.
     Batches are not yet marked as augmentable, but might be in the future.
+
+    Added in 0.4.0.
 
     """

--- a/imgaug/augmentables/batches.py
+++ b/imgaug/augmentables/batches.py
@@ -157,6 +157,8 @@ class UnnormalizedBatch(object):
         data is contained in the batch that has to be augmented, visualized
         or something similar.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of str
@@ -221,6 +223,8 @@ class UnnormalizedBatch(object):
         ``*_aug`` attributes out if it and assigns them to this
         batch *in unnormalized form*. Hence, the datatypes of all ``*_aug``
         attributes will match the datatypes of the ``*_unaug`` attributes.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -400,6 +404,8 @@ class Batch(object):
         data is contained in the batch that has to be augmented, visualized
         or something similar.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of str
@@ -414,6 +420,8 @@ class Batch(object):
         This method does nothing and only exists to simplify interfaces
         that accept both :class:`UnnormalizedBatch` and :class:`Batch`.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.batches.Batch
@@ -424,6 +432,8 @@ class Batch(object):
 
     def to_batch_in_augmentation(self):
         """Convert this batch to a :class:`_BatchInAugmentation` instance.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -451,6 +461,8 @@ class Batch(object):
         """Set the columns in this batch to the column values of another batch.
 
         This method works in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -598,6 +610,7 @@ class Batch(object):
         return batch
 
 
+# Added in 0.4.0.
 class _BatchInAugmentationPropagationContext(object):
     def __init__(self, batch, augmenter, hooks, parents):
         self.batch = batch
@@ -626,6 +639,8 @@ class _BatchInAugmentation(object):
     :class:`Batch`. Data within the batch may be changed in-place. No initial
     copy is needed.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     images : None or (N,H,W,C) ndarray or list of (H,W,C) ndarray
@@ -651,6 +666,7 @@ class _BatchInAugmentation(object):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, images=None, heatmaps=None, segmentation_maps=None,
                  keypoints=None, bounding_boxes=None, polygons=None,
                  line_strings=None, data=None):
@@ -668,6 +684,8 @@ class _BatchInAugmentation(object):
     def empty(self):
         """Estimate whether this batch is empty, i.e. contains no data.
 
+        Added in 0.4.0.
+
         Returns
         -------
         bool
@@ -683,6 +701,8 @@ class _BatchInAugmentation(object):
 
         Note that this method assumes that all columns have the same number
         of rows.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -703,6 +723,8 @@ class _BatchInAugmentation(object):
         Each column represents one datatype and its corresponding data,
         e.g. images or polygons.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of _AugmentableColumn
@@ -717,6 +739,8 @@ class _BatchInAugmentation(object):
         This method is intended for situations where one wants to know which
         data is contained in the batch that has to be augmented, visualized
         or something similar.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -735,6 +759,8 @@ class _BatchInAugmentation(object):
         This method assumes that all ``.shape`` attributes contain the same
         shape and that it is identical to the image's shape.
         It also assumes that there are no columns containing only ``None`` s.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -760,6 +786,8 @@ class _BatchInAugmentation(object):
 
     def subselect_rows_by_indices(self, indices):
         """Reduce this batch to a subset of rows based on their row indices.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -794,6 +822,8 @@ class _BatchInAugmentation(object):
         :func:`_BatchInAugmentation.subselect_rows_by_indices`.
 
         This method has to be executed on the batch *before* subselection.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -860,6 +890,8 @@ class _BatchInAugmentation(object):
     def propagation_hooks_ctx(self, augmenter, hooks, parents):
         """Start a context in which propagation hooks are applied.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         augmenter : imgaug.augmenters.meta.Augmenter
@@ -884,6 +916,8 @@ class _BatchInAugmentation(object):
         """Set columns in this batch to ``None`` based on a propagation hook.
 
         This method works in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -927,6 +961,8 @@ class _BatchInAugmentation(object):
 
         This method works in-place.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         noned_info : list of tuple of str
@@ -950,6 +986,8 @@ class _BatchInAugmentation(object):
         This method simply returns the batch itself. It exists for consistency
         with the other batch classes.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.batches._BatchInAugmentation
@@ -962,6 +1000,8 @@ class _BatchInAugmentation(object):
         """Set the columns in this batch to the column values of another batch.
 
         This method works in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -990,6 +1030,8 @@ class _BatchInAugmentation(object):
 
     def to_batch(self, batch_before_aug):
         """Convert this batch into a :class:`Batch` instance.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1027,6 +1069,8 @@ class _BatchInAugmentation(object):
 
     def deepcopy(self):
         """Copy this batch and all of its column values.
+
+        Added in 0.4.0.
 
         Returns
         -------

--- a/imgaug/augmentables/bbs.py
+++ b/imgaug/augmentables/bbs.py
@@ -61,6 +61,8 @@ class BoundingBox(object):
     def coords(self):
         """Get the top-left and bottom-right coordinates as one array.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -227,6 +229,8 @@ class BoundingBox(object):
         This is intended for cases where the original image is resized.
         It cannot be used for more complex changes (e.g. padding, cropping).
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         from_shape : tuple of int or ndarray
@@ -279,6 +283,8 @@ class BoundingBox(object):
 
     def extend_(self, all_sides=0, top=0, right=0, bottom=0, left=0):
         """Extend the size of the bounding box along its sides in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -433,6 +439,8 @@ class BoundingBox(object):
     def compute_out_of_image_area(self, image):
         """Compute the area of the BB that is outside of the image plane.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         image : (H,W,...) ndarray or tuple of int
@@ -461,6 +469,8 @@ class BoundingBox(object):
         This estimates ``f = A_ooi / A``, where ``A_ooi`` is the area of the
         bounding box that is outside of the image plane, while ``A`` is the
         total area of the bounding box.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -584,6 +594,8 @@ class BoundingBox(object):
     def clip_out_of_image_(self, image):
         """Clip off parts of the BB box that are outside of the image in-place.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         image : (H,W,...) ndarray or tuple of int
@@ -639,6 +651,8 @@ class BoundingBox(object):
 
         The origin ``(0, 0)`` is at the top left of the image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         x : number, optional
@@ -650,22 +664,22 @@ class BoundingBox(object):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -700,22 +714,22 @@ class BoundingBox(object):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -735,6 +749,8 @@ class BoundingBox(object):
         """Draw a box showing the BB's label.
 
         The box is placed right above the BB's rectangle.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -804,6 +820,8 @@ class BoundingBox(object):
         """Draw the rectangle of the bounding box on an image.
 
         This method does not draw the label.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1112,6 +1130,8 @@ class BoundingBox(object):
     def to_polygon(self):
         """Convert this bounding box to a polygon covering the same area.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.polys.Polygon
@@ -1131,6 +1151,8 @@ class BoundingBox(object):
     # TODO also introduce similar area_almost_equals()
     def coords_almost_equals(self, other, max_distance=1e-4):
         """Estimate if this and another BB have almost identical coordinates.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1177,6 +1199,8 @@ class BoundingBox(object):
         :func:`~imgaug.augmentables.bbs.BoundingBox.coords_almost_equals` but
         additionally compares the labels.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         other : imgaug.augmentables.bbs.BoundingBox or iterable
@@ -1204,6 +1228,8 @@ class BoundingBox(object):
 
         This is the inverse of
         :func:`~imgaug.BoundingBoxesOnImage.to_xyxy_array`.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1315,6 +1341,8 @@ class BoundingBox(object):
     def __getitem__(self, indices):
         """Get the coordinate(s) with given indices.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -1325,6 +1353,8 @@ class BoundingBox(object):
 
     def __iter__(self):
         """Iterate over the coordinates of this instance.
+
+        Added in 0.4.0.
 
         Yields
         ------
@@ -1376,6 +1406,8 @@ class BoundingBoxesOnImage(IAugmentable):
     def items(self):
         """Get the bounding boxes in this container.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of BoundingBox
@@ -1387,6 +1419,8 @@ class BoundingBoxesOnImage(IAugmentable):
     @items.setter
     def items(self, value):
         """Set the bounding boxes in this container.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1438,6 +1472,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
     def on_(self, image):
         """Project BBs from one image (shape) to a another one in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1531,6 +1567,8 @@ class BoundingBoxesOnImage(IAugmentable):
     def from_point_soups(cls, xy, shape):
         """Convert an ``(N, 2P) or (N, P, 2) ndarray`` to a BBsOI instance.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         xy : (N, 2P) ndarray or (N, P, 2) array or iterable of iterable of number or iterable of iterable of iterable of number
@@ -1590,6 +1628,8 @@ class BoundingBoxesOnImage(IAugmentable):
     def to_xy_array(self):
         """Convert the ``BoundingBoxesOnImage`` object to an ``(N,2) ndarray``.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -1612,6 +1652,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
             This method will automatically flip x-coordinates if ``x1>x2``
             for a bounding box. (Analogous for y-coordinates.)
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1652,6 +1694,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
         See
         :func:`~imgaug.augmentables.bbs.BoundingBoxesOnImage.fill_from_xyxy_array_`.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1726,6 +1770,8 @@ class BoundingBoxesOnImage(IAugmentable):
     def remove_out_of_image_(self, fully=True, partly=False):
         """Remove in-place all BBs that are fully/partially outside of the image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         fully : bool, optional
@@ -1778,6 +1824,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
         'OOI' is the abbreviation for 'out of image'.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         fraction : number
@@ -1798,6 +1846,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
     def remove_out_of_image_fraction(self, fraction):
         """Remove all BBs with an out of image fraction of at least `fraction`.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1826,6 +1876,8 @@ class BoundingBoxesOnImage(IAugmentable):
     def clip_out_of_image_(self):
         """
         Clip off in-place all parts from all BBs that are outside of the image.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -1859,6 +1911,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
         The origin ``(0, 0)`` is at the top left of the image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         x : number, optional
@@ -1870,22 +1924,22 @@ class BoundingBoxesOnImage(IAugmentable):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1918,22 +1972,22 @@ class BoundingBoxesOnImage(IAugmentable):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1949,6 +2003,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
     def to_keypoints_on_image(self):
         """Convert the bounding boxes to one ``KeypointsOnImage`` instance.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -1983,6 +2039,8 @@ class BoundingBoxesOnImage(IAugmentable):
         This function writes in-place into this ``BoundingBoxesOnImage``
         instance.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         kpsoi : imgaug.augmentables.kps.KeypointsOnImages
@@ -2013,6 +2071,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
     def to_polygons_on_image(self):
         """Convert the bounding boxes to one ``PolygonsOnImage`` instance.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -2084,6 +2144,8 @@ class BoundingBoxesOnImage(IAugmentable):
     def __getitem__(self, indices):
         """Get the bounding box(es) with given indices.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of imgaug.augmentables.bbs.BoundingBoxes
@@ -2094,6 +2156,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
     def __iter__(self):
         """Iterate over the bounding boxes in this container.
+
+        Added in 0.4.0.
 
         Yields
         ------
@@ -2107,6 +2171,8 @@ class BoundingBoxesOnImage(IAugmentable):
 
     def __len__(self):
         """Get the number of items in this instance.
+
+        Added in 0.4.0.
 
         Returns
         -------

--- a/imgaug/augmentables/kps.py
+++ b/imgaug/augmentables/kps.py
@@ -88,6 +88,8 @@ class Keypoint(object):
     def coords(self):
         """Get the xy-coordinates as an ``(N,2)`` ndarray.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -127,6 +129,8 @@ class Keypoint(object):
     def xy(self):
         """Get the keypoint's x- and y-coordinate as a single array.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -138,6 +142,8 @@ class Keypoint(object):
     @property
     def xy_int(self):
         """Get the keypoint's xy-coord, rounded to closest integer.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -157,6 +163,8 @@ class Keypoint(object):
 
         This is intended for cases where the original image is resized.
         It cannot be used for more complex changes (e.g. padding, cropping).
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -207,6 +215,8 @@ class Keypoint(object):
     def is_out_of_image(self, image):
         """Estimate whether this point is outside of the given image plane.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         image : (H,W,...) ndarray or tuple of int
@@ -235,6 +245,8 @@ class Keypoint(object):
         plane) or ``0.0`` (point is inside the image plane). This method
         exists for consistency with other augmentables, e.g. bounding boxes.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         image : (H,W,...) ndarray or tuple of int
@@ -254,6 +266,8 @@ class Keypoint(object):
 
     def shift_(self, x=0, y=0):
         """Move the keypoint around on an image in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -475,6 +489,8 @@ class Keypoint(object):
     def coords_almost_equals(self, other, max_distance=1e-4):
         """Estimate if this and another KP have almost identical coordinates.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         other : imgaug.augmentables.kps.Keypoint or iterable
@@ -516,6 +532,8 @@ class Keypoint(object):
 
             This method is currently identical to ``coords_almost_equals``.
             It exists for consistency with ``BoundingBox`` and ``Polygons``.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -618,6 +636,8 @@ class KeypointsOnImage(IAugmentable):
     def items(self):
         """Get the keypoints in this container.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of Keypoint
@@ -629,6 +649,8 @@ class KeypointsOnImage(IAugmentable):
     @items.setter
     def items(self, value):
         """Set the keypoints in this container.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -676,6 +698,8 @@ class KeypointsOnImage(IAugmentable):
 
     def on_(self, image):
         """Project all keypoints from one image shape to a new one in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -773,6 +797,8 @@ class KeypointsOnImage(IAugmentable):
         This method exists for consistency with other augmentables, e.g.
         bounding boxes.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         fraction : number
@@ -798,6 +824,8 @@ class KeypointsOnImage(IAugmentable):
         This method exists for consistency with other augmentables, e.g.
         bounding boxes.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         fraction : number
@@ -822,6 +850,8 @@ class KeypointsOnImage(IAugmentable):
         This method exists for consistency with other augmentables, e.g.
         bounding boxes.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.kps.KeypointsOnImage
@@ -838,6 +868,8 @@ class KeypointsOnImage(IAugmentable):
         This method exists for consistency with other augmentables, e.g.
         bounding boxes.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.kps.KeypointsOnImage
@@ -848,6 +880,8 @@ class KeypointsOnImage(IAugmentable):
 
     def shift_(self, x=0, y=0):
         """Move the keypoints on the x/y-axis in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -979,6 +1013,8 @@ class KeypointsOnImage(IAugmentable):
             This currently expects that `xy` contains exactly as many
             coordinates as there are keypoints in this instance. Otherwise,
             an ``AssertionError`` will be raised.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1304,6 +1340,8 @@ class KeypointsOnImage(IAugmentable):
         This method exists for consistency with ``BoundingBoxesOnImage``,
         ``PolygonsOnImage`` and ``LineStringsOnImage``.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.kps.KeypointsOnImage
@@ -1317,6 +1355,8 @@ class KeypointsOnImage(IAugmentable):
 
         This function writes in-place into this ``KeypointsOnImage``
         instance.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1401,6 +1441,8 @@ class KeypointsOnImage(IAugmentable):
     def __getitem__(self, indices):
         """Get the keypoint(s) with given indices.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of imgaug.augmentables.kps.Keypoint
@@ -1411,6 +1453,8 @@ class KeypointsOnImage(IAugmentable):
 
     def __iter__(self):
         """Iterate over the keypoints in this container.
+
+        Added in 0.4.0.
 
         Yields
         ------
@@ -1424,6 +1468,8 @@ class KeypointsOnImage(IAugmentable):
 
     def __len__(self):
         """Get the number of items in this instance.
+
+        Added in 0.4.0.
 
         Returns
         -------

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -323,6 +323,8 @@ class LineString(object):
         This is intended for cases where the original image is resized.
         It cannot be used for more complex changes (e.g. padding, cropping).
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         from_shape : tuple of int or ndarray
@@ -374,6 +376,8 @@ class LineString(object):
         This estimates ``f = A_ooi / A``, where ``A_ooi`` is the area of the
         polygon that is outside of the image plane, while ``A`` is the
         total area of the bounding box.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -665,6 +669,8 @@ class LineString(object):
 
         The origin ``(0, 0)`` is at the top left of the image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         x : number, optional
@@ -676,22 +682,22 @@ class LineString(object):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -724,22 +730,22 @@ class LineString(object):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -1623,6 +1629,8 @@ class LineString(object):
     def __getitem__(self, indices):
         """Get the coordinate(s) with given indices.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -1633,6 +1641,8 @@ class LineString(object):
 
     def __iter__(self):
         """Iterate over the coordinates of this instance.
+
+        Added in 0.4.0.
 
         Yields
         ------
@@ -1707,6 +1717,8 @@ class LineStringsOnImage(IAugmentable):
     def items(self):
         """Get the line strings in this container.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of LineString
@@ -1718,6 +1730,8 @@ class LineStringsOnImage(IAugmentable):
     @items.setter
     def items(self, value):
         """Set the line strings in this container.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1741,6 +1755,8 @@ class LineStringsOnImage(IAugmentable):
 
     def on_(self, image):
         """Project the line strings from one image shape to a new one in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1926,6 +1942,8 @@ class LineStringsOnImage(IAugmentable):
         """
         Remove all LS that are fully/partially outside of an image in-place.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         fully : bool, optional
@@ -1974,6 +1992,8 @@ class LineStringsOnImage(IAugmentable):
         """Remove all LS with an OOI fraction of at least `fraction` in-place.
 
         'OOI' is the abbreviation for 'out of image'.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2030,6 +2050,8 @@ class LineStringsOnImage(IAugmentable):
             hence will be clipped off, resulting in two or more unconnected
             line string parts that are left in the image plane.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.lines.LineStringsOnImage
@@ -2074,6 +2096,8 @@ class LineStringsOnImage(IAugmentable):
 
         The origin ``(0, 0)`` is at the top left of the image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         x : number, optional
@@ -2085,22 +2109,22 @@ class LineStringsOnImage(IAugmentable):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -2133,22 +2157,22 @@ class LineStringsOnImage(IAugmentable):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -2164,6 +2188,8 @@ class LineStringsOnImage(IAugmentable):
 
     def to_xy_array(self):
         """Convert all line string coordinates to one array of shape ``(N,2)``.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -2184,6 +2210,8 @@ class LineStringsOnImage(IAugmentable):
             This currently expects that `xy` contains exactly as many
             coordinates as the line strings within this instance have corner
             points. Otherwise, an ``AssertionError`` will be raised.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2228,6 +2256,8 @@ class LineStringsOnImage(IAugmentable):
     def to_keypoints_on_image(self):
         """Convert the line strings to one ``KeypointsOnImage`` instance.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.kps.KeypointsOnImage
@@ -2251,6 +2281,8 @@ class LineStringsOnImage(IAugmentable):
 
         This function writes in-place into this ``LineStringsOnImage``
         instance.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2348,6 +2380,8 @@ class LineStringsOnImage(IAugmentable):
     def __getitem__(self, indices):
         """Get the line string(s) with given indices.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of imgaug.augmentables.lines.LineString
@@ -2358,6 +2392,8 @@ class LineStringsOnImage(IAugmentable):
 
     def __iter__(self):
         """Iterate over the line strings in this container.
+
+        Added in 0.4.0.
 
         Yields
         ------
@@ -2371,6 +2407,8 @@ class LineStringsOnImage(IAugmentable):
 
     def __len__(self):
         """Get the number of items in this instance.
+
+        Added in 0.4.0.
 
         Returns
         -------

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -145,6 +145,8 @@ class Polygon(object):
     def coords(self):
         """Alias for attribute ``exterior``.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -288,6 +290,8 @@ class Polygon(object):
         This is intended for cases where the original image is resized.
         It cannot be used for more complex changes (e.g. padding, cropping).
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         from_shape : tuple of int
@@ -378,6 +382,8 @@ class Polygon(object):
     def compute_out_of_image_area(self, image):
         """Compute the area of the BB that is outside of the image plane.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         image : (H,W,...) ndarray or tuple of int
@@ -404,6 +410,8 @@ class Polygon(object):
         This estimates ``f = A_ooi / A``, where ``A_ooi`` is the area of the
         polygon that is outside of the image plane, while ``A`` is the
         total area of the bounding box.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -646,6 +654,8 @@ class Polygon(object):
 
         The origin ``(0, 0)`` is at the top left of the image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         x : number, optional
@@ -657,22 +667,22 @@ class Polygon(object):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -705,22 +715,22 @@ class Polygon(object):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             right (towards the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift this object *from* the
             left (towards the right).
 
@@ -1057,6 +1067,8 @@ class Polygon(object):
 
         See :func:`~imgaug.augmentables.lines.LineString.subdivide` for details.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         points_per_edge : int
@@ -1082,6 +1094,8 @@ class Polygon(object):
         """Derive a new polygon with ``N`` interpolated points per edge.
 
         See :func:`~imgaug.augmentables.lines.LineString.subdivide` for details.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1397,6 +1411,8 @@ class Polygon(object):
     def __getitem__(self, indices):
         """Get the coordinate(s) with given indices.
 
+        Added in 0.4.0.
+
         Returns
         -------
         ndarray
@@ -1407,6 +1423,8 @@ class Polygon(object):
 
     def __iter__(self):
         """Iterate over the coordinates of this instance.
+
+        Added in 0.4.0.
 
         Yields
         ------
@@ -1463,6 +1481,8 @@ class PolygonsOnImage(IAugmentable):
     def items(self):
         """Get the polygons in this container.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of Polygon
@@ -1474,6 +1494,8 @@ class PolygonsOnImage(IAugmentable):
     @items.setter
     def items(self, value):
         """Set the polygons in this container.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1497,6 +1519,8 @@ class PolygonsOnImage(IAugmentable):
 
     def on_(self, image):
         """Project all polygons from one image shape to a new one in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1655,6 +1679,8 @@ class PolygonsOnImage(IAugmentable):
 
         'OOI' is the abbreviation for 'out of image'.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         fully : bool, optional
@@ -1700,6 +1726,8 @@ class PolygonsOnImage(IAugmentable):
     def remove_out_of_image_fraction_(self, fraction):
         """Remove all Polys with an OOI fraction of ``>=fraction`` in-place.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         fraction : number
@@ -1720,6 +1748,8 @@ class PolygonsOnImage(IAugmentable):
 
     def remove_out_of_image_fraction(self, fraction):
         """Remove all Polys with an out of image fraction of ``>=fraction``.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1755,6 +1785,8 @@ class PolygonsOnImage(IAugmentable):
             connected by areas that are outside of the image plane and hence
             will be clipped off, resulting in two or more unconnected polygon
             parts that are left in the image plane.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -1800,6 +1832,8 @@ class PolygonsOnImage(IAugmentable):
 
         The origin ``(0, 0)`` is at the top left of the image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         x : number, optional
@@ -1811,22 +1845,22 @@ class PolygonsOnImage(IAugmentable):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1858,22 +1892,22 @@ class PolygonsOnImage(IAugmentable):
             towards the bottom images.
 
         top : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             top (towards the bottom).
 
         right : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             right (towads the left).
 
         bottom : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             bottom (towards the top).
 
         left : None or int, optional
-            **Deprecated.**
+            Deprecated since 0.4.0.
             Amount of pixels by which to shift all objects *from* the
             left (towards the right).
 
@@ -1889,6 +1923,8 @@ class PolygonsOnImage(IAugmentable):
 
     def subdivide_(self, points_per_edge):
         """Interpolate ``N`` points on each polygon.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1908,6 +1944,8 @@ class PolygonsOnImage(IAugmentable):
     def subdivide(self, points_per_edge):
         """Interpolate ``N`` points on each polygon.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         points_per_edge : int
@@ -1923,6 +1961,8 @@ class PolygonsOnImage(IAugmentable):
 
     def to_xy_array(self):
         """Convert all polygon coordinates to one array of shape ``(N,2)``.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -1949,6 +1989,8 @@ class PolygonsOnImage(IAugmentable):
             This does not validate the new coordinates or repair the resulting
             polygons. If bad coordinates are provided, the result will be
             invalid polygons (e.g. self-intersections).
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1992,6 +2034,8 @@ class PolygonsOnImage(IAugmentable):
     def to_keypoints_on_image(self):
         """Convert the polygons to one ``KeypointsOnImage`` instance.
 
+        Added in 0.4.0.
+
         Returns
         -------
         imgaug.augmentables.kps.KeypointsOnImage
@@ -2013,6 +2057,8 @@ class PolygonsOnImage(IAugmentable):
 
         This function writes in-place into this ``PolygonsOnImage``
         instance.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2110,6 +2156,8 @@ class PolygonsOnImage(IAugmentable):
     def __getitem__(self, indices):
         """Get the polygon(s) with given indices.
 
+        Added in 0.4.0.
+
         Returns
         -------
         list of imgaug.augmentables.polys.Polygon
@@ -2120,6 +2168,8 @@ class PolygonsOnImage(IAugmentable):
 
     def __iter__(self):
         """Iterate over the polygons in this container.
+
+        Added in 0.4.0.
 
         Yields
         ------
@@ -2133,6 +2183,8 @@ class PolygonsOnImage(IAugmentable):
 
     def __len__(self):
         """Get the number of items in this instance.
+
+        Added in 0.4.0.
 
         Returns
         -------

--- a/imgaug/augmentables/utils.py
+++ b/imgaug/augmentables/utils.py
@@ -20,6 +20,7 @@ def copy_augmentables(augmentables):
     return result
 
 
+# Added in 0.4.0.
 def deepcopy_fast(obj):
     if obj is None:
         return None
@@ -63,6 +64,8 @@ def project_coords_(coords, from_shape, to_shape):
 
     This performs a relative projection, e.g. a point at ``60%`` of the old
     image width will be at ``60%`` of the new image width after projection.
+
+    Added in 0.4.0.
 
     Parameters
     ----------
@@ -270,6 +273,8 @@ def interpolate_points_by_max_distance(points, max_distance, closed=True):
 def convert_cbaois_to_kpsois(cbaois):
     """Convert coordinate-based augmentables to KeypointsOnImage instances.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     cbaois : list of imgaug.augmentables.bbs.BoundingBoxesOnImage or list of imgaug.augmentables.bbs.PolygonsOnImage or list of imgaug.augmentables.bbs.LineStringsOnImage or imgaug.augmentables.bbs.BoundingBoxesOnImage or imgaug.augmentables.bbs.PolygonsOnImage or imgaug.augmentables.bbs.LineStringsOnImage
@@ -295,6 +300,8 @@ def invert_convert_cbaois_to_kpsois_(cbaois, kpsois):
     """Invert the output of :func:`convert_to_cbaois_to_kpsois` in-place.
 
     This function writes in-place into `cbaois`.
+
+    Added in 0.4.0.
 
     Parameters
     ----------
@@ -328,6 +335,7 @@ def invert_convert_cbaois_to_kpsois_(cbaois, kpsois):
 
 
 # TODO remove this once all calls switched to _remove_out_of_image_fraction_()
+# Added in 0.4.0.
 def _remove_out_of_image_fraction(cbaoi, fraction, result_class):
     items_clean = [
         item for item in cbaoi.items
@@ -335,6 +343,7 @@ def _remove_out_of_image_fraction(cbaoi, fraction, result_class):
     return result_class(items_clean, shape=cbaoi.shape)
 
 
+# Added in 0.4.0.
 def _remove_out_of_image_fraction_(cbaoi, fraction):
     cbaoi.items = [
         item for item in cbaoi.items
@@ -342,6 +351,7 @@ def _remove_out_of_image_fraction_(cbaoi, fraction):
     return cbaoi
 
 
+# Added in 0.4.0.
 def _normalize_shift_args(x, y, top=None, right=None, bottom=None, left=None):
     """Normalize ``shift()`` arguments to x, y and handle deprecated args."""
     if any([v is not None for v in [top, right, bottom, left]]):

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -646,6 +646,8 @@ def cutout(image, x1, y1, x2, y2,
 
     See :func:`~imgaug.augmenters.arithmetic.cutout_`.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     image : ndarray
@@ -700,6 +702,7 @@ def cutout_(image, x1, y1, x2, y2,
         in the interval ``[0.0, 1.0]`` and hence sample values from a
         gaussian within that interval, i.e. from ``N(0.5, std=0.5/3)``.
 
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -782,6 +785,8 @@ def _fill_rectangle_gaussian_(image, x1, y1, x2, y2, cval, per_channel,
                               random_state):
     """Fill a rectangular image area with samples from a gaussian.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -849,6 +854,8 @@ def _fill_rectangle_constant_(image, x1, y1, x2, y2, cval, per_channel,
     `cval` may be a single value or one per channel. If the number of items
     in `cval` does not match the number of channels in `image`, it may
     be tiled up to the number of channels.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1037,6 +1044,8 @@ def invert_(image, min_value=None, max_value=None, threshold=None,
             invert_above_threshold=True):
     """Invert an array in-place.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     if (min_value=None and max_value=None):
@@ -1184,6 +1193,7 @@ def _invert_bool(arr, min_value, max_value):
     return ~arr
 
 
+# Added in 0.4.0.
 def _invert_uint8_(arr, min_value, max_value, threshold,
                    invert_above_threshold):
     table = _generate_table_for_invert_uint8(
@@ -1192,6 +1202,7 @@ def _invert_uint8_(arr, min_value, max_value, threshold,
     return arr
 
 
+# Added in 0.4.0.
 def _invert_uint16_or_larger_(arr, min_value, max_value):
     min_max_is_vr = (min_value == 0
                      and max_value == np.iinfo(arr.dtype).max)
@@ -1203,6 +1214,7 @@ def _invert_uint16_or_larger_(arr, min_value, max_value):
     )
 
 
+# Added in 0.4.0.
 def _invert_int_(arr, min_value, max_value):
     # note that for int dtypes the max value is
     #   (-1) * min_value - 1
@@ -1269,6 +1281,7 @@ def _invert_by_distance(arr, min_value, max_value):
     return arr_inv
 
 
+# Added in 0.4.0.
 def _generate_table_for_invert_uint8(min_value, max_value, threshold,
                                      invert_above_threshold):
     table = np.arange(256).astype(np.int32)
@@ -1299,6 +1312,8 @@ def _generate_table_for_invert_uint8(min_value, max_value, threshold,
 def solarize(image, threshold=128):
     """Invert pixel values above a threshold.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.arithmetic.solarize_`.
@@ -1327,6 +1342,8 @@ def solarize_(image, threshold=128):
 
     This function performs the same transformation as
     :func:`PIL.ImageOps.solarize`.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1542,6 +1559,7 @@ class Add(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(
             per_channel, "per_channel")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -1687,6 +1705,7 @@ class AddElementwise(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(
             per_channel, "per_channel")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -2155,6 +2174,7 @@ class Multiply(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(
             per_channel, "per_channel")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -2298,6 +2318,7 @@ class MultiplyElementwise(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(per_channel,
                                                         "per_channel")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -2336,7 +2357,9 @@ class MultiplyElementwise(meta.Augmenter):
         return [self.mul, self.per_channel]
 
 
+# Added in 0.4.0.
 class _CutoutSamples(object):
+    # Added in 0.4.0.
     def __init__(self, nb_iterations, pos_x, pos_y, size_h, size_w, squared,
                  fill_mode, cval, fill_per_channel):
         self.nb_iterations = nb_iterations
@@ -2375,6 +2398,8 @@ class Cutout(meta.Augmenter):
         Gaussian fill mode will assume that float input images contain values
         in the interval ``[0.0, 1.0]`` and hence sample values from a
         gaussian within that interval, i.e. from ``N(0.5, std=0.5/3)``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2515,6 +2540,7 @@ class Cutout(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  nb_iterations=1,
                  position="uniform",
@@ -2544,6 +2570,7 @@ class Cutout(meta.Augmenter):
         self.fill_per_channel = iap.handle_probability_param(
             fill_per_channel, "fill_per_channel")
 
+    # Added in 0.4.0.
     @classmethod
     def _handle_fill_mode_param(cls, fill_mode):
         if ia.is_string(fill_mode):
@@ -2559,6 +2586,7 @@ class Cutout(meta.Augmenter):
                 type(fill_mode).__name__))
         return iap.Choice(fill_mode)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -2598,6 +2626,7 @@ class Cutout(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, images, random_state):
         rngs = random_state.duplicate(8)
         nb_rows = len(images)
@@ -2643,6 +2672,7 @@ class Cutout(meta.Augmenter):
             fill_per_channel=fill_per_channel
         )
 
+    # Added in 0.4.0.
     @classmethod
     def _augment_image_by_samples(cls, image, x1, y1, x2, y2, squared,
                                   fill_mode, cval, fill_per_channel,
@@ -2667,6 +2697,7 @@ class Cutout(meta.Augmenter):
                 seed=random_state)
         return image
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.nb_iterations, self.position, self.size, self.squared,
@@ -2767,6 +2798,7 @@ class Dropout(MultiplyElementwise):
             random_state=random_state, deterministic=deterministic)
 
 
+# Added in 0.4.0.
 def _handle_dropout_probability_param(p, name):
     if ia.is_single_number(p):
         p_param = iap.Binomial(1 - p)
@@ -2995,6 +3027,8 @@ class Dropout2d(meta.Augmenter):
         It does so if and only if *all* channels of an image are dropped.
         If ``nb_keep_channels >= 1`` then that never happens.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -3072,6 +3106,7 @@ class Dropout2d(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, p=0.1, nb_keep_channels=1,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3092,6 +3127,7 @@ class Dropout2d(meta.Augmenter):
         self._heatmaps_cval = 0.0
         self._segmentation_maps_cval = 0
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         imagewise_drop_channel_ids, all_dropped_ids = self._draw_samples(
             batch, random_state)
@@ -3128,6 +3164,7 @@ class Dropout2d(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         # maybe noteworthy here that the channel axis can have size 0,
         # e.g. (5, 5, 0)
@@ -3171,6 +3208,7 @@ class Dropout2d(meta.Augmenter):
 
         return imagewise_channels_to_drop, all_dropped_ids
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p, self.nb_keep_channels]
@@ -3186,6 +3224,8 @@ class TotalDropout(meta.Augmenter):
         This augmenter also sets the arrays of heatmaps and segmentation
         maps to zero and removes all coordinate-based data (e.g. it removes
         all bounding boxes on images that were filled with zeros).
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3254,6 +3294,7 @@ class TotalDropout(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, p=1,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3273,6 +3314,7 @@ class TotalDropout(meta.Augmenter):
         self._heatmaps_cval = 0.0
         self._segmentation_maps_cval = 0
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         drop_mask = self._draw_samples(batch, random_state)
         drop_ids = None
@@ -3310,17 +3352,20 @@ class TotalDropout(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         p = self.p.draw_samples((batch.nb_rows,), random_state=random_state)
         drop_mask = (p < 0.5)
         return drop_mask
 
+    # Added in 0.4.0.
     @classmethod
     def _generate_drop_ids_once(cls, drop_mask, drop_ids):
         if drop_ids is None:
             drop_ids = np.nonzero(drop_mask)[0]
         return drop_ids
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.p]
@@ -3446,6 +3491,7 @@ class ReplaceElementwise(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(per_channel,
                                                         "per_channel")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -3622,6 +3668,7 @@ class ImpulseNoise(SaltAndPepper):
     Replace ``10%`` of all pixels with impulse noise.
 
     """
+
     def __init__(self, p=(0.0, 0.03),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3761,6 +3808,7 @@ class CoarseSaltAndPepper(ReplaceElementwise):
     independently per image channel.
 
     """
+
     def __init__(self, p=(0.02, 0.1), size_px=None, size_percent=None,
                  per_channel=False, min_size=3,
                  seed=None, name=None,
@@ -4383,6 +4431,7 @@ class Invert(meta.Augmenter):
         self.invert_above_threshold = iap.handle_probability_param(
             invert_above_threshold, "invert_above_threshold")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -4410,6 +4459,7 @@ class Invert(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         nb_images = batch.nb_rows
         nb_channels = meta.estimate_max_number_of_channels(batch.images)
@@ -4447,7 +4497,9 @@ class Invert(meta.Augmenter):
                 self.threshold, self.invert_above_threshold]
 
 
+# Added in 0.4.0.
 class _InvertSamples(object):
+    # Added in 0.4.0.
     def __init__(self, p, per_channel, min_value, max_value,
                  threshold, invert_above_threshold):
         self.p = p
@@ -4466,6 +4518,8 @@ class Solarize(Invert):
     to ``True`` (i.e. only values above the threshold will be inverted).
 
     See :class:`Invert` for more details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4542,6 +4596,8 @@ def ContrastNormalization(alpha=1.0, per_channel=False,
     dtype support:
 
         See ``imgaug.augmenters.contrast.LinearContrast``.
+
+    Deprecated since 0.3.0.
 
     Parameters
     ----------
@@ -4693,6 +4749,7 @@ class JpegCompression(meta.Augmenter):
             compression, "compression",
             value_range=(0, 100), tuple_to_uniform=True, list_to_choice=True)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch

--- a/imgaug/augmenters/artistic.py
+++ b/imgaug/augmenters/artistic.py
@@ -5,6 +5,8 @@ List of augmenters:
 
     * :class:`Cartoon`
 
+Added in 0.4.0.
+
 """
 
 from __future__ import print_function, division, absolute_import
@@ -35,6 +37,8 @@ def stylize_cartoon(image, blur_ksize=3, segmentation_size=1.0,
 
     This method is loosely based on the one proposed in
     https://stackoverflow.com/a/11614479/3760780
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -155,6 +159,7 @@ def stylize_cartoon(image, blur_ksize=3, segmentation_size=1.0,
                      from_colorspace)
 
 
+# Added in 0.4.0.
 def _find_edges_canny(image, edge_multiplier, from_colorspace):
     image_gray = colorlib.change_colorspace_(np.copy(image),
                                              to_colorspace=colorlib.CSPACE_GRAY,
@@ -165,6 +170,7 @@ def _find_edges_canny(image, edge_multiplier, from_colorspace):
     return edges
 
 
+# Added in 0.4.0.
 def _find_edges_laplacian(image, edge_multiplier, from_colorspace):
     image_gray = colorlib.change_colorspace_(np.copy(image),
                                              to_colorspace=colorlib.CSPACE_GRAY,
@@ -183,6 +189,7 @@ def _find_edges_laplacian(image, edge_multiplier, from_colorspace):
     return edges_uint8
 
 
+# Added in 0.4.0.
 def _blur_median(image, ksize):
     if ksize % 2 == 0:
         ksize += 1
@@ -191,6 +198,7 @@ def _blur_median(image, ksize):
     return cv2.medianBlur(_normalize_cv2_input_arr_(image), ksize)
 
 
+# Added in 0.4.0.
 def _threshold(image, thresh):
     mask = (image < thresh)
     result = np.copy(image)
@@ -198,6 +206,7 @@ def _threshold(image, thresh):
     return result
 
 
+# Added in 0.4.0.
 def _suppress_edge_blobs(edges, size, thresh, inverse):
     kernel = np.ones((size, size), dtype=np.float32)
     counts = cv2.filter2D(_normalize_cv2_input_arr_(edges / 255.0), -1, kernel)
@@ -212,6 +221,7 @@ def _suppress_edge_blobs(edges, size, thresh, inverse):
     return edges
 
 
+# Added in 0.4.0.
 def _saturate(image, factor, from_colorspace):
     image = np.copy(image)
     if np.isclose(factor, 1.0, atol=1e-2):
@@ -229,6 +239,7 @@ def _saturate(image, factor, from_colorspace):
     return image_sat
 
 
+# Added in 0.4.0.
 def _blend_edges(image, image_edges):
     image_edges = 1.0 - (image_edges / 255.0)
     image_edges = np.tile(image_edges[..., np.newaxis], (1, 1, 3))
@@ -248,6 +259,8 @@ class Cartoon(meta.Augmenter):
     learned style transfer, let alone human-made images. A lack of detected
     edges or also too many detected edges are probably the most significant
     drawbacks.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -342,6 +355,8 @@ class Cartoon(meta.Augmenter):
     images.
 
     """
+
+    # Added in 0.4.0.
     def __init__(self, blur_ksize=(1, 5), segmentation_size=(0.8, 1.2),
                  saturation=(1.5, 2.5), edge_prevalence=(0.9, 1.1),
                  from_colorspace=colorlib.CSPACE_RGB,
@@ -365,6 +380,7 @@ class Cartoon(meta.Augmenter):
             tuple_to_uniform=True, list_to_choice=True)
         self.from_colorspace = from_colorspace
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             samples = self._draw_samples(batch, random_state)
@@ -379,6 +395,7 @@ class Cartoon(meta.Augmenter):
                 )
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         nb_rows = batch.nb_rows
         return (
@@ -390,6 +407,7 @@ class Cartoon(meta.Augmenter):
                                               random_state=random_state)
         )
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.blur_ksize, self.segmentation_size, self.saturation,

--- a/imgaug/augmenters/base.py
+++ b/imgaug/augmenters/base.py
@@ -3,6 +3,8 @@
 This module is planned to contain :class:`imgaug.augmenters.meta.Augmenter`
 in the future.
 
+Added in 0.4.0.
+
 """
 import imgaug as ia
 

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -211,6 +211,7 @@ def blend_alpha(image_fg, image_bg, alpha, eps=1e-2):
     return image_blend
 
 
+# Added in 0.4.0.
 def _generate_branch_outputs(augmenter, batch, hooks, parents):
     parents_extended = parents + [augmenter]
 
@@ -241,6 +242,7 @@ def _generate_branch_outputs(augmenter, batch, hooks, parents):
     return outputs_fg, outputs_bg
 
 
+# Added in 0.4.0.
 def _to_deterministic(augmenter):
     aug = augmenter.copy()
     aug.foreground = (
@@ -278,6 +280,8 @@ class BlendAlpha(meta.Augmenter):
         Currently, if ``factor >= 0.5`` (per image), the results of the
         foreground branch are used as the new coordinates, otherwise the
         results of the background branch.
+
+    Added in 0.4.0. (Before that named `Alpha`.)
 
     **Supported dtypes**:
 
@@ -391,6 +395,7 @@ class BlendAlpha(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, factor=(0.0, 1.0), foreground=None, background=None,
                  per_channel=False,
                  seed=None, name=None,
@@ -416,6 +421,7 @@ class BlendAlpha(meta.Augmenter):
 
         self.epsilon = 1e-2
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         batch_fg, batch_bg = _generate_branch_outputs(
             self, batch, hooks, parents)
@@ -465,18 +471,22 @@ class BlendAlpha(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _to_deterministic(self):
         return _to_deterministic(self)
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.factor, self.per_channel]
 
+    # Added in 0.4.0.
     def get_children_lists(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [lst for lst in [self.foreground, self.background]
                 if lst is not None]
 
+    # Added in 0.4.0.
     def __str__(self):
         pattern = (
             "%s("
@@ -522,6 +532,8 @@ class BlendAlphaMask(meta.Augmenter):
         For bounding boxes, line strings and polygons, either all objects
         (on an image) of the foreground or all of the background branch will
         be used, based on the average over the whole alpha mask.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -596,6 +608,7 @@ class BlendAlphaMask(meta.Augmenter):
     _MODE_POINTWISE = "pointwise"
     _MODES = [_MODE_POINTWISE, _MODE_EITHER_OR]
 
+    # Added in 0.4.0.
     def __init__(self, mask_generator,
                  foreground=None, background=None,
                  seed=None, name=None,
@@ -634,6 +647,7 @@ class BlendAlphaMask(meta.Augmenter):
 
         self.epsilon = 1e-2
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         batch_fg, batch_bg = _generate_branch_outputs(
             self, batch, hooks, parents)
@@ -680,6 +694,7 @@ class BlendAlphaMask(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     @classmethod
     def _binarize_mask(cls, mask, arr_height, arr_width):
         # Average over channels, resize to heatmap/segmap array size
@@ -702,6 +717,7 @@ class BlendAlphaMask(meta.Augmenter):
         mask_arr_binarized = (mask_arr >= 0.5)
         return mask_arr_binarized
 
+    # Added in 0.4.0.
     @classmethod
     def _blend_coordinates(cls, cbaoi, cbaoi_fg, cbaoi_bg, mask_image,
                            mode):
@@ -768,18 +784,22 @@ class BlendAlphaMask(meta.Augmenter):
             coords_aug, shape=cbaoi.shape)
         return augm_utils.invert_convert_cbaois_to_kpsois_(cbaoi, kpsoi_aug)
 
+    # Added in 0.4.0.
     def _to_deterministic(self):
         return _to_deterministic(self)
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.mask_generator]
 
+    # Added in 0.4.0.
     def get_children_lists(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [lst for lst in [self.foreground, self.background]
                 if lst is not None]
 
+    # Added in 0.4.0.
     def __str__(self):
         pattern = (
             "%s("
@@ -812,6 +832,8 @@ class BlendAlphaElementwise(BlendAlphaMask):
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
+
+    Added in 0.4.0. (Before that named `AlphaElementwise`.)
 
     **Supported dtypes**:
 
@@ -928,6 +950,7 @@ class BlendAlphaElementwise(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, factor=(0.0, 1.0), foreground=None, background=None,
                  per_channel=False,
                  seed=None, name=None,
@@ -941,6 +964,7 @@ class BlendAlphaElementwise(BlendAlphaMask):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     @property
     def factor(self):
         return self.mask_generator.parameter
@@ -952,6 +976,8 @@ class BlendAlphaSimplexNoise(BlendAlphaElementwise):
     The alpha masks are sampled using a simplex noise method, roughly creating
     connected blobs of 1s surrounded by 0s. If nearest neighbour
     upsampling is used, these blobs can be rectangular with sharp edges.
+
+    Added in 0.4.0. (Before that named `SimplexNoiseAlpha`.)
 
     **Supported dtypes**:
 
@@ -1124,6 +1150,7 @@ class BlendAlphaSimplexNoise(BlendAlphaElementwise):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, foreground=None, background=None, per_channel=False,
                  size_px_max=(2, 16), upscale_method=None,
                  iterations=(1, 3), aggregation_method="max",
@@ -1175,6 +1202,8 @@ class BlendAlphaFrequencyNoise(BlendAlphaElementwise):
     by ``0`` s and other times results in smaller patterns. If nearest
     neighbour upsampling is used, these blobs can be rectangular with sharp
     edges.
+
+    Added in 0.4.0. (Before that named `FrequencyNoiseAlpha`.)
 
     **Supported dtypes**:
 
@@ -1371,6 +1400,7 @@ class BlendAlphaFrequencyNoise(BlendAlphaElementwise):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, exponent=(-4, 4), foreground=None, background=None,
                  per_channel=False, size_px_max=(4, 16), upscale_method=None,
                  iterations=(1, 3), aggregation_method=["avg", "max"],
@@ -1439,6 +1469,8 @@ class BlendAlphaSomeColors(BlendAlphaMask):
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1538,6 +1570,7 @@ class BlendAlphaSomeColors(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, foreground=None, background=None,
                  nb_bins=(5, 15), smoothness=(0.1, 0.3),
                  alpha=[0.0, 1.0], rotation_deg=(0, 360),
@@ -1576,6 +1609,8 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1660,6 +1695,7 @@ class BlendAlphaHorizontalLinearGradient(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, foreground=None, background=None,
                  min_value=(0.0, 0.2), max_value=(0.8, 1.0),
                  start_at=(0.0, 0.2), end_at=(0.8, 1.0),
@@ -1695,6 +1731,8 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1786,6 +1824,7 @@ class BlendAlphaVerticalLinearGradient(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, foreground=None, background=None,
                  min_value=(0.0, 0.2), max_value=(0.8, 1.0),
                  start_at=(0.0, 0.2), end_at=(0.8, 1.0),
@@ -1824,6 +1863,8 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1911,6 +1952,7 @@ class BlendAlphaRegularGrid(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, nb_rows, nb_cols,
                  foreground=None, background=None,
                  alpha=[0.0, 1.0],
@@ -1947,6 +1989,8 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
         Avoid using augmenters as children that affect pixel locations (e.g.
         horizontal flips). See
         :class:`~imgaug.augmenters.blend.BlendAlphaMask` for details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2012,6 +2056,7 @@ class BlendAlphaCheckerboard(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, nb_rows, nb_cols,
                  foreground=None, background=None,
                  seed=None, name=None,
@@ -2053,6 +2098,8 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
 
         This class will produce an ``AssertionError`` if there are no
         segmentation maps in a batch.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2139,6 +2186,7 @@ class BlendAlphaSegMapClassIds(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  class_ids,
                  foreground=None, background=None,
@@ -2177,6 +2225,8 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
 
         This class will produce an ``AssertionError`` if there are no
         bounding boxes in a batch.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2265,6 +2315,7 @@ class BlendAlphaBoundingBoxes(BlendAlphaMask):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  labels,
                  foreground=None, background=None,
@@ -2290,8 +2341,11 @@ class IBatchwiseMaskGenerator(object):
     of masks, one per row (i.e. image), matching the row shape (i.e. image
     shape). This is used in :class:`~imgaug.augmenters.blend.BlendAlphaMask`.
 
+    Added in 0.4.0.
+
     """
 
+    # Added in 0.4.0.
     def draw_masks(self, batch, random_state=None):
         """Generate a mask with given shape.
 
@@ -2328,6 +2382,8 @@ class StochasticParameterMaskGen(IBatchwiseMaskGenerator):
     ``(H, W, C)`` mask (if ``per_channel`` is true-like).
     The ``per_channel`` is sampled per batch for each row/image.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     parameter : imgaug.parameters.StochasticParameter
@@ -2346,12 +2402,14 @@ class StochasticParameterMaskGen(IBatchwiseMaskGenerator):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, parameter, per_channel):
         super(StochasticParameterMaskGen, self).__init__()
         self.parameter = parameter
         self.per_channel = iap.handle_probability_param(per_channel,
                                                         "per_channel")
 
+    # Added in 0.4.0.
     def draw_masks(self, batch, random_state=None):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
@@ -2366,6 +2424,7 @@ class StochasticParameterMaskGen(IBatchwiseMaskGenerator):
                 for shape, per_channel_i
                 in zip(shapes, per_channel)]
 
+    # Added in 0.4.0.
     def _draw_mask(self, shape, random_state, per_channel):
         if len(shape) == 2 or per_channel >= 0.5:
             mask = self.parameter.draw_samples(shape,
@@ -2419,6 +2478,8 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
         This mask generator will produce an ``AssertionError`` for batches
         that contain no images.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2492,6 +2553,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
     """
 
+    # Added in 0.4.0.
     # TODO colorlib.CSPACE_RGB produces 'has no attribute' error?
     def __init__(self, nb_bins=(5, 15), smoothness=(0.1, 0.3),
                  alpha=[0.0, 1.0], rotation_deg=(0, 360),
@@ -2515,6 +2577,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
         self.sigma_max = 10.0
 
+    # Added in 0.4.0.
     def draw_masks(self, batch, random_state=None):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
@@ -2530,6 +2593,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
                 for i, image
                 in enumerate(batch.images)]
 
+    # Added in 0.4.0.
     def _draw_mask(self, image, image_idx, samples):
         return self.generate_mask(
             image,
@@ -2538,6 +2602,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
             samples[2][image_idx],
             self.from_colorspace)
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         nb_rows = batch.nb_rows
         nb_bins = self.nb_bins.draw_samples((nb_rows,),
@@ -2564,6 +2629,8 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
     def generate_mask(cls, image, binwise_alphas, sigma,
                       rotation_bins, from_colorspace):
         """Generate a colorwise alpha mask for a single image.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2616,6 +2683,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
         return mask
 
+    # Added in 0.4.0.
     @classmethod
     def _upscale_to_256_alpha_bins(cls, alphas):
         # repeat alphas bins so that B sampled bins become 256 bins
@@ -2625,6 +2693,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
         alphas = alphas[0:256]
         return alphas
 
+    # Added in 0.4.0.
     @classmethod
     def _rotate_alpha_bins(cls, alphas, rotation_bins):
         # e.g. for offset 2: abcdef -> cdefab
@@ -2633,6 +2702,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
             alphas = np.roll(alphas, -rotation_bins)
         return alphas
 
+    # Added in 0.4.0.
     @classmethod
     def _smoothen_alphas(cls, alphas, sigma):
         if sigma <= 0.0+1e-2:
@@ -2664,6 +2734,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
 
         return alphas
 
+    # Added in 0.4.0.
     @classmethod
     def _generate_pixelwise_alpha_mask(cls, image_hsv, hue_to_alpha):
         hue = image_hsv[:, :, 0]
@@ -2673,7 +2744,9 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
         return mask.astype(np.float32) / 255.0
 
 
+# Added in 0.4.0.
 class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
+    # Added in 0.4.0.
     def __init__(self, axis, min_value=0.0, max_value=1.0,
                  start_at=0.0, end_at=1.0):
         self.axis = axis
@@ -2694,6 +2767,8 @@ class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
+        Added in 0.4.0.
+
         """
         random_state = iarandom.RNG(random_state)
         shapes = batch.get_rowwise_shapes()
@@ -2703,6 +2778,7 @@ class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
                 for i, shape
                 in enumerate(shapes)]
 
+    # Added in 0.4.0.
     def _draw_mask(self, shape, image_idx, samples):
         return self.generate_mask(
             shape,
@@ -2711,6 +2787,7 @@ class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
             samples[2][image_idx],
             samples[3][image_idx])
 
+    # Added in 0.4.0.
     def _draw_samples(self, nb_rows, random_state):
         min_value = self.min_value.draw_samples((nb_rows,),
                                                 random_state=random_state)
@@ -2727,6 +2804,8 @@ class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
     @abstractmethod
     def generate_mask(cls, shape, min_value, max_value, start_at, end_at):
         """Generate a horizontal gradient mask.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2756,6 +2835,7 @@ class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
 
         """
 
+    # Added in 0.4.0.
     @classmethod
     def _generate_mask(cls, shape, axis, min_value, max_value, start_at,
                        end_at):
@@ -2815,6 +2895,8 @@ class HorizontalLinearGradientMaskGen(_LinearGradientMaskGen):
 
     Note that this has nothing to do with a *derivative* along the x-axis.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     min_value : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
@@ -2854,6 +2936,7 @@ class HorizontalLinearGradientMaskGen(_LinearGradientMaskGen):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, min_value=(0.0, 0.2), max_value=(0.8, 1.0),
                  start_at=(0.0, 0.2), end_at=(0.8, 1.0)):
         super(HorizontalLinearGradientMaskGen, self).__init__(
@@ -2866,6 +2949,8 @@ class HorizontalLinearGradientMaskGen(_LinearGradientMaskGen):
     @classmethod
     def generate_mask(cls, shape, min_value, max_value, start_at, end_at):
         """Generate a linear horizontal gradient mask.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2909,6 +2994,8 @@ class VerticalLinearGradientMaskGen(_LinearGradientMaskGen):
     See :class:`~imgaug.augmenters.blend.HorizontalLinearGradientMaskGen`
     for details.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     min_value : number or tuple of number or list of number or imgaug.parameters.StochasticParameter, optional
@@ -2948,6 +3035,7 @@ class VerticalLinearGradientMaskGen(_LinearGradientMaskGen):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, min_value=(0.0, 0.2), max_value=(0.8, 1.0),
                  start_at=(0.0, 0.2), end_at=(0.8, 1.0)):
         super(VerticalLinearGradientMaskGen, self).__init__(
@@ -2960,6 +3048,8 @@ class VerticalLinearGradientMaskGen(_LinearGradientMaskGen):
     @classmethod
     def generate_mask(cls, shape, min_value, max_value, start_at, end_at):
         """Generate a linear horizontal gradient mask.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -3008,6 +3098,8 @@ class RegularGridMaskGen(IBatchwiseMaskGenerator):
     samples random alpha values per cell, while in the checkerboard the
     alpha values follow a fixed pattern.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     nb_rows : int or tuple of int or list of int or imgaug.parameters.StochasticParameter
@@ -3036,6 +3128,7 @@ class RegularGridMaskGen(IBatchwiseMaskGenerator):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, nb_rows, nb_cols, alpha=[0.0, 1.0]):
         # pylint: disable=dangerous-default-value
         self.nb_rows = iap.handle_discrete_param(
@@ -3054,6 +3147,8 @@ class RegularGridMaskGen(IBatchwiseMaskGenerator):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
+        Added in 0.4.0.
+
         """
         random_state = iarandom.RNG(random_state)
         shapes = batch.get_rowwise_shapes()
@@ -3064,6 +3159,7 @@ class RegularGridMaskGen(IBatchwiseMaskGenerator):
                 for shape, nb_rows_i, nb_cols_i, alpha_i
                 in zip(shapes, nb_rows, nb_cols, alpha)]
 
+    # Added in 0.4.0.
     def _draw_samples(self, nb_images, random_state):
         nb_rows = self.nb_rows.draw_samples((nb_images,),
                                             random_state=random_state)
@@ -3081,6 +3177,8 @@ class RegularGridMaskGen(IBatchwiseMaskGenerator):
     @classmethod
     def generate_mask(cls, shape, nb_rows, nb_cols, alphas):
         """Generate a mask following a checkerboard pattern.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -3153,6 +3251,8 @@ class CheckerboardMaskGen(IBatchwiseMaskGenerator):
     and bottom neighbour cells are ``0.0``. The 4-neighbours of any cell always
     have a value opposite to the cell's value (``0.0`` vs. ``1.0``).
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     nb_rows : int or tuple of int or list of int or imgaug.parameters.StochasticParameter, optional
@@ -3178,15 +3278,37 @@ class CheckerboardMaskGen(IBatchwiseMaskGenerator):
 
     @property
     def nb_rows(self):
+        """Get the number of rows of the checkerboard grid.
+
+        Added in 0.4.0.
+
+        Returns
+        -------
+        int
+            The number of rows.
+
+        """
         return self.grid.nb_rows
 
     @property
     def nb_cols(self):
+        """Get the number of columns of the checkerboard grid.
+
+        Added in 0.4.0.
+
+        Returns
+        -------
+        int
+            The number of columns.
+
+        """
         return self.grid.nb_cols
 
     def draw_masks(self, batch, random_state=None):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+
+        Added in 0.4.0.
 
         """
         # pylint: disable=protected-access
@@ -3202,6 +3324,8 @@ class CheckerboardMaskGen(IBatchwiseMaskGenerator):
     @classmethod
     def generate_mask(cls, shape, nb_rows, nb_cols):
         """Generate a mask following a checkerboard pattern.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -3257,6 +3381,8 @@ class SegMapClassIdsMaskGen(IBatchwiseMaskGenerator):
         This class will produce an ``AssertionError`` if there are no
         segmentation maps in a batch.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     class_ids : int or tuple of int or list of int or imgaug.parameters.StochasticParameter
@@ -3303,6 +3429,7 @@ class SegMapClassIdsMaskGen(IBatchwiseMaskGenerator):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, class_ids, nb_sample_classes=None):
         if nb_sample_classes is None:
             if ia.is_single_integer(class_ids):
@@ -3329,6 +3456,8 @@ class SegMapClassIdsMaskGen(IBatchwiseMaskGenerator):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
+        Added in 0.4.0.
+
         """
         assert batch.segmentation_maps is not None, (
             "Can only generate masks for batches that contain segmentation "
@@ -3341,6 +3470,7 @@ class SegMapClassIdsMaskGen(IBatchwiseMaskGenerator):
                 for segmap, class_ids_i
                 in zip(batch.segmentation_maps, class_ids)]
 
+    # Added in 0.4.0.
     def _draw_samples(self, nb_rows, random_state):
         nb_sample_classes = self.nb_sample_classes
         if nb_sample_classes is None:
@@ -3364,6 +3494,8 @@ class SegMapClassIdsMaskGen(IBatchwiseMaskGenerator):
     @classmethod
     def generate_mask(cls, segmap, class_ids):
         """Generate a mask of where the segmentation map has the given classes.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -3414,6 +3546,8 @@ class BoundingBoxesMaskGen(IBatchwiseMaskGenerator):
         This class will produce an ``AssertionError`` if there are no
         bounding boxes in a batch.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     labels : None or str or list of str or imgaug.parameters.StochasticParameter
@@ -3459,6 +3593,7 @@ class BoundingBoxesMaskGen(IBatchwiseMaskGenerator):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, labels=None, nb_sample_labels=None):
         if labels is None:
             self.labels = None
@@ -3485,6 +3620,8 @@ class BoundingBoxesMaskGen(IBatchwiseMaskGenerator):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
 
+        Added in 0.4.0.
+
         """
         assert batch.bounding_boxes is not None, (
             "Can only generate masks for batches that contain bounding boxes, "
@@ -3501,6 +3638,7 @@ class BoundingBoxesMaskGen(IBatchwiseMaskGenerator):
                 for bbsoi, labels_i
                 in zip(batch.bounding_boxes, labels)]
 
+    # Added in 0.4.0.
     def _draw_samples(self, nb_rows, random_state):
         nb_sample_labels = self.nb_sample_labels
         if nb_sample_labels is None:
@@ -3524,6 +3662,8 @@ class BoundingBoxesMaskGen(IBatchwiseMaskGenerator):
     @classmethod
     def generate_mask(cls, bbsoi, labels):
         """Generate a mask of the areas of bounding boxes with given labels.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -3566,6 +3706,8 @@ class InvertMaskGen(IBatchwiseMaskGenerator):
     a child mask generator to produce a mask. That mask is then inverted
     for ``p%`` of all rows, i.e. converted to ``1.0 - mask``.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     p : bool or float or imgaug.parameters.StochasticParameter, optional
@@ -3577,6 +3719,7 @@ class InvertMaskGen(IBatchwiseMaskGenerator):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, p, child):
         self.p = iap.handle_probability_param(p, "p")
         self.child = child
@@ -3584,6 +3727,8 @@ class InvertMaskGen(IBatchwiseMaskGenerator):
     def draw_masks(self, batch, random_state=None):
         """
         See :func:`~imgaug.augmenters.blend.IBatchwiseMaskGenerator.draw_masks`.
+
+        Added in 0.4.0.
 
         """
         random_state = iarandom.RNG(random_state)
@@ -3602,14 +3747,21 @@ class InvertMaskGen(IBatchwiseMaskGenerator):
                        "Parameter 'first' was renamed to 'foreground'. "
                        "Parameter 'second' was renamed to 'background'.")
 def Alpha(factor=0, first=None, second=None, per_channel=False,
-          seed=None, name=None, random_state="deprecated", deterministic="deprecated"):
+          seed=None, name=None,
+          random_state="deprecated", deterministic="deprecated"):
+    """See :class:`BlendAlpha`.
+
+    Deprecated since 0.4.0.
+
+    """
     # pylint: disable=invalid-name
     return BlendAlpha(
         factor=factor,
         foreground=first,
         background=second,
         per_channel=per_channel,
-        seed=seed, name=name, random_state=random_state, deterministic=deterministic)
+        seed=seed, name=name,
+        random_state=random_state, deterministic=deterministic)
 
 
 @ia.deprecated(alt_func="AlphaElementwise",
@@ -3619,15 +3771,21 @@ def Alpha(factor=0, first=None, second=None, per_channel=False,
                        "Parameter 'first' was renamed to 'foreground'. "
                        "Parameter 'second' was renamed to 'background'.")
 def AlphaElementwise(factor=0, first=None, second=None, per_channel=False,
-                     seed=None, name=None, random_state="deprecated", deterministic="deprecated"):
-    """See :class:`BlendAlpha`."""
+                     seed=None, name=None,
+                     random_state="deprecated", deterministic="deprecated"):
+    """See :class:`BlendAlphaElementwise`.
+
+    Deprecated since 0.4.0.
+
+    """
     # pylint: disable=invalid-name
     return BlendAlphaElementwise(
         factor=factor,
         foreground=first,
         background=second,
         per_channel=per_channel,
-        seed=seed, name=name, random_state=random_state, deterministic=deterministic)
+        seed=seed, name=name,
+        random_state=random_state, deterministic=deterministic)
 
 
 @ia.deprecated(alt_func="BlendAlphaSimplexNoise",
@@ -3640,8 +3798,13 @@ def SimplexNoiseAlpha(first=None, second=None, per_channel=False,
                       size_px_max=(2, 16), upscale_method=None,
                       iterations=(1, 3), aggregation_method="max",
                       sigmoid=True, sigmoid_thresh=None,
-                      seed=None, name=None, random_state="deprecated", deterministic="deprecated"):
-    """See :class:`BlendAlphaSimplexNoise`."""
+                      seed=None, name=None,
+                      random_state="deprecated", deterministic="deprecated"):
+    """See :class:`BlendAlphaSimplexNoise`.
+
+    Deprecated since 0.4.0.
+
+    """
     # pylint: disable=invalid-name
     return BlendAlphaSimplexNoise(
         foreground=first,
@@ -3653,7 +3816,8 @@ def SimplexNoiseAlpha(first=None, second=None, per_channel=False,
         aggregation_method=aggregation_method,
         sigmoid=sigmoid,
         sigmoid_thresh=sigmoid_thresh,
-        seed=seed, name=name, random_state=random_state, deterministic=deterministic)
+        seed=seed, name=name,
+        random_state=random_state, deterministic=deterministic)
 
 
 @ia.deprecated(alt_func="BlendAlphaFrequencyNoise",
@@ -3667,8 +3831,13 @@ def FrequencyNoiseAlpha(exponent=(-4, 4), first=None, second=None,
                         upscale_method=None,
                         iterations=(1, 3), aggregation_method=["avg", "max"],
                         sigmoid=0.5, sigmoid_thresh=None,
-                        seed=None, name=None, random_state="deprecated", deterministic="deprecated"):
-    """See :class:`BlendAlphaFrequencyNoise`."""
+                        seed=None, name=None,
+                        random_state="deprecated", deterministic="deprecated"):
+    """See :class:`BlendAlphaFrequencyNoise`.
+
+    Deprecated since 0.4.0.
+
+    """
     # pylint: disable=invalid-name, dangerous-default-value
     return BlendAlphaFrequencyNoise(
         exponent=exponent,
@@ -3681,4 +3850,5 @@ def FrequencyNoiseAlpha(exponent=(-4, 4), first=None, second=None,
         aggregation_method=aggregation_method,
         sigmoid=sigmoid,
         sigmoid_thresh=sigmoid_thresh,
-        seed=seed, name=name, random_state=random_state, deterministic=deterministic)
+        seed=seed, name=name,
+        random_state=random_state, deterministic=deterministic)

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -286,6 +286,8 @@ def blur_mean_shift_(image, spatial_window_radius, color_window_radius):
 
         This function is quite slow.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -453,6 +455,7 @@ class GaussianBlur(meta.Augmenter):
         # apply the blur
         self.eps = 1e-3
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -614,6 +617,7 @@ class AverageBlur(meta.Augmenter):
                 "Expected int, tuple/list with 2 entries or "
                 "StochasticParameter. Got %s." % (type(k),))
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -778,6 +782,7 @@ class MedianBlur(meta.Augmenter):
                 "Expected all values in iterable k to be odd, but at least "
                 "one was not. Add or subtract 1 to/from that value.")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -938,6 +943,7 @@ class BilateralBlur(meta.Augmenter):
             sigma_space, "sigma_space", value_range=(1, None),
             tuple_to_uniform=True, list_to_choice=True)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=invalid-name
         if batch.images is None:
@@ -1085,13 +1091,16 @@ class MotionBlur(iaa_convolutional.Convolve):
             random_state=random_state, deterministic=deterministic)
 
 
+# Added in 0.4.0.
 class _MotionBlurMatrixGenerator(object):
+    # Added in 0.4.0.
     def __init__(self, k, angle, direction, order):
         self.k = k
         self.angle = angle
         self.direction = direction
         self.order = order
 
+    # Added in 0.4.0.
     def __call__(self, _image, nb_channels, random_state):
         # avoid cyclic import between blur and geometric
         from . import geometric as iaa_geometric
@@ -1138,6 +1147,8 @@ class MeanShiftBlur(meta.Augmenter):
     .. note::
 
         This augmenter is quite slow.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1194,6 +1205,8 @@ class MeanShiftBlur(meta.Augmenter):
     Create a mean shift blur augmenter.
 
     """
+
+    # Added in 0.4.0.
     def __init__(self, spatial_radius=(5.0, 40.0), color_radius=(5.0, 40.0),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1209,6 +1222,7 @@ class MeanShiftBlur(meta.Augmenter):
             value_range=(0.01, None), tuple_to_uniform=True,
             list_to_choice=True)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             samples = self._draw_samples(batch, random_state)
@@ -1221,6 +1235,7 @@ class MeanShiftBlur(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         nb_rows = batch.nb_rows
         return (
@@ -1230,6 +1245,7 @@ class MeanShiftBlur(meta.Augmenter):
                                                   random_state=random_state)
         )
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.spatial_window_radius, self.color_window_radius]

--- a/imgaug/augmenters/collections.py
+++ b/imgaug/augmenters/collections.py
@@ -4,6 +4,8 @@ List of augmenters:
 
     * :class:`RandAugment`
 
+Added in 0.4.0.
+
 """
 from __future__ import print_function, division, absolute_import
 
@@ -64,6 +66,8 @@ class RandAugment(meta.Sequential):
         process non-image data. (This augmenter uses PIL-based affine
         transformations to ensure that outputs are as similar as possible
         to the paper's implementation.)
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -180,6 +184,7 @@ class RandAugment(meta.Sequential):
     # N=2, M=9 is optimal for ImageNet with ResNet-50
     # N=2, M=28 is optimal for ImageNet with EfficientNet-B7
     # for cval they use [125, 122, 113]
+    # Added in 0.4.0.
     def __init__(self, n=2, m=(6, 12), cval=128,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -221,6 +226,7 @@ class RandAugment(meta.Sequential):
             random_state=random_state, deterministic=deterministic
         )
 
+    # Added in 0.4.0.
     @classmethod
     def _create_initial_augmenters_list(cls, m):
         # pylint: disable=invalid-name
@@ -241,6 +247,7 @@ class RandAugment(meta.Sequential):
             )
         ]
 
+    # Added in 0.4.0.
     @classmethod
     def _create_main_augmenters_list(cls, m, cval):
         # pylint: disable=invalid-name
@@ -327,6 +334,7 @@ class RandAugment(meta.Sequential):
             pillike.FilterSmooth()
         ]
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         someof = self[1]

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -394,9 +394,11 @@ def change_colorspaces_(images, to_colorspaces, from_colorspaces=CSPACE_RGB):
     return images
 
 
+# Added in 0.4.0.
 class _KelvinToRGBTableSingleton(object):
     _INSTANCE = None
 
+    # Added in 0.4.0.
     @classmethod
     def get_instance(cls):
         if cls._INSTANCE is None:
@@ -404,7 +406,9 @@ class _KelvinToRGBTableSingleton(object):
         return cls._INSTANCE
 
 
+# Added in 0.4.0.
 class _KelvinToRGBTable(object):
+    # Added in 0.4.0.
     def __init__(self):
         self.table = self.create_table()
 
@@ -414,6 +418,8 @@ class _KelvinToRGBTable(object):
         A single returned multiplier denotes the channelwise multipliers
         in the range ``[0.0, 1.0]`` to apply to an image to change its kelvin
         value to the desired one.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -446,6 +452,7 @@ class _KelvinToRGBTable(object):
 
         return multipliers
 
+    # Added in 0.4.0.
     @classmethod
     def create_table(cls):
         table = np.float32([
@@ -848,6 +855,8 @@ class _KelvinToRGBTable(object):
 def change_color_temperatures_(images, kelvins, from_colorspaces=CSPACE_RGB):
     """Change in-place the temperature of images to given values in Kelvin.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :class:`~imgaug.augmenters.color.change_colorspace_`.
@@ -942,6 +951,8 @@ def change_color_temperatures_(images, kelvins, from_colorspaces=CSPACE_RGB):
 
 def change_color_temperature(image, kelvin, from_colorspace=CSPACE_RGB):
     """Change the temperature of an image to a given value in Kelvin.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1056,6 +1067,7 @@ class WithColorspace(meta.Augmenter):
         self.from_colorspace = from_colorspace
         self.children = meta.handle_children_list(children, self.name, "then")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             # TODO this did not fail in the tests when there was only one
@@ -1111,6 +1123,8 @@ class WithBrightnessChannels(meta.Augmenter):
     channel and applies its child augmenters to this one channel. Afterwards,
     it reintegrates the augmented channel into the full image and converts
     back to the input colorspace.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1195,6 +1209,7 @@ class WithBrightnessChannels(meta.Augmenter):
 
     _VALID_COLORSPACES = set(_CSPACE_TO_CHANNEL_ID.keys())
 
+    # Added in 0.4.0.
     def __init__(self, children=None,
                  to_colorspace=[
                      CSPACE_YCrCb,
@@ -1217,6 +1232,7 @@ class WithBrightnessChannels(meta.Augmenter):
             valid_values=self._VALID_COLORSPACES)
         self.from_colorspace = from_colorspace
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             images_cvt = None
@@ -1248,6 +1264,7 @@ class WithBrightnessChannels(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _extract_brightness_channels(self, images, colorspaces):
         result = []
         for image, colorspace in zip(images, colorspaces):
@@ -1258,6 +1275,7 @@ class WithBrightnessChannels(meta.Augmenter):
             result.append(channel)
         return result
 
+    # Added in 0.4.0.
     def _invert_extract_brightness_channels(self, channels, images,
                                             colorspaces):
         for channel, image, colorspace in zip(channels, images, colorspaces):
@@ -1265,6 +1283,7 @@ class WithBrightnessChannels(meta.Augmenter):
             image[:, :, channel_id:channel_id+1] = channel
         return images
 
+    # Added in 0.4.0.
     def _to_deterministic(self):
         aug = self.copy()
         aug.children = aug.children.to_deterministic()
@@ -1272,14 +1291,17 @@ class WithBrightnessChannels(meta.Augmenter):
         aug.random_state = self.random_state.derive_rng_()
         return aug
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.to_colorspace, self.from_colorspace]
 
+    # Added in 0.4.0.
     def get_children_lists(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
+    # Added in 0.4.0.
     def __str__(self):
         return (
             "WithBrightnessChannels("
@@ -1301,6 +1323,8 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
 
     This is a wrapper around :class:`WithBrightnessChannels` and hence
     performs internally the same projection to random colorspaces.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1354,6 +1378,7 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, mul=(0.7, 1.3), add=(-30, 30),
                  to_colorspace=[
                      CSPACE_YCrCb,
@@ -1383,6 +1408,7 @@ class MultiplyAndAddToBrightness(WithBrightnessChannels):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def __str__(self):
         return (
             "MultiplyAndAddToBrightness("
@@ -1408,6 +1434,8 @@ class MultiplyBrightness(MultiplyAndAddToBrightness):
 
     This is a wrapper around :class:`WithBrightnessChannels` and hence
     performs internally the same projection to random colorspaces.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1452,6 +1480,7 @@ class MultiplyBrightness(MultiplyAndAddToBrightness):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, mul=(0.7, 1.3),
                  to_colorspace=[
                      CSPACE_YCrCb,
@@ -1479,6 +1508,8 @@ class AddToBrightness(MultiplyAndAddToBrightness):
 
     This is a wrapper around :class:`WithBrightnessChannels` and hence
     performs internally the same projection to random colorspaces.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1523,6 +1554,7 @@ class AddToBrightness(MultiplyAndAddToBrightness):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, add=(-30, 30),
                  to_colorspace=[
                      CSPACE_YCrCb,
@@ -1641,6 +1673,7 @@ class WithHueAndSaturation(meta.Augmenter):
         # for Add or Multiply
         self._internal_dtype = np.int16
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             images_hs, images_hsv = self._images_to_hsv_(batch.images)
@@ -1653,6 +1686,7 @@ class WithHueAndSaturation(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _images_to_hsv_(self, images):
         if images is None:
             return None, None
@@ -1676,6 +1710,7 @@ class WithHueAndSaturation(meta.Augmenter):
             images_hs = np.stack(images_hs, axis=0)
         return images_hs, images_hsv
 
+    # Added in 0.4.0.
     def _hs_to_images_(self, images_hs, images_hsv):
         if images_hs is None:
             return None
@@ -2092,6 +2127,8 @@ class RemoveSaturation(MultiplySaturation):
 
     This augmenter is the same as ``MultiplySaturation((0.0, 1.0))``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :class:`~imgaug.augmenters.color.MultiplySaturation`.
@@ -2151,6 +2188,7 @@ class RemoveSaturation(MultiplySaturation):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, mul=1, from_colorspace=CSPACE_RGB,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2398,6 +2436,7 @@ class AddToHueAndSaturation(meta.Augmenter):
 
         return samples_hue, samples_saturation
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -2872,6 +2911,7 @@ class ChangeColorspace(meta.Augmenter):
             (n_augmentables,), random_state=rss[1])
         return alphas, to_colorspaces
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -2993,10 +3033,12 @@ class ChangeColorTemperature(meta.Augmenter):
     in progressively darker blue tones.
 
     Color temperatures taken from
-    http://www.vendian.org/mncharity/dir3/blackbody/UnstableURLs/bbr_color.html
+    `<http://www.vendian.org/mncharity/dir3/blackbody/UnstableURLs/bbr_color.html>`_
 
     Basic method to change color temperatures taken from
-    https://stackoverflow.com/a/11888449
+    `<https://stackoverflow.com/a/11888449>`_
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3026,6 +3068,7 @@ class ChangeColorTemperature(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, kelvin=(1000, 11000), from_colorspace=CSPACE_RGB,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3038,6 +3081,7 @@ class ChangeColorTemperature(meta.Augmenter):
             list_to_choice=True)
         self.from_colorspace = from_colorspace
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             nb_rows = batch.nb_rows
@@ -3049,6 +3093,7 @@ class ChangeColorTemperature(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.kelvin, self.from_colorspace]
@@ -3092,6 +3137,7 @@ class _AbstractColorQuantization(meta.Augmenter):
 
         return counts
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -3341,7 +3387,11 @@ class KMeansColorQuantization(_AbstractColorQuantization):
 
     @property
     def n_colors(self):
-        """Alias for property ``counts``."""
+        """Alias for property ``counts``.
+
+        Added in 0.4.0.
+
+        """
         return self.counts
 
     def _quantize(self, image, counts):
@@ -3350,7 +3400,11 @@ class KMeansColorQuantization(_AbstractColorQuantization):
 
 @ia.deprecated("imgaug.augmenters.colors.quantize_kmeans")
 def quantize_colors_kmeans(image, n_colors, n_max_iter=10, eps=1.0):
-    """Outdated name of :func:`quantize_kmeans`."""
+    """Outdated name of :func:`quantize_kmeans`.
+
+    Deprecated since 0.4.0.
+
+    """
     return quantize_kmeans(arr=image, nb_clusters=n_colors,
                            nb_max_iter=n_max_iter, eps=eps)
 
@@ -3370,6 +3424,8 @@ def quantize_kmeans(arr, nb_clusters, nb_max_iter=10, eps=1.0):
         This function currently changes the RNG state of both OpenCV's
         internal RNG and imgaug's global RNG. This is necessary in order
         to ensure that the k-means clustering happens deterministically.
+
+    Added in 0.4.0. (Previously called ``quantize_colors_kmeans()``.)
 
     **Supported dtypes**:
 
@@ -3614,7 +3670,11 @@ class UniformColorQuantization(_AbstractColorQuantization):
 
     @property
     def n_colors(self):
-        """Alias for property ``counts``."""
+        """Alias for property ``counts``.
+
+        Added in 0.4.0.
+
+        """
         return self.counts
 
     def _quantize(self, image, counts):
@@ -3642,6 +3702,8 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
         or to have 3 or 4 channels and use colorspace `from_colorspace`. If
         images have 4 channels, it is assumed that the 4th channel is an alpha
         channel and it will not be quantized.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3745,6 +3807,7 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  nb_bits=(1, 8),
                  from_colorspace=CSPACE_RGB,
@@ -3767,12 +3830,15 @@ class UniformColorQuantizationToNBits(_AbstractColorQuantization):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def _quantize(self, image, counts):
         return quantize_uniform_to_n_bits_(image, counts)
 
 
 class Posterize(UniformColorQuantizationToNBits):
     """Alias for :class:`UniformColorQuantizationToNBits`.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3783,7 +3849,11 @@ class Posterize(UniformColorQuantizationToNBits):
 
 @ia.deprecated("imgaug.augmenters.colors.quantize_uniform")
 def quantize_colors_uniform(image, n_colors):
-    """Outdated name for :func:`quantize_uniform`."""
+    """Outdated name for :func:`quantize_uniform`.
+
+    Deprecated since 0.4.0.
+
+    """
     return quantize_uniform(arr=image, nb_bins=n_colors)
 
 
@@ -3791,6 +3861,8 @@ def quantize_uniform(arr, nb_bins, to_bin_centers=True):
     """Quantize an array into N equally-sized bins.
 
     See :func:`quantize_uniform_` for details.
+
+    Added in 0.4.0. (Previously called ``quantize_colors_uniform()``.)
 
     **Supported dtypes**:
 
@@ -3827,6 +3899,8 @@ def quantize_uniform_(arr, nb_bins, to_bin_centers=True):
     ``q = 256/N``, where ``v`` is a pixel intensity value and ``N`` is
     the target number of bins (roughly matches number of colors) after
     quantization.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3899,12 +3973,15 @@ def quantize_uniform_(arr, nb_bins, to_bin_centers=True):
     return arr
 
 
+# Added in 0.4.0.
 class _QuantizeUniformCenterizedLUTTableSingleton(object):
     _INSTANCE = None
 
     @classmethod
     def get_instance(cls):
         """Get singleton instance of :class:`_QuantizeUniformLUTTable`.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -3917,6 +3994,7 @@ class _QuantizeUniformCenterizedLUTTableSingleton(object):
         return cls._INSTANCE
 
 
+# Added in 0.4.0.
 class _QuantizeUniformNotCenterizedLUTTableSingleton(object):
     """Table for :func:`quantize_uniform` with ``to_bin_centers=False``."""
     _INSTANCE = None
@@ -3924,6 +4002,8 @@ class _QuantizeUniformNotCenterizedLUTTableSingleton(object):
     @classmethod
     def get_instance(cls):
         """Get singleton instance of :class:`_QuantizeUniformLUTTable`.
+
+        Added in 0.4.0.
 
         Returns
         -------
@@ -3936,14 +4016,20 @@ class _QuantizeUniformNotCenterizedLUTTableSingleton(object):
         return cls._INSTANCE
 
 
+# Added in 0.4.0.
 class _QuantizeUniformLUTTable(object):
     def __init__(self, centerize):
         self.table = self._generate_quantize_uniform_table(centerize)
 
     def get_for_nb_bins(self, nb_bins):
-        """Get LUT ndarray for a provided number of bins."""
+        """Get LUT ndarray for a provided number of bins.
+
+        Added in 0.4.0.
+
+        """
         return self.table[nb_bins, :]
 
+    # Added in 0.4.0.
     @classmethod
     def _generate_quantize_uniform_table(cls, centerize):
         # For simplicity, we generate here the tables for nb_bins=0 (results
@@ -3970,6 +4056,8 @@ def quantize_uniform_to_n_bits(arr, nb_bits):
     """Reduce each component in an array to a maximum number of bits.
 
     See :func:`quantize_uniform_to_n_bits` for details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4005,6 +4093,8 @@ def quantize_uniform_to_n_bits_(arr, nb_bits):
 
     This function produces the same outputs as :func:`PIL.ImageOps.posterize`,
     but is significantly faster.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4050,6 +4140,8 @@ def posterize(arr, nb_bits):
 
     This function is an alias for :func:`quantize_uniform_to_n_bits` and was
     added for users familiar with the same function in PIL.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -44,6 +44,7 @@ class _ContrastFuncWrapper(meta.Augmenter):
         self.dtypes_allowed = dtypes_allowed
         self.dtypes_disallowed = dtypes_disallowed
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -1011,6 +1012,7 @@ class AllChannelsCLAHE(meta.Augmenter):
         self.per_channel = iap.handle_probability_param(per_channel,
                                                         "per_channel")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -1273,6 +1275,7 @@ class CLAHE(meta.Augmenter):
         self.intensity_channel_based_applier = _IntensityChannelBasedApplier(
             from_colorspace, to_colorspace)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -1386,6 +1389,7 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -1545,6 +1549,7 @@ class HistogramEqualization(meta.Augmenter):
         self.intensity_channel_based_applier = _IntensityChannelBasedApplier(
             from_colorspace, to_colorspace)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -145,6 +145,7 @@ class Convolve(meta.Augmenter):
                 "StochasticParameter. Got %s." % (
                     type(matrix),))
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch

--- a/imgaug/augmenters/debug.py
+++ b/imgaug/augmenters/debug.py
@@ -4,6 +4,8 @@ List of augmenters:
 
     * :class:`SaveDebugImageEveryNBatches`
 
+Added in 0.4.0.
+
 """
 from __future__ import print_function, division, absolute_import
 
@@ -32,6 +34,8 @@ def _resizepad_to_size(image, size, cval):
     This first resizes until one image size matches one size in `size` (while
     retaining the aspect ratio).
     Then it pads the other side until both sides match `size`.
+
+    Added in 0.4.0.
 
     """
     # resize to height H and width W while keeping aspect ratio
@@ -80,19 +84,31 @@ class _IDebugGridCell(object):
 
     Usually corresponds to one image, but can also be e.g. a title/description.
 
+    Added in 0.4.0.
+
     """
 
     @abstractproperty
     def min_width(self):
-        """Minimum width in pixels that the cell requires."""
+        """Minimum width in pixels that the cell requires.
+
+        Added in 0.4.0.
+
+        """
 
     @abstractproperty
     def min_height(self):
-        """Minimum height in pixels that the cell requires."""
+        """Minimum height in pixels that the cell requires.
+
+        Added in 0.4.0.
+
+        """
 
     @abstractmethod
     def draw(self, height, width):
         """Draw the debug image grid cell's content.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -111,21 +127,29 @@ class _IDebugGridCell(object):
 
 
 class _DebugGridBorderCell(_IDebugGridCell):
-    """Helper to add a border around a cell within the debug image grid."""
+    """Helper to add a border around a cell within the debug image grid.
 
+    Added in 0.4.0.
+
+    """
+
+    # Added in 0.4.0.
     def __init__(self, size, color, child):
         self.size = size
         self.color = color
         self.child = child
 
+    # Added in 0.4.0.
     @property
     def min_height(self):
         return self.child.min_height
 
+    # Added in 0.4.0.
     @property
     def min_width(self):
         return self.child.min_width
 
+    # Added in 0.4.0.
     def draw(self, height, width):
         content = self.child.draw(height, width)
         content = sizelib.pad(content,
@@ -136,15 +160,22 @@ class _DebugGridBorderCell(_IDebugGridCell):
 
 
 class _DebugGridTextCell(_IDebugGridCell):
-    """Cell containing text."""
+    """Cell containing text.
 
+    Added in 0.4.0.
+
+    """
+
+    # Added in 0.4.0.
     def __init__(self, text):
         self.text = text
 
+    # Added in 0.4.0.
     @property
     def min_height(self):
         return max(20, len(self.text.split("\n")) * 17)
 
+    # Added in 0.4.0.
     @property
     def min_width(self):
         lines = self.text.split("\n")
@@ -152,6 +183,7 @@ class _DebugGridTextCell(_IDebugGridCell):
             return 20
         return max(20, int(7 * max([len(line) for line in lines])))
 
+    # Added in 0.4.0.
     def draw(self, height, width):
         image = np.full((height, width, 3), 255, dtype=np.uint8)
         image = ia.draw_text(image, 0, 0, self.text, color=(0, 0, 0),
@@ -160,21 +192,29 @@ class _DebugGridTextCell(_IDebugGridCell):
 
 
 class _DebugGridImageCell(_IDebugGridCell):
-    """Cell containing an image, possibly with an different-shaped overlay."""
+    """Cell containing an image, possibly with an different-shaped overlay.
 
+    Added in 0.4.0.
+
+    """
+
+    # Added in 0.4.0.
     def __init__(self, image, overlay=None, overlay_alpha=0.75):
         self.image = image
         self.overlay = overlay
         self.overlay_alpha = overlay_alpha
 
+    # Added in 0.4.0.
     @property
     def min_height(self):
         return self.image.shape[0]
 
+    # Added in 0.4.0.
     @property
     def min_width(self):
         return self.image.shape[1]
 
+    # Added in 0.4.0.
     def draw(self, height, width):
         image = self.image
         kind = image.dtype.kind
@@ -209,6 +249,7 @@ class _DebugGridImageCell(_IDebugGridCell):
 
         return blend
 
+    # Added in 0.4.0.
     @classmethod
     def _resize_overlay(cls, arr, size):
         arr_rs = ia.imresize_single_image(arr, size, interpolation="nearest")
@@ -221,20 +262,26 @@ class _DebugGridCBAsOICell(_IDebugGridCell):
     CBAsOI = coordinate-based augmentables on images,
     e.g. ``KeypointsOnImage``.
 
+    Added in 0.4.0.
+
     """
 
+    # Added in 0.4.0.
     def __init__(self, cbasoi, image):
         self.cbasoi = cbasoi
         self.image = image
 
+    # Added in 0.4.0.
     @property
     def min_height(self):
         return self.image.shape[0]
 
+    # Added in 0.4.0.
     @property
     def min_width(self):
         return self.image.shape[1]
 
+    # Added in 0.4.0.
     def draw(self, height, width):
         image_rsp, size_rs, paddings = _resizepad_to_size(
             self.image, (height, width), cval=_COLOR_GRID_BACKGROUND)
@@ -248,28 +295,48 @@ class _DebugGridCBAsOICell(_IDebugGridCell):
 
 
 class _DebugGridColumn(object):
-    """A single column within the debug image grid."""
+    """A single column within the debug image grid.
+
+    Added in 0.4.0.
+
+    """
 
     def __init__(self, cells):
         self.cells = cells
 
     @property
     def nb_rows(self):
-        """Number of rows in the column, i.e. examples in batch."""
+        """Number of rows in the column, i.e. examples in batch.
+
+        Added in 0.4.0.
+
+        """
         return len(self.cells)
 
     @property
     def max_cell_width(self):
-        """Width in pixels of the widest cell in the column."""
+        """Width in pixels of the widest cell in the column.
+
+        Added in 0.4.0.
+
+        """
         return max([cell.min_width for cell in self.cells])
 
     @property
     def max_cell_height(self):
-        """Height in pixels of the tallest cell in the column."""
+        """Height in pixels of the tallest cell in the column.
+
+        Added in 0.4.0.
+
+        """
         return max([cell.min_height for cell in self.cells])
 
     def draw(self, heights):
-        """Convert this column to an image array."""
+        """Convert this column to an image array.
+
+        Added in 0.4.0.
+
+        """
         width = self.max_cell_width
         return np.vstack([cell.draw(height=height, width=width)
                           for cell, height
@@ -282,14 +349,21 @@ class _DebugGrid(object):
     Columns correspond to the input datatypes (e.g. images, bounding boxes).
     Rows correspond to the examples within a batch.
 
+    Added in 0.4.0.
+
     """
 
+    # Added in 0.4.0.
     def __init__(self, columns):
         assert len(columns) > 0
         self.columns = columns
 
     def draw(self):
-        """Convert this grid to an image array."""
+        """Convert this grid to an image array.
+
+        Added in 0.4.0.
+
+        """
         nb_rows_by_col = [column.nb_rows for column in self.columns]
         assert len(set(nb_rows_by_col)) == 1
         rowwise_heights = np.zeros((self.columns[0].nb_rows,), dtype=np.int32)
@@ -309,6 +383,8 @@ def draw_debug_image(images, heatmaps=None, segmentation_maps=None,
                      keypoints=None, bounding_boxes=None, polygons=None,
                      line_strings=None):
     """Generate a debug image grid of a single batch and various datatypes.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -420,17 +496,20 @@ def draw_debug_image(images, heatmaps=None, segmentation_maps=None,
     return result
 
 
+# Added in 0.4.0.
 def _add_borders(cells):
     """Add a border (cell) around a cell."""
     return [_DebugGridBorderCell(1, _COLOR_GRID_BACKGROUND, cell)
             for cell in cells]
 
 
+# Added in 0.4.0.
 def _add_text_cell(title, cells):
     """Add a text cell before other cells."""
     return [_DebugGridTextCell(title)] + cells
 
 
+# Added in 0.4.0.
 def _create_images_column(images):
     """Create columns for image data."""
     cells = [_DebugGridImageCell(image) for image in images]
@@ -448,6 +527,7 @@ def _create_images_column(images):
     return column
 
 
+# Added in 0.4.0.
 def _create_heatmaps_columns(heatmaps, images):
     """Create columns for heatmap data."""
     nb_map_channels = max([heatmap.arr_0to1.shape[2]
@@ -478,6 +558,7 @@ def _create_heatmaps_columns(heatmaps, images):
     return columns
 
 
+# Added in 0.4.0.
 def _create_segmap_columns(segmentation_maps, images):
     """Create columns for segmentation map data."""
     nb_map_channels = max([segmap.arr.shape[2]
@@ -512,6 +593,7 @@ def _create_segmap_columns(segmentation_maps, images):
     return columns
 
 
+# Added in 0.4.0.
 def _create_cbasois_column(cbasois, images, column_name):
     """Create a column for coordinate-based augmentables."""
     cells = [_DebugGridCBAsOICell(cbasoi, image)
@@ -529,6 +611,7 @@ def _create_cbasois_column(cbasois, images, column_name):
     return column
 
 
+# Added in 0.4.0.
 def _generate_images_description(images):
     """Generate description for image columns."""
     if ia.is_np_array(images):
@@ -588,6 +671,7 @@ def _generate_images_description(images):
     return _join_description_strs(strs)
 
 
+# Added in 0.4.0.
 def _generate_segmaps_description(segmaps, channel_idx, show_details):
     """Generate description for segmap columns."""
     if len(segmaps) == 0:
@@ -606,6 +690,7 @@ def _generate_segmaps_description(segmaps, channel_idx, show_details):
     return _join_description_strs(strs + [value_range_str])
 
 
+# Added in 0.4.0.
 def _generate_heatmaps_description(heatmaps, channel_idx, show_details):
     """Generate description for heatmap columns."""
     if len(heatmaps) == 0:
@@ -623,6 +708,7 @@ def _generate_heatmaps_description(heatmaps, channel_idx, show_details):
     return _join_description_strs(strs + [value_range_str])
 
 
+# Added in 0.4.0.
 def _generate_sm_hm_description(augmentables, channel_idx, show_details):
     """Generate description for SegMap/Heatmap columns."""
     if augmentables is None:
@@ -670,6 +756,7 @@ def _generate_sm_hm_description(augmentables, channel_idx, show_details):
     return [channel_str, shapes_str, on_shapes_str]
 
 
+# Added in 0.4.0.
 def _generate_cbasois_description(cbasois, images):
     """Generate description for coordinate-based augmentable columns."""
     images_str = "items for %d images" % (len(cbasois),)
@@ -739,6 +826,7 @@ def _generate_cbasois_description(cbasois, images):
                                    labels_str, ooi_str, on_shapes_str])
 
 
+# Added in 0.4.0.
 def _generate_on_image_shapes_descr(augmentables):
     """Generate text block for non-image data describing their image shapes."""
     on_shapes = [augmentable.shape for augmentable in augmentables]
@@ -755,6 +843,7 @@ def _generate_on_image_shapes_descr(augmentables):
     return on_shapes_str
 
 
+# Added in 0.4.0.
 def _join_description_strs(strs):
     """Join lines to a single string while removing empty lines."""
     strs = [str_i for str_i in strs if len(str_i) > 0]
@@ -766,19 +855,24 @@ class _ListOfArraysStats(object):
 
     E.g. shape of the largest array, number of unique dtypes etc.
 
+    Added in 0.4.0.
+
     """
 
     def __init__(self, arrays):
         self.arrays = arrays
 
+    # Added in 0.4.0.
     @property
     def empty(self):
         return len(self.arrays) == 0
 
+    # Added in 0.4.0.
     @property
     def areas(self):
         return [np.prod(arr.shape[0:2]) for arr in self.arrays]
 
+    # Added in 0.4.0.
     @property
     def arrays_by_area(self):
         arrays_by_area = [
@@ -787,62 +881,74 @@ class _ListOfArraysStats(object):
         ]
         return arrays_by_area
 
+    # Added in 0.4.0.
     @property
     def shapes(self):
         return [arr.shape for arr in self.arrays]
 
+    # Added in 0.4.0.
     @property
     def all_same_shape(self):
         if self.empty:
             return True
         return len(set(self.shapes)) == 1
 
+    # Added in 0.4.0.
     @property
     def smallest_shape(self):
         if self.empty:
             return tuple()
         return self.arrays_by_area[0].shape
 
+    # Added in 0.4.0.
     @property
     def largest_shape(self):
         if self.empty:
             return tuple()
         return self.arrays_by_area[-1].shape
 
+    # Added in 0.4.0.
     @property
     def area_max(self):
         if self.empty:
             return tuple()
         return np.prod(self.arrays_by_area[-1][0:2])
 
+    # Added in 0.4.0.
     @property
     def heights(self):
         return [arr.shape[0] for arr in self.arrays]
 
+    # Added in 0.4.0.
     @property
     def height_min(self):
         heights = self.heights
         return min(heights) if len(heights) > 0 else 0
 
+    # Added in 0.4.0.
     @property
     def height_max(self):
         heights = self.heights
         return max(heights) if len(heights) > 0 else 0
 
+    # Added in 0.4.0.
     @property
     def widths(self):
         return [arr.shape[1] for arr in self.arrays]
 
+    # Added in 0.4.0.
     @property
     def width_min(self):
         widths = self.widths
         return min(widths) if len(widths) > 0 else 0
 
+    # Added in 0.4.0.
     @property
     def width_max(self):
         widths = self.widths
         return max(widths) if len(widths) > 0 else 0
 
+    # Added in 0.4.0.
     def get_channels_min(self, default):
         if self.empty:
             return -1
@@ -850,6 +956,7 @@ class _ListOfArraysStats(object):
             return default
         return min([arr.shape[2] for arr in self.arrays if arr.ndim > 2])
 
+    # Added in 0.4.0.
     def get_channels_max(self, default):
         if self.empty:
             return -1
@@ -857,36 +964,44 @@ class _ListOfArraysStats(object):
             return default
         return max([arr.shape[2] for arr in self.arrays if arr.ndim > 2])
 
+    # Added in 0.4.0.
     @property
     def dtypes(self):
         return [arr.dtype for arr in self.arrays]
 
+    # Added in 0.4.0.
     @property
     def dtype_names(self):
         return [dtype.name for dtype in self.dtypes]
 
+    # Added in 0.4.0.
     @property
     def all_same_dtype(self):
         return len(set(self.dtype_names)) in [0, 1]
 
+    # Added in 0.4.0.
     @property
     def all_dtypes_intlike(self):
         if self.empty:
             return True
         return all([arr.dtype.kind in ["u", "i", "b"] for arr in self.arrays])
 
+    # Added in 0.4.0.
     @property
     def unique_dtype_names(self):
         return sorted(list({arr.dtype.name for arr in self.arrays}))
 
+    # Added in 0.4.0.
     @property
     def value_min(self):
         return min([np.min(arr) for arr in self.arrays])
 
+    # Added in 0.4.0.
     @property
     def value_max(self):
         return max([np.max(arr) for arr in self.arrays])
 
+    # Added in 0.4.0.
     @property
     def nb_unique_values(self):
         values_uq = set()
@@ -895,6 +1010,7 @@ class _ListOfArraysStats(object):
         return len(values_uq)
 
 
+# Added in 0.4.0.
 @six.add_metaclass(ABCMeta)
 class _IImageDestination(object):
     """A destination which receives images to save."""
@@ -903,6 +1019,8 @@ class _IImageDestination(object):
         """Signal to the destination that a new batch is processed.
 
         This is intended to be used by the destination e.g. to count batches.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -914,6 +1032,8 @@ class _IImageDestination(object):
     def receive(self, image):
         """Receive and handle an image.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         image : ndarray
@@ -922,24 +1042,30 @@ class _IImageDestination(object):
         """
 
 
+# Added in 0.4.0.
 class _MultiDestination(_IImageDestination):
     """A list of multiple destinations behaving like a single one."""
 
+    # Added in 0.4.0.
     def __init__(self, destinations):
         self.destinations = destinations
 
+    # Added in 0.4.0.
     def on_batch(self, batch):
         for destination in self.destinations:
             destination.on_batch(batch)
 
+    # Added in 0.4.0.
     def receive(self, image):
         for destination in self.destinations:
             destination.receive(image)
 
 
+# Added in 0.4.0.
 class _FolderImageDestination(_IImageDestination):
     """A destination which saves images to a directory."""
 
+    # Added in 0.4.0.
     def __init__(self, folder_path,
                  filename_pattern="batch_{batch_id:06d}.png"):
         super(_FolderImageDestination, self).__init__()
@@ -948,22 +1074,27 @@ class _FolderImageDestination(_IImageDestination):
         self._batch_id = -1
         self._filepath = None
 
+    # Added in 0.4.0.
     def on_batch(self, batch):
         self._batch_id += 1
         self._filepath = os.path.join(
             self.folder_path,
             self.filename_pattern.format(batch_id=self._batch_id))
 
+    # Added in 0.4.0.
     def receive(self, image):
         imageio.imwrite(self._filepath, image)
 
 
+# Added in 0.4.0.
 @six.add_metaclass(ABCMeta)
 class _IBatchwiseSchedule(object):
     """A schedule determining per batch whether a condition is met."""
 
     def on_batch(self, batch):
         """Determine for the given batch whether the condition is met.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -978,10 +1109,13 @@ class _IBatchwiseSchedule(object):
         """
 
 
+# Added in 0.4.0.
 class _EveryNBatchesSchedule(_IBatchwiseSchedule):
     """A schedule that generates a signal at every ``N`` th batch.
 
     This schedule must be called for *every* batch in order to count them.
+
+    Added in 0.4.0.
 
     """
 
@@ -989,6 +1123,7 @@ class _EveryNBatchesSchedule(_IBatchwiseSchedule):
         self.interval = interval
         self._batch_id = -1
 
+    # Added in 0.4.0.
     def on_batch(self, batch):
         self._batch_id += 1
         signal = (self._batch_id % self.interval == 0)
@@ -997,6 +1132,8 @@ class _EveryNBatchesSchedule(_IBatchwiseSchedule):
 
 class _SaveDebugImage(meta.Augmenter):
     """Augmenter saving debug images to a destination according to a schedule.
+
+    Added in 0.4.0.
 
     Parameters
     ----------
@@ -1026,6 +1163,7 @@ class _SaveDebugImage(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, destination, schedule,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1035,6 +1173,7 @@ class _SaveDebugImage(meta.Augmenter):
         self.destination = destination
         self.schedule = schedule
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         save = self.schedule.on_batch(batch)
         self.destination.on_batch(batch)
@@ -1056,6 +1195,8 @@ class _SaveDebugImage(meta.Augmenter):
 
 class SaveDebugImageEveryNBatches(_SaveDebugImage):
     """Visualize data in batches and save corresponding plots to a folder.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1108,6 +1249,7 @@ class SaveDebugImageEveryNBatches(_SaveDebugImage):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, destination, interval,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1126,6 +1268,7 @@ class SaveDebugImageEveryNBatches(_SaveDebugImage):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def get_parameters(self):
         dests = self.destination.destinations
         return [

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -414,6 +414,7 @@ class Canny(meta.Augmenter):
 
         return alpha_samples, hthresh_samples, sobel_samples
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -874,6 +874,7 @@ class Fliplr(meta.Augmenter):
             random_state=random_state, deterministic=deterministic)
         self.p = iap.handle_probability_param(p, "p")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self.p.draw_samples((batch.nb_rows,),
                                       random_state=random_state)
@@ -985,6 +986,7 @@ class Flipud(meta.Augmenter):
             random_state=random_state, deterministic=deterministic)
         self.p = iap.handle_probability_param(p, "p")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self.p.draw_samples((batch.nb_rows,),
                                       random_state=random_state)

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -358,6 +358,8 @@ def apply_jigsaw(arr, destinations):
     This function will split the image into ``rows x cols`` cells and
     move each cell to the target index given in `destinations`.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -447,6 +449,8 @@ def apply_jigsaw_to_coords(coords, destinations, image_shape):
     This is the same as :func:`apply_jigsaw`, but moves coordinates within
     the cells.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     coords : ndarray
@@ -507,6 +511,8 @@ def apply_jigsaw_to_coords(coords, destinations, image_shape):
 def generate_jigsaw_destinations(nb_rows, nb_cols, max_steps, seed,
                                  connectivity=4):
     """Generate a destination pattern for :func:`apply_jigsaw`.
+
+    Added in 0.4.0.
 
     Parameters
     ----------
@@ -588,6 +594,7 @@ class _AffineSamplingResult(object):
         self.mode = mode
         self.order = order
 
+    # Added in 0.4.0.
     def get_affine_parameters(self, idx, arr_shape, image_shape):
         scale_y = self.scale[1][idx]  # TODO 1 and 0 should be inverted here
         scale_x = self.scale[0][idx]
@@ -665,9 +672,11 @@ class _AffineSamplingResult(object):
             return _compute_affine_warp_output_shape(matrix, arr_shape)
         return matrix, arr_shape
 
+    # Added in 0.4.0.
     def to_matrix_cba(self, idx, arr_shape, fit_output, shift_add=(0.0, 0.0)):
         return self.to_matrix(idx, arr_shape, arr_shape, fit_output, shift_add)
 
+    # Added in 0.4.0.
     def copy(self):
         return _AffineSamplingResult(
             scale=self.scale,
@@ -1292,6 +1301,7 @@ class Affine(meta.Augmenter):
                 "px"
             )
 
+    # Added in 0.4.0.
     @classmethod
     def _handle_shear_arg(cls, shear):
         # pylint: disable=no-else-return
@@ -1318,6 +1328,7 @@ class Affine(meta.Augmenter):
                 list_to_choice=True
             ), param_type
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self._draw_samples(batch.nb_rows, random_state)
 
@@ -1417,6 +1428,7 @@ class Affine(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, samples,
                                  arr_attr_name, cval, mode, order, cval_dtype):
         nb_images = len(augmentables)
@@ -1531,6 +1543,8 @@ class ScaleX(Affine):
 
     This is a wrapper around :class:`Affine`.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :class:`~imgaug.augmenters.geometric.Affine`.
@@ -1585,6 +1599,7 @@ class ScaleX(Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, scale=(0.5, 1.5), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None,
@@ -1604,6 +1619,8 @@ class ScaleY(Affine):
     """Apply affine scaling on the y-axis to input data.
 
     This is a wrapper around :class:`Affine`.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1659,6 +1676,7 @@ class ScaleY(Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, scale=(0.5, 1.5), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None,
@@ -1679,6 +1697,8 @@ class TranslateX(Affine):
     """Apply affine translation on the x-axis to input data.
 
     This is a wrapper around :class:`Affine`.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1743,6 +1763,7 @@ class TranslateX(Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, percent=None, px=None, order=1,
                  cval=0, mode="constant", fit_output=False, backend="auto",
                  seed=None, name=None,
@@ -1767,6 +1788,8 @@ class TranslateY(Affine):
     """Apply affine translation on the y-axis to input data.
 
     This is a wrapper around :class:`Affine`.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1831,6 +1854,7 @@ class TranslateY(Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, percent=None, px=None, order=1,
                  cval=0, mode="constant", fit_output=False, backend="auto",
                  seed=None, name=None,
@@ -1855,6 +1879,8 @@ class Rotate(Affine):
 
     This is a wrapper around :class:`Affine`.
     It is the same as ``Affine(rotate=<value>)``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1907,6 +1933,7 @@ class Rotate(Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, rotate=(-30, 30), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None,
@@ -1926,6 +1953,8 @@ class ShearX(Affine):
     """Apply affine shear on the x-axis to input data.
 
     This is a wrapper around :class:`Affine`.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1979,6 +2008,7 @@ class ShearX(Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, shear=(-30, 30), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None,
@@ -1998,6 +2028,8 @@ class ShearY(Affine):
     """Apply affine shear on the y-axis to input data.
 
     This is a wrapper around :class:`Affine`.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2051,6 +2083,7 @@ class ShearY(Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, shear=(-30, 30), order=1, cval=0, mode="constant",
                  fit_output=False, backend="auto",
                  seed=None, name=None,
@@ -2093,6 +2126,8 @@ class AffineCv2(meta.Augmenter):
     Some transformations involve interpolations between several pixels
     of the input image to generate output pixel values. The parameter `order`
     deals with the method of interpolation used for this.
+
+    Deprecated since 0.4.0.
 
     **Supported dtypes**:
 
@@ -3007,6 +3042,7 @@ class PiecewiseAffine(meta.Augmenter):
         self._cval_heatmaps = 0
         self._cval_segmentation_maps = 0
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self._draw_samples(batch.nb_rows, random_state)
 
@@ -3044,6 +3080,7 @@ class PiecewiseAffine(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
         iadt.gate_dtypes(
             images,
@@ -3090,6 +3127,7 @@ class PiecewiseAffine(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, arr_attr_name, samples,
                                  cval, mode, order):
         result = augmentables
@@ -3130,6 +3168,7 @@ class PiecewiseAffine(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, kpsois, samples):
         # pylint: disable=pointless-string-statement
         result = []
@@ -3452,6 +3491,8 @@ class PerspectiveTransform(meta.Augmenter):
         This setting should not be set to ``True`` when using large `scale`
         values as it could lead to very large images.
 
+        Added in 0.4.0.
+
     polygon_recoverer : 'auto' or None or imgaug.augmentables.polygons._ConcavePolygonRecoverer, optional
         The class to use to repair invalid polygons.
         If ``"auto"``, a new instance of
@@ -3582,6 +3623,7 @@ class PerspectiveTransform(meta.Augmenter):
             "of int/strings or StochasticParameter, got %s." % (
                 type(mode),))
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # Advance once, because below we always use random_state.copy() and
         # hence the sampling calls actually don't change random_state's state.
@@ -3638,6 +3680,7 @@ class PerspectiveTransform(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
         iadt.gate_dtypes(
             images,
@@ -3709,6 +3752,7 @@ class PerspectiveTransform(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, arr_attr_name,
                                  samples, samples_images, cval, mode, flags):
         result = augmentables
@@ -3772,6 +3816,7 @@ class PerspectiveTransform(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, kpsois, samples_images):
         result = kpsois
 
@@ -3801,6 +3846,7 @@ class PerspectiveTransform(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _draw_samples(self, shapes, random_state):
         # pylint: disable=invalid-name
         matrices = []
@@ -3941,6 +3987,7 @@ class PerspectiveTransform(meta.Augmenter):
         # return the ordered coordinates
         return pts_ordered
 
+    # Added in 0.4.0.
     @classmethod
     def _expand_transform(cls, matrix, shape):
         height, width = shape
@@ -4257,6 +4304,7 @@ class ElasticTransformation(meta.Augmenter):
         return _ElasticTransformationSamplingResult(
             rss[0:-5], alphas, sigmas, orders, cvals, modes)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=invalid-name
         if batch.images is not None:
@@ -4309,6 +4357,7 @@ class ElasticTransformation(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _augment_image_by_samples(self, image, row_idx, samples, dx, dy):
         # pylint: disable=invalid-name
         min_value, _center_value, max_value = \
@@ -4329,6 +4378,7 @@ class ElasticTransformation(meta.Augmenter):
             image_aug = iadt.restore_dtypes_(image_aug, input_dtype)
         return image_aug
 
+    # Added in 0.4.0.
     def _augment_hm_or_sm_by_samples(self, augmentable, row_idx, samples,
                                      dx, dy, arr_attr_name, cval, mode, order):
         # pylint: disable=invalid-name
@@ -4382,6 +4432,7 @@ class ElasticTransformation(meta.Augmenter):
 
         return augmentable
 
+    # Added in 0.4.0.
     def _augment_kpsoi_by_samples(self, kpsoi, row_idx, samples, dx, dy):
         # pylint: disable=misplaced-comparison-constant, invalid-name
         height, width = kpsoi.shape[0:2]
@@ -4444,6 +4495,7 @@ class ElasticTransformation(meta.Augmenter):
 
         return kpsoi
 
+    # Added in 0.4.0.
     def _augment_psoi_by_samples(self, psoi, row_idx, samples, dx, dy):
         # pylint: disable=invalid-name
         func = functools.partial(self._augment_kpsoi_by_samples,
@@ -4451,12 +4503,14 @@ class ElasticTransformation(meta.Augmenter):
         return self._apply_to_polygons_as_keypoints(
             psoi, func, recoverer=self.polygon_recoverer)
 
+    # Added in 0.4.0.
     def _augment_lsoi_by_samples(self, lsoi, row_idx, samples, dx, dy):
         # pylint: disable=invalid-name
         func = functools.partial(self._augment_kpsoi_by_samples,
                                  row_idx=row_idx, samples=samples, dx=dx, dy=dy)
         return self._apply_to_cbaois_as_keypoints(lsoi, func)
 
+    # Added in 0.4.0.
     def _augment_bbsoi_by_samples(self, bbsoi, row_idx, samples, dx, dy):
         # pylint: disable=invalid-name
         func = functools.partial(self._augment_kpsoi_by_samples,
@@ -4859,6 +4913,7 @@ class Rot90(meta.Augmenter):
     def _draw_samples(self, nb_images, random_state):
         return self.k.draw_samples((nb_images,), random_state=random_state)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=invalid-name
         ks = self._draw_samples(batch.nb_rows, random_state)
@@ -4910,6 +4965,7 @@ class Rot90(meta.Augmenter):
                 arrs_aug = np.array(arrs_aug, dtype=input_dtype)
         return arrs_aug
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, arr_attr_name, ks):
         # pylint: disable=invalid-name
         arrs = [getattr(map_i, arr_attr_name) for map_i in augmentables]
@@ -4934,6 +4990,7 @@ class Rot90(meta.Augmenter):
             maps_aug.append(augmentable_i)
         return maps_aug
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, keypoints_on_images, ks):
         # pylint: disable=invalid-name
         result = []
@@ -5028,6 +5085,8 @@ class WithPolarWarping(meta.Augmenter):
         recovery are currently ``PerspectiveTransform``, ``PiecewiseAffine``
         and ``ElasticTransformation``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -5099,6 +5158,7 @@ class WithPolarWarping(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, children,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -5107,6 +5167,7 @@ class WithPolarWarping(meta.Augmenter):
             random_state=random_state, deterministic=deterministic)
         self.children = meta.handle_children_list(children, self.name, "then")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             iadt.gate_dtypes(
@@ -5142,6 +5203,7 @@ class WithPolarWarping(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     @classmethod
     def _convert_bbs_to_polygons_(cls, batch):
         batch_contained_polygons = batch.polygons is not None
@@ -5175,6 +5237,7 @@ class WithPolarWarping(meta.Augmenter):
 
         return batch, (True, batch_contained_polygons)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_convert_bbs_to_polygons_(cls, batch, inv_data):
         batch_contained_bbs, batch_contained_polygons = inv_data
@@ -5214,69 +5277,84 @@ class WithPolarWarping(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_images_(cls, images):
         return cls._warp_arrays(images, False)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_images_(cls, images_warped, inv_data):
         return cls._invert_warp_arrays(images_warped, False, inv_data)
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_heatmaps_(cls, heatmaps):
         return cls._warp_maps_(heatmaps, "arr_0to1", False)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_heatmaps_(cls, heatmaps_warped, inv_data):
         return cls._invert_warp_maps_(heatmaps_warped, "arr_0to1", False,
                                       inv_data)
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_segmentation_maps_(cls, segmentation_maps):
         return cls._warp_maps_(segmentation_maps, "arr", True)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_segmentation_maps_(cls, segmentation_maps_warped,
                                         inv_data):
         return cls._invert_warp_maps_(segmentation_maps_warped, "arr", True,
                                       inv_data)
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_keypoints_(cls, kpsois):
         return cls._warp_cbaois_(kpsois)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_keypoints_(cls, kpsois_warped, image_shapes_orig):
         return cls._invert_warp_cbaois_(kpsois_warped, image_shapes_orig)
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_bounding_boxes_(cls, bbsois):  # pylint: disable=useless-return
         assert bbsois is None, ("Expected BBs to have been converted "
                                 "to polygons.")
         return None
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_bounding_boxes_(cls, bbsois_warped, _image_shapes_orig):  # pylint: disable=useless-return
         assert bbsois_warped is None, ("Expected BBs to have been converted "
                                        "to polygons.")
         return None
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_polygons_(cls, psois):
         return cls._warp_cbaois_(psois)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_polygons_(cls, psois_warped, image_shapes_orig):
         return cls._invert_warp_cbaois_(psois_warped, image_shapes_orig)
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_line_strings_(cls, lsois):
         return cls._warp_cbaois_(lsois)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_line_strings_(cls, lsois_warped, image_shapes_orig):
         return cls._invert_warp_cbaois_(lsois_warped, image_shapes_orig)
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_arrays(cls, arrays, interpolation_nearest):
         if arrays is None:
@@ -5334,6 +5412,7 @@ class WithPolarWarping(meta.Augmenter):
             shapes_orig.append(arr.shape)
         return arrays_warped, shapes_orig
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_arrays(cls, arrays_warped, interpolation_nearest,
                             inv_data):
@@ -5396,6 +5475,7 @@ class WithPolarWarping(meta.Augmenter):
             arrays_inv.append(arr_inv)
         return arrays_inv
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_maps_(cls, maps, arr_attr_name, interpolation_nearest):
         if maps is None:
@@ -5424,6 +5504,7 @@ class WithPolarWarping(meta.Augmenter):
 
         return maps, (shapes_imgs_orig, warparr_inv_data, skipped)
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_maps_(cls, maps_warped, arr_attr_name,
                            interpolation_nearest, invert_data):
@@ -5450,6 +5531,7 @@ class WithPolarWarping(meta.Augmenter):
 
         return maps_warped
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_coords(cls, coords, image_shapes):
         if coords is None:
@@ -5477,6 +5559,7 @@ class WithPolarWarping(meta.Augmenter):
             coords_warped.append(coords_i_warped)
         return coords_warped, image_shapes
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_coords(cls, coords_warped, image_shapes_after_aug,
                             inv_data):
@@ -5505,6 +5588,7 @@ class WithPolarWarping(meta.Augmenter):
             coords_inv.append(coords_i_inv)
         return coords_inv
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_cbaois_(cls, cbaois):
         if cbaois is None:
@@ -5523,6 +5607,7 @@ class WithPolarWarping(meta.Augmenter):
 
         return cbaois, inv_data
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_warp_cbaois_(cls, cbaois_warped, image_shapes_orig):
         if cbaois_warped is None:
@@ -5543,6 +5628,7 @@ class WithPolarWarping(meta.Augmenter):
 
         return cbaois
 
+    # Added in 0.4.0.
     @classmethod
     def _warp_shape_tuples(cls, shapes):
         # pylint: disable=invalid-name
@@ -5567,6 +5653,7 @@ class WithPolarWarping(meta.Augmenter):
             result.append(tuple([height, width] + list(shape[2:])))
         return result
 
+    # Added in 0.4.0.
     @classmethod
     def warpPolarCoords(cls, src, dsize, center, maxRadius, flags):
         # See
@@ -5619,14 +5706,17 @@ class WithPolarWarping(meta.Augmenter):
 
             return np.concatenate([rho, phi], axis=1)
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
 
+    # Added in 0.4.0.
     def get_children_lists(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_children_lists`."""
         return [self.children]
 
+    # Added in 0.4.0.
     def _to_deterministic(self):
         aug = self.copy()
         aug.children = aug.children.to_deterministic()
@@ -5634,6 +5724,7 @@ class WithPolarWarping(meta.Augmenter):
         aug.random_state = self.random_state.derive_rng_()
         return aug
 
+    # Added in 0.4.0.
     def __str__(self):
         pattern = (
             "%s("
@@ -5666,6 +5757,8 @@ class Jigsaw(meta.Augmenter):
         This augmenter currently only supports augmentation of images,
         heatmaps, segmentation maps and keypoints. Other augmentables,
         i.e. bounding boxes, polygons and line strings, will result in errors.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -5748,6 +5841,7 @@ class Jigsaw(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, nb_rows=(3, 10), nb_cols=(3, 10), max_steps=1,
                  allow_pad=True,
                  seed=None, name=None,
@@ -5767,6 +5861,7 @@ class Jigsaw(meta.Augmenter):
             tuple_to_uniform=True, list_to_choice=True, allow_floats=False)
         self.allow_pad = allow_pad
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         samples = self._draw_samples(batch, random_state)
 
@@ -5837,6 +5932,7 @@ class Jigsaw(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         nb_images = batch.nb_rows
         nb_rows = self.nb_rows.draw_samples((nb_images,),
@@ -5856,6 +5952,7 @@ class Jigsaw(meta.Augmenter):
         samples = _JigsawSamples(nb_rows, nb_cols, max_steps, destinations)
         return samples
 
+    # Added in 0.4.0.
     @classmethod
     def _resize_maps(cls, batch):
         # skip computation of rowwise shapes
@@ -5870,6 +5967,7 @@ class Jigsaw(meta.Augmenter):
 
         return batch, (heatmaps_shapes_orig, sm_shapes_orig)
 
+    # Added in 0.4.0.
     @classmethod
     def _resize_maps_single_list(cls, augmentables, arr_attr_name,
                                  image_shapes):
@@ -5885,6 +5983,7 @@ class Jigsaw(meta.Augmenter):
             shapes_orig.append(shape_orig)
         return augms_resized, shapes_orig
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_resize_maps(cls, batch, shapes_orig):
         batch.heatmaps = cls._invert_resize_maps_single_list(
@@ -5894,6 +5993,7 @@ class Jigsaw(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     @classmethod
     def _invert_resize_maps_single_list(cls, augmentables, shapes_orig):
         if shapes_orig is None:
@@ -5904,11 +6004,14 @@ class Jigsaw(meta.Augmenter):
             augms_resized.append(augmentable.resize(shape_orig[0:2]))
         return augms_resized
 
+    # Added in 0.4.0.
     def get_parameters(self):
         return [self.nb_rows, self.nb_cols, self.max_steps, self.allow_pad]
 
 
+# Added in 0.4.0.
 class _JigsawSamples(object):
+    # Added in 0.4.0.
     def __init__(self, nb_rows, nb_cols, max_steps, destinations):
         self.nb_rows = nb_rows
         self.nb_cols = nb_cols

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -64,6 +64,8 @@ Example usage::
     Use e.g. ``iaa.imgcorruptlike.GaussianNoise(severity=2)(images=...)`` to
     create and apply a specific augmenter.
 
+Added in 0.4.0.
+
 """
 from __future__ import print_function, division, absolute_import
 
@@ -89,6 +91,7 @@ _MISSING_PACKAGE_ERROR_MSG = (
 )
 
 
+# Added in 0.4.0.
 def _clipped_zoom_no_scipy_warning(img, zoom_factor):
     from scipy.ndimage import zoom as scizoom
 
@@ -114,6 +117,8 @@ def _call_imgcorrupt_func(fname, seed, convert_to_pil, *args, **kwargs):
 
     The dtype support below is basically a placeholder to which the
     augmentation functions can point to decrease the amount of documentation.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -216,6 +221,8 @@ def get_corruption_names(subset="common"):
         corresponding augmentation functions, while ``get_corruption_names()``
         in ``imagecorruptions`` only returns the augmentation names.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     subset : {'common', 'validation', 'all'}, optional.
@@ -261,6 +268,8 @@ def get_corruption_names(subset="common"):
 def apply_gaussian_noise(x, severity=1, seed=None):
     """Apply ``gaussian_noise`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -290,6 +299,8 @@ def apply_gaussian_noise(x, severity=1, seed=None):
 
 def apply_shot_noise(x, severity=1, seed=None):
     """Apply ``shot_noise`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -321,6 +332,8 @@ def apply_shot_noise(x, severity=1, seed=None):
 def apply_impulse_noise(x, severity=1, seed=None):
     """Apply ``impulse_noise`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -350,6 +363,8 @@ def apply_impulse_noise(x, severity=1, seed=None):
 
 def apply_speckle_noise(x, severity=1, seed=None):
     """Apply ``speckle_noise`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -381,6 +396,8 @@ def apply_speckle_noise(x, severity=1, seed=None):
 def apply_gaussian_blur(x, severity=1, seed=None):
     """Apply ``gaussian_blur`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -411,6 +428,8 @@ def apply_gaussian_blur(x, severity=1, seed=None):
 def apply_glass_blur(x, severity=1, seed=None):
     """Apply ``glass_blur`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -439,6 +458,7 @@ def apply_glass_blur(x, severity=1, seed=None):
                                  severity)
 
 
+# Added in 0.4.0.
 def _apply_glass_blur_imgaug(x, severity=1):
     # false positive on x_shape[0]
     # invalid name for dx, dy
@@ -501,6 +521,8 @@ def _apply_glass_blur_imgaug(x, severity=1):
 def apply_defocus_blur(x, severity=1, seed=None):
     """Apply ``defocus_blur`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -530,6 +552,8 @@ def apply_defocus_blur(x, severity=1, seed=None):
 
 def apply_motion_blur(x, severity=1, seed=None):
     """Apply ``motion_blur`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -561,6 +585,8 @@ def apply_motion_blur(x, severity=1, seed=None):
 def apply_zoom_blur(x, severity=1, seed=None):
     """Apply ``zoom_blur`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -590,6 +616,8 @@ def apply_zoom_blur(x, severity=1, seed=None):
 
 def apply_fog(x, severity=1, seed=None):
     """Apply ``fog`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -621,6 +649,8 @@ def apply_fog(x, severity=1, seed=None):
 def apply_frost(x, severity=1, seed=None):
     """Apply ``frost`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -650,6 +680,8 @@ def apply_frost(x, severity=1, seed=None):
 
 def apply_snow(x, severity=1, seed=None):
     """Apply ``snow`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -681,6 +713,8 @@ def apply_snow(x, severity=1, seed=None):
 def apply_spatter(x, severity=1, seed=None):
     """Apply ``spatter`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -710,6 +744,8 @@ def apply_spatter(x, severity=1, seed=None):
 
 def apply_contrast(x, severity=1, seed=None):
     """Apply ``contrast`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -741,6 +777,8 @@ def apply_contrast(x, severity=1, seed=None):
 def apply_brightness(x, severity=1, seed=None):
     """Apply ``brightness`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -770,6 +808,8 @@ def apply_brightness(x, severity=1, seed=None):
 
 def apply_saturate(x, severity=1, seed=None):
     """Apply ``saturate`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -801,6 +841,8 @@ def apply_saturate(x, severity=1, seed=None):
 def apply_jpeg_compression(x, severity=1, seed=None):
     """Apply ``jpeg_compression`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -831,6 +873,8 @@ def apply_jpeg_compression(x, severity=1, seed=None):
 def apply_pixelate(x, severity=1, seed=None):
     """Apply ``pixelate`` from ``imagecorruptions``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.imgcorruptlike._call_imgcorrupt_func`.
@@ -860,6 +904,8 @@ def apply_pixelate(x, severity=1, seed=None):
 
 def apply_elastic_transform(image, severity=1, seed=None):
     """Apply ``elastic_transform`` from ``imagecorruptions``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -955,6 +1001,7 @@ def apply_elastic_transform(image, severity=1, seed=None):
 #     return augmenter_class
 
 
+# Added in 0.4.0.
 class _ImgcorruptAugmenterBase(meta.Augmenter):
     def __init__(self, func, severity=1,
                  seed=None, name=None,
@@ -968,6 +1015,7 @@ class _ImgcorruptAugmenterBase(meta.Augmenter):
             severity, "severity", value_range=(1, 5), tuple_to_uniform=True,
             list_to_choice=True, allow_floats=False)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -980,6 +1028,7 @@ class _ImgcorruptAugmenterBase(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, nb_rows, random_state):
         severities = self.severity.draw_samples((nb_rows,),
                                                 random_state=random_state)
@@ -987,6 +1036,7 @@ class _ImgcorruptAugmenterBase(meta.Augmenter):
 
         return severities, seeds
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.severity]
@@ -999,6 +1049,8 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1039,6 +1091,7 @@ class GaussianNoise(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1055,6 +1108,8 @@ class ShotNoise(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1095,6 +1150,7 @@ class ShotNoise(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1111,6 +1167,8 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1151,6 +1209,7 @@ class ImpulseNoise(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1167,6 +1226,8 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1207,6 +1268,7 @@ class SpeckleNoise(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1223,6 +1285,8 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1263,6 +1327,7 @@ class GaussianBlur(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1279,6 +1344,8 @@ class GlassBlur(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1319,6 +1386,7 @@ class GlassBlur(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1335,6 +1403,8 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1375,6 +1445,7 @@ class DefocusBlur(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1391,6 +1462,8 @@ class MotionBlur(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1431,6 +1504,7 @@ class MotionBlur(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1447,6 +1521,8 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1487,6 +1563,7 @@ class ZoomBlur(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1503,6 +1580,8 @@ class Fog(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1543,6 +1622,7 @@ class Fog(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1559,6 +1639,8 @@ class Frost(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1599,6 +1681,7 @@ class Frost(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1615,6 +1698,8 @@ class Snow(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1655,6 +1740,7 @@ class Snow(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1671,6 +1757,8 @@ class Spatter(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1711,6 +1799,7 @@ class Spatter(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1727,6 +1816,8 @@ class Contrast(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1767,6 +1858,7 @@ class Contrast(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1783,6 +1875,8 @@ class Brightness(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1823,6 +1917,7 @@ class Brightness(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1839,6 +1934,8 @@ class Saturate(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1879,6 +1976,7 @@ class Saturate(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1895,6 +1993,8 @@ class JpegCompression(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1935,6 +2035,7 @@ class JpegCompression(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1951,6 +2052,8 @@ class Pixelate(_ImgcorruptAugmenterBase):
     .. note::
 
         This augmenter only affects images. Other data is not changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1991,6 +2094,7 @@ class Pixelate(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2011,6 +2115,8 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
         coordinate-based augmentables will be rejected with an error.
         Use :class:`~imgaug.augmenters.geometric.ElasticTransformation` if
         you have to transform such inputs.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2051,6 +2157,7 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, severity=(1, 5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2059,6 +2166,7 @@ class ElasticTransform(_ImgcorruptAugmenterBase):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         cols = batch.get_column_names()
         assert len(cols) == 0 or (len(cols) == 1 and "images" in cols), (

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -258,6 +258,8 @@ class Augmenter(object):
         If a new bit generator has to be created, it will be an instance
         of :class:`numpy.random.SFC64`.
 
+        Added in 0.4.0.
+
     name : None or str, optional
         Name given to the Augmenter instance. This name is used when
         converting the instance to a string, e.g. for ``print`` statements.
@@ -551,7 +553,11 @@ class Augmenter(object):
                            "must be changed to "
                            "`augment_batch(batch, hooks=hooks)`.")
     def augment_batch(self, batch, hooks=None):
-        """Augment a single batch."""
+        """Augment a single batch.
+
+        Deprecated since 0.4.0.
+
+        """
         # We call augment_batch_() directly here without copy, because this
         # method never copies. Would make sense to add a copy here if the
         # method is un-deprecated at some point.
@@ -561,6 +567,8 @@ class Augmenter(object):
     def augment_batch_(self, batch, parents=None, hooks=None):
         """
         Augment a single batch in-place.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -686,6 +694,8 @@ class Augmenter(object):
         This method does not have to care about determinism or the
         Augmenter instance's ``random_state`` variable. The parameter
         ``random_state`` takes care of both of these.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1342,6 +1352,8 @@ class Augmenter(object):
             is now the preferred way of implementing custom augmentation
             routines.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         bounding_boxes_on_images : list of imgaug.augmentables.bbs.BoundingBoxesOnImage
@@ -1455,6 +1467,8 @@ class Augmenter(object):
         """
         Augment BBs by applying keypoint augmentation to their corners.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         bounding_boxes_on_images : list of imgaug.augmentables.bbs.BoundingBoxesOnImages or imgaug.augmentables.bbs.BoundingBoxesOnImages
@@ -1565,6 +1579,8 @@ class Augmenter(object):
         """
         Augment bounding boxes by applying KP augmentation to their corners.
 
+        Added in 0.4.0.
+
         Parameters
         ----------
         cbaois : list of imgaug.augmentables.bbs.BoundingBoxesOnImage or list of imgaug.augmentables.polys.PolygonsOnImage or list of imgaug.augmentables.lines.LineStringsOnImage or imgaug.augmentables.bbs.BoundingBoxesOnImage or imgaug.augmentables.polys.PolygonsOnImage or imgaug.augmentables.lines.LineStringsOnImage
@@ -1598,6 +1614,8 @@ class Augmenter(object):
                                         recoverer=None, random_state=None):
         """
         Apply a callback to polygons in keypoint-representation.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -1655,6 +1673,8 @@ class Augmenter(object):
     def _apply_to_cbaois_as_keypoints(cls, cbaois, func):
         """
         Augment bounding boxes by applying KP augmentation to their corners.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2282,7 +2302,11 @@ class Augmenter(object):
 
     @ia.deprecated("imgaug.augmenters.meta.Augmenter.seed_")
     def reseed(self, random_state=None, deterministic_too=False):
-        """Old name of :func:`~imgaug.augmenters.meta.Augmenter.seed_`."""
+        """Old name of :func:`~imgaug.augmenters.meta.Augmenter.seed_`.
+
+        Deprecated since 0.4.0.
+
+        """
         self.seed_(entropy=random_state, deterministic_too=deterministic_too)
 
     # TODO mark this as in-place
@@ -2312,6 +2336,8 @@ class Augmenter(object):
         use the same seeds and therefore apply the same augmentations.
         Note that :func:`Augmenter.augment_batches` and :func:`Augmenter.pool`
         already do this automatically.
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -2833,7 +2859,7 @@ class Augmenter(object):
             This can only be ``False`` if copy is set to ``True``.
 
         noop_if_topmost : bool, optional
-            Deprecated.
+            Deprecated since 0.4.0.
 
         Returns
         -------
@@ -2877,7 +2903,11 @@ class Augmenter(object):
 
     @ia.deprecated("remove_augmenters_")
     def remove_augmenters_inplace(self, func, parents=None):
-        """Old name for :func:`~imgaug.meta.Augmenter.remove_augmenters_`."""
+        """Old name for :func:`~imgaug.meta.Augmenter.remove_augmenters_`.
+
+        Deprecated since 0.4.0.
+
+        """
         self.remove_augmenters_(func=func, parents=parents)
 
     # TODO allow first arg to be string name, class type or func
@@ -2889,6 +2919,8 @@ class Augmenter(object):
         :func:`~imgaug.augmenters.meta.remove_augmenters` with
         ``copy=False``, except that it does not affect the topmost augmenter
         (the one on which this function is initially called on).
+
+        Added in 0.4.0.
 
         Parameters
         ----------
@@ -3094,6 +3126,7 @@ class Sequential(Augmenter, list):
                 type(random_order),))
         self.random_order = random_order
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             if self.random_order:
@@ -3354,6 +3387,7 @@ class SomeOf(Augmenter, list):
             random_state.shuffle(row)
         return augmenter_active
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             # This must happen before creating the augmenter_active array,
@@ -3587,6 +3621,7 @@ class Sometimes(Augmenter):
         self.else_list = handle_children_list(else_list, self.name, "else",
                                               default=None)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             samples = self.p.draw_samples((batch.nb_rows,),
@@ -3744,6 +3779,7 @@ class WithChannels(Augmenter):
 
         self.children = handle_children_list(children, self.name, "then")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if self.channels is not None and len(self.channels) == 0:
             return batch
@@ -3788,6 +3824,7 @@ class WithChannels(Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     @classmethod
     def _assert_lengths_not_changed(cls, images_aug, images):
         assert len(images_aug) == len(images), (
@@ -3795,6 +3832,7 @@ class WithChannels(Augmenter):
             "augmentation, but got %d vs. originally %d images." % (
                 len(images_aug), len(images)))
 
+    # Added in 0.4.0.
     @classmethod
     def _assert_shapes_not_changed(cls, images_aug, images):
         if ia.is_np_array(images_aug) and ia.is_np_array(images):
@@ -3811,6 +3849,7 @@ class WithChannels(Augmenter):
                 str([image_aug.shape[0:2] for image_aug in images_aug]),
             ))
 
+    # Added in 0.4.0.
     @classmethod
     def _assert_dtypes_not_changed(cls, images_aug, images):
         if ia.is_np_array(images_aug) and ia.is_np_array(images):
@@ -3828,12 +3867,14 @@ class WithChannels(Augmenter):
                 str([image_aug.dtype.name for image_aug in images_aug]),
             ))
 
+    # Added in 0.4.0.
     @classmethod
     def _recover_images_array(cls, images_aug, images):
         if ia.is_np_array(images):
             return np.array(images_aug)
         return images_aug
 
+    # Added in 0.4.0.
     def _reduce_images_to_channels(self, images):
         if self.channels is None:
             return images
@@ -3841,6 +3882,7 @@ class WithChannels(Augmenter):
             return images[..., self.channels]
         return [image[..., self.channels] for image in images]
 
+    # Added in 0.4.0.
     def _invert_reduce_images_to_channels(self, images_aug, images):
         if self.channels is None:
             return images_aug
@@ -3849,6 +3891,7 @@ class WithChannels(Augmenter):
             image[..., self.channels] = image_aug
         return images
 
+    # Added in 0.4.0.
     def _replace_unaugmented_cells(self, augmentables_aug, augmentables):
         if self.channels is None:
             return augmentables_aug
@@ -3898,6 +3941,8 @@ class Identity(Augmenter):
     This augmenter is useful e.g. during validation/testing as it allows
     to re-use the training code without actually performing any augmentation.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -3942,6 +3987,7 @@ class Identity(Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3949,9 +3995,11 @@ class Identity(Augmenter):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         return batch
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
@@ -4089,6 +4137,8 @@ class Lambda(Augmenter):
         bounding boxes will automatically be augmented by transforming their
         corner vertices to keypoints and calling `func_keypoints`.
 
+        Added in 0.4.0.
+
     func_polygons : "keypoints" or None or callable, optional
         The function to call for each batch of polygons.
         It must follow the form::
@@ -4118,6 +4168,8 @@ class Lambda(Augmenter):
         If this is the string ``"keypoints"`` instead of a function, the
         line strings will automatically be augmented by transforming their
         corner vertices to keypoints and calling `func_keypoints`.
+
+        Added in 0.4.0.
 
     seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
@@ -4272,6 +4324,7 @@ class Lambda(Augmenter):
             return result
         return polygons_on_images
 
+    # Added in 0.4.0.
     def _augment_line_strings(self, line_strings_on_images, random_state,
                               parents, hooks):
         if self.func_line_strings == "keypoints":
@@ -4293,6 +4346,7 @@ class Lambda(Augmenter):
             return result
         return line_strings_on_images
 
+    # Added in 0.4.0.
     def _augment_bounding_boxes(self, bounding_boxes_on_images, random_state,
                                 parents, hooks):
         if self.func_bounding_boxes == "keypoints":
@@ -4405,6 +4459,8 @@ class AssertLambda(Lambda):
         It essentially re-uses the interface of
         :func:`~imgaug.augmenters.meta.Augmenter._augment_bounding_boxes`.
 
+        Added in 0.4.0.
+
     func_polygons : None or callable, optional
         The function to call for each batch of polygons.
         It must follow the form::
@@ -4424,6 +4480,8 @@ class AssertLambda(Lambda):
         and return either ``True`` (valid input) or ``False`` (invalid input).
         It essentially re-uses the interface of
         :func:`~imgaug.augmenters.meta.Augmenter._augment_line_strings`.
+
+        Added in 0.4.0.
 
     seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
@@ -4470,11 +4528,14 @@ class AssertLambda(Lambda):
             random_state=random_state, deterministic=deterministic)
 
 
+# Added in 0.4.0.
 class _AssertLambdaCallback(object):
+    # Added in 0.4.0.
     def __init__(self, func, augmentable_name):
         self.func = func
         self.augmentable_name = augmentable_name
 
+    # Added in 0.4.0.
     def __call__(self, augmentables, random_state, parents, hooks):
         assert self.func(augmentables, random_state, parents, hooks), (
             "Input %s did not fulfill user-defined assertion in "
@@ -4557,6 +4618,8 @@ class AssertShape(Lambda):
         :class:`~imgaug.augmentables.bbs.BoundingBoxesOnImage` instance the
         ``.shape`` attribute, i.e. the shape of the corresponding image.
 
+        Added in 0.4.0.
+
     check_polygons : bool, optional
         Whether to validate input polygons via the given shape.
         This will check (a) the number of polygons and (b) for each
@@ -4568,6 +4631,8 @@ class AssertShape(Lambda):
         This will check (a) the number of line strings and (b) for each
         :class:`~imgaug.augmentables.lines.LineStringsOnImage` instance the
         ``.shape`` attribute, i.e. the shape of the corresponding image.
+
+        Added in 0.4.0.
 
     seed : None or int or imgaug.random.RNG or numpy.random.Generator or numpy.random.BitGenerator or numpy.random.SeedSequence or numpy.random.RandomState, optional
         See :func:`~imgaug.augmenters.meta.Augmenter.__init__`.
@@ -4684,6 +4749,7 @@ class AssertShape(Lambda):
 
 # turning these checks below into classmethods of AssertShape breaks pickling
 # in python 2.7
+# Added in 0.4.0.
 class _AssertShapeImagesCheck(object):
     def __init__(self, shape):
         self.shape = shape
@@ -4696,6 +4762,7 @@ class _AssertShapeImagesCheck(object):
         return images
 
 
+# Added in 0.4.0.
 class _AssertShapeHeatmapsCheck(object):
     def __init__(self, shape):
         self.shape = shape
@@ -4706,6 +4773,7 @@ class _AssertShapeHeatmapsCheck(object):
         return heatmaps
 
 
+# Added in 0.4.0.
 class _AssertShapeSegmapCheck(object):
     def __init__(self, shape):
         self.shape = shape
@@ -4716,6 +4784,7 @@ class _AssertShapeSegmapCheck(object):
         return segmaps
 
 
+# Added in 0.4.0.
 class _AssertShapeKeypointsCheck(object):
     def __init__(self, shape):
         self.shape = shape
@@ -4726,6 +4795,7 @@ class _AssertShapeKeypointsCheck(object):
         return keypoints_on_images
 
 
+# Added in 0.4.0.
 class _AssertShapeBoundingBoxesCheck(object):
     def __init__(self, shape):
         self.shape = shape
@@ -4738,6 +4808,7 @@ class _AssertShapeBoundingBoxesCheck(object):
         return bounding_boxes_on_images
 
 
+# Added in 0.4.0.
 class _AssertShapePolygonsCheck(object):
     def __init__(self, shape):
         self.shape = shape
@@ -4748,6 +4819,7 @@ class _AssertShapePolygonsCheck(object):
         return polygons_on_images
 
 
+# Added in 0.4.0.
 class _AssertShapeLineStringsCheck(object):
     def __init__(self, shape):
         self.shape = shape
@@ -4847,6 +4919,7 @@ class ChannelShuffle(Augmenter):
                 type(channels),))
         self.channels = channels
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -4943,6 +5016,8 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
     augmentable's area that is outside of the image, e.g. for a bounding box
     that has half of its area outside of the image it would be ``0.5``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -5020,6 +5095,7 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, fraction,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -5029,6 +5105,7 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
 
         self.fraction = fraction
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         for column in batch.columns:
             if column.name in ["keypoints", "bounding_boxes", "polygons",
@@ -5039,6 +5116,7 @@ class RemoveCBAsByOutOfImageFraction(Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.fraction]
@@ -5053,6 +5131,8 @@ class ClipCBAsToImagePlanes(Augmenter):
     will be retained. This may e.g. shrink down bounding boxes. For keypoints,
     it removes any single points outside of the image plane. Any augmentable
     that is completely outside of the image plane will be removed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -5103,6 +5183,7 @@ class ClipCBAsToImagePlanes(Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -5110,6 +5191,7 @@ class ClipCBAsToImagePlanes(Augmenter):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         for column in batch.columns:
             if column.name in ["keypoints", "bounding_boxes", "polygons",
@@ -5119,6 +5201,7 @@ class ClipCBAsToImagePlanes(Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -44,6 +44,8 @@ Standard usage of these augmenters follows roughly the schema::
 
     images_aug = aug(images=[image, image, image])
 
+Added in 0.4.0.
+
 """
 from __future__ import print_function, division, absolute_import
 
@@ -73,6 +75,7 @@ from .. import parameters as iap
 _EQUALIZE_USE_PIL_BELOW = 64*64  # H*W
 
 
+# Added in 0.4.0.
 def _ensure_valid_shape(image, func_name):
     is_hw1 = image.ndim == 3 and image.shape[-1] == 1
     if is_hw1:
@@ -92,6 +95,8 @@ def solarize_(image, threshold=128):
 
     This function has identical outputs to ``PIL.ImageOps.solarize``.
     It does however work in-place.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -122,6 +127,8 @@ def solarize(image, threshold=128):
 
     This function has identical outputs to ``PIL.ImageOps.solarize``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See ``~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)``.
@@ -150,6 +157,8 @@ def posterize_(image, bits):
     This function has identical outputs to ``PIL.ImageOps.posterize``.
     It does however work in-place.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.color.quantize_uniform_to_n_bits_`.
@@ -177,6 +186,8 @@ def posterize(image, bits):
     """Reduce the number of bits for each color channel.
 
     This function has identical outputs to ``PIL.ImageOps.posterize``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -207,6 +218,8 @@ def equalize(image, mask=None):
 
     This function is identical in inputs and outputs to
     ``PIL.ImageOps.equalize``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -244,6 +257,8 @@ def equalize_(image, mask=None):
 
     This function has identical outputs to ``PIL.ImageOps.equalize``.
     It does however work in-place.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -300,6 +315,7 @@ def equalize_(image, mask=None):
 
 # note that this is supposed to be a non-PIL reimplementation of PIL's
 # equalize, which produces slightly different results from cv2.equalizeHist()
+# Added in 0.4.0.
 def _equalize_no_pil_(image, mask=None):
     nb_channels = 1 if image.ndim == 2 else image.shape[-1]
     # TODO remove the first axis, no longer needed
@@ -331,6 +347,7 @@ def _equalize_no_pil_(image, mask=None):
     return image
 
 
+# Added in 0.4.0.
 def _equalize_pil_(image, mask=None):
     if mask is not None:
         mask = PIL.Image.fromarray(mask).convert("L")
@@ -355,6 +372,8 @@ def autocontrast(image, cutoff=0, ignore=None):
 
     This function has identical outputs to ``PIL.ImageOps.autocontrast``.
     The speed is almost identical.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -407,6 +426,7 @@ def autocontrast(image, cutoff=0, ignore=None):
     return _autocontrast_no_pil(image, cutoff, ignore)
 
 
+# Added in 0.4.0.
 def _autocontrast_pil(image, cutoff, ignore):
     # don't return np.asarray(...) as its results are read-only
     return np.array(
@@ -420,6 +440,7 @@ def _autocontrast_pil(image, cutoff, ignore):
 # This function is only faster than the corresponding PIL function if no
 # cutoff is used.
 # C901 is "<functionname> is too complex"
+# Added in 0.4.0.
 def _autocontrast_no_pil(image, cutoff, ignore):  # noqa: C901
     # pylint: disable=invalid-name
     if ignore is not None and not ia.is_iterable(ignore):
@@ -510,6 +531,7 @@ def _autocontrast_no_pil(image, cutoff, ignore):  # noqa: C901
     return result
 
 
+# Added in 0.4.0.
 def _apply_enhance_func(image, cls, factor):
     assert image.dtype.name == "uint8", (
         "Can apply PIL image enhancement only to uint8 images, "
@@ -537,6 +559,8 @@ def enhance_color(image, factor):
 
     This function has identical outputs to
     ``PIL.ImageEnhance.Color``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -578,6 +602,8 @@ def enhance_contrast(image, factor):
 
     This function has identical outputs to
     ``PIL.ImageEnhance.Contrast``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -621,6 +647,8 @@ def enhance_brightness(image, factor):
     This function has identical outputs to
     ``PIL.ImageEnhance.Brightness``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -662,6 +690,8 @@ def enhance_sharpness(image, factor):
     This function has identical outputs to
     ``PIL.ImageEnhance.Sharpness``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -697,6 +727,7 @@ def enhance_sharpness(image, factor):
     return _apply_enhance_func(image, PIL.ImageEnhance.Sharpness, factor)
 
 
+# Added in 0.4.0.
 def _filter_by_kernel(image, kernel):
     assert image.dtype.name == "uint8", (
         "Can apply PIL filters only to uint8 images, "
@@ -723,6 +754,8 @@ def filter_blur(image):
     """Apply a blur filter kernel to the image.
 
     This is the same as using PIL's ``PIL.ImageFilter.BLUR`` kernel.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -759,6 +792,8 @@ def filter_smooth(image):
 
     This is the same as using PIL's ``PIL.ImageFilter.SMOOTH`` kernel.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -794,6 +829,8 @@ def filter_smooth_more(image):
 
     This is the same as using PIL's ``PIL.ImageFilter.SMOOTH_MORE`` kernel.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -828,6 +865,8 @@ def filter_edge_enhance(image):
     """Apply an edge enhancement filter kernel to the image.
 
     This is the same as using PIL's ``PIL.ImageFilter.EDGE_ENHANCE`` kernel.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -865,6 +904,8 @@ def filter_edge_enhance_more(image):
     This is the same as using PIL's ``PIL.ImageFilter.EDGE_ENHANCE_MORE``
     kernel.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -899,6 +940,8 @@ def filter_find_edges(image):
     """Apply an edge detection filter kernel to the image.
 
     This is the same as using PIL's ``PIL.ImageFilter.FIND_EDGES`` kernel.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -935,6 +978,8 @@ def filter_contour(image):
 
     This is the same as using PIL's ``PIL.ImageFilter.CONTOUR`` kernel.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -969,6 +1014,8 @@ def filter_emboss(image):
     """Apply an emboss filter kernel to the image.
 
     This is the same as using PIL's ``PIL.ImageFilter.EMBOSS`` kernel.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1005,6 +1052,8 @@ def filter_sharpen(image):
 
     This is the same as using PIL's ``PIL.ImageFilter.SHARPEN`` kernel.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -1040,6 +1089,8 @@ def filter_detail(image):
 
     This is the same as using PIL's ``PIL.ImageFilter.DETAIL`` kernel.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; fully tested
@@ -1072,6 +1123,7 @@ def filter_detail(image):
 
 # TODO unify this with the matrix generation for Affine,
 #      there is probably no need to keep these separate
+# Added in 0.4.0.
 def _create_affine_matrix(scale_x=1.0, scale_y=1.0,
                           translate_x_px=0, translate_y_px=0,
                           rotate_deg=0,
@@ -1148,6 +1200,8 @@ def warp_affine(image,
 
     This function has identical outputs to
     ``PIL.Image.transform`` with ``method=PIL.Image.AFFINE``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1265,6 +1319,8 @@ class Solarize(arithmetic.Invert):
 
     The outputs are identical to PIL's ``solarize()``.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See ``~imgaug.augmenters.arithmetic.invert_(min_value=None and max_value=None)``.
@@ -1327,6 +1383,8 @@ class Posterize(colorlib.Posterize):
     i.e. all three classes are right now guarantueed to have the same
     outputs as PIL's function.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :class:`~imgaug.augmenters.color.Posterize`.
@@ -1338,6 +1396,8 @@ class Equalize(meta.Augmenter):
     """Equalize the image histogram.
 
     This augmenter has identical outputs to ``PIL.ImageOps.equalize``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1371,6 +1431,7 @@ class Equalize(meta.Augmenter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1378,6 +1439,7 @@ class Equalize(meta.Augmenter):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=no-self-use
         if batch.images is not None:
@@ -1385,6 +1447,7 @@ class Equalize(meta.Augmenter):
                 image[...] = equalize_(image)
         return batch
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
@@ -1396,6 +1459,8 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
     This augmenter has identical outputs to ``PIL.ImageOps.autocontrast``.
 
     See :func:`~imgaug.augmenters.pillike.autocontrast` for more details.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1455,6 +1520,7 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
     """
     # pylint: disable=protected-access
 
+    # Added in 0.4.0.
     def __init__(self, cutoff=(0, 20), per_channel=False,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1477,7 +1543,9 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
             random_state=random_state, deterministic=deterministic)
 
 
+# Added in 0.4.0.
 class _EnhanceBase(meta.Augmenter):
+    # Added in 0.4.0.
     def __init__(self, func, factor, factor_value_range,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1489,6 +1557,7 @@ class _EnhanceBase(meta.Augmenter):
             factor, "factor", value_range=factor_value_range,
             tuple_to_uniform=True, list_to_choice=True)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -1498,9 +1567,11 @@ class _EnhanceBase(meta.Augmenter):
             image[...] = self.func(image, factor)
         return batch
 
+    # Added in 0.4.0.
     def _draw_samples(self, nb_rows, random_state):
         return self.factor.draw_samples((nb_rows,), random_state=random_state)
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.factor]
@@ -1510,6 +1581,8 @@ class EnhanceColor(_EnhanceBase):
     """Convert images to grayscale.
 
     This augmenter has identical outputs to ``PIL.ImageEnhance.Color``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1557,6 +1630,7 @@ class EnhanceColor(_EnhanceBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, factor=(0.0, 3.0),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1572,6 +1646,8 @@ class EnhanceContrast(_EnhanceBase):
     """Change the contrast of images.
 
     This augmenter has identical outputs to ``PIL.ImageEnhance.Contrast``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1620,6 +1696,7 @@ class EnhanceContrast(_EnhanceBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, factor=(0.5, 1.5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1636,6 +1713,8 @@ class EnhanceBrightness(_EnhanceBase):
 
     This augmenter has identical outputs to
     ``PIL.ImageEnhance.Brightness``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1683,6 +1762,7 @@ class EnhanceBrightness(_EnhanceBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, factor=(0.5, 1.5),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1699,6 +1779,8 @@ class EnhanceSharpness(_EnhanceBase):
 
     This augmenter has identical outputs to
     ``PIL.ImageEnhance.Sharpness``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1746,6 +1828,7 @@ class EnhanceSharpness(_EnhanceBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, factor=(0.0, 2.0),
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1757,7 +1840,9 @@ class EnhanceSharpness(_EnhanceBase):
             random_state=random_state, deterministic=deterministic)
 
 
+# Added in 0.4.0.
 class _FilterBase(meta.Augmenter):
+    # Added in 0.4.0.
     def __init__(self, func,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1766,12 +1851,14 @@ class _FilterBase(meta.Augmenter):
             random_state=random_state, deterministic=deterministic)
         self.func = func
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
             for image in batch.images:
                 image[...] = self.func(image)
         return batch
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return []
@@ -1782,6 +1869,8 @@ class FilterBlur(_FilterBase):
 
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel ``PIL.ImageFilter.BLUR``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1815,6 +1904,7 @@ class FilterBlur(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1829,6 +1919,8 @@ class FilterSmooth(_FilterBase):
 
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel ``PIL.ImageFilter.SMOOTH``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1862,6 +1954,7 @@ class FilterSmooth(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1876,6 +1969,8 @@ class FilterSmoothMore(_FilterBase):
 
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel ``PIL.ImageFilter.BLUR``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1910,6 +2005,7 @@ class FilterSmoothMore(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1925,6 +2021,8 @@ class FilterEdgeEnhance(_FilterBase):
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel
     ``PIL.ImageFilter.EDGE_ENHANCE``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1959,6 +2057,7 @@ class FilterEdgeEnhance(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -1974,6 +2073,8 @@ class FilterEdgeEnhanceMore(_FilterBase):
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel
     ``PIL.ImageFilter.EDGE_ENHANCE_MORE``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2008,6 +2109,7 @@ class FilterEdgeEnhanceMore(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2023,6 +2125,8 @@ class FilterFindEdges(_FilterBase):
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel
     ``PIL.ImageFilter.FIND_EDGES``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2056,6 +2160,7 @@ class FilterFindEdges(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2070,6 +2175,8 @@ class FilterContour(_FilterBase):
 
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel ``PIL.ImageFilter.CONTOUR``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2104,6 +2211,7 @@ class FilterContour(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2118,6 +2226,8 @@ class FilterEmboss(_FilterBase):
 
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel ``PIL.ImageFilter.EMBOSS``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2151,6 +2261,7 @@ class FilterEmboss(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2165,6 +2276,8 @@ class FilterSharpen(_FilterBase):
 
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel ``PIL.ImageFilter.SHARPEN``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2198,6 +2311,7 @@ class FilterSharpen(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2212,6 +2326,8 @@ class FilterDetail(_FilterBase):
 
     This augmenter has identical outputs to
     calling ``PIL.Image.filter`` with kernel ``PIL.ImageFilter.DETAIL``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2246,6 +2362,7 @@ class FilterDetail(_FilterBase):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -2276,6 +2393,8 @@ class Affine(geometric.Affine):
         translation matrices. Without such translation, PIL uses the image
         top left corner as the transformation center. To mirror that
         behaviour, use ``center=(0.0, 0.0)``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2356,6 +2475,7 @@ class Affine(geometric.Affine):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, scale=1.0, translate_percent=None, translate_px=None,
                  rotate=0.0, shear=0.0, fillcolor=0, center=(0.5, 0.5),
                  seed=None, name=None,
@@ -2376,6 +2496,7 @@ class Affine(geometric.Affine):
         # TODO move that func to iap
         self.center = sizelib._handle_position_parameter(center)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         cols = batch.get_column_names()
         assert len(cols) == 0 or (len(cols) == 1 and "images" in cols), (
@@ -2386,6 +2507,7 @@ class Affine(geometric.Affine):
         return super(Affine, self)._augment_batch_(
             batch, random_state, parents, hooks)
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples,
                                    image_shapes=None,
                                    return_matrices=False):
@@ -2415,6 +2537,7 @@ class Affine(geometric.Affine):
 
         return images
 
+    # Added in 0.4.0.
     def _draw_samples(self, nb_samples, random_state):
         # standard affine samples
         samples = super(Affine, self)._draw_samples(nb_samples,
@@ -2437,6 +2560,7 @@ class Affine(geometric.Affine):
         samples.center_y = yy
         return samples
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -78,6 +78,7 @@ class _AbstractPoolingBase(meta.Augmenter):
             np.clip(kernel_sizes_w, 1, None)
         )
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None and self.keep_size:
             return batch
@@ -90,6 +91,7 @@ class _AbstractPoolingBase(meta.Augmenter):
             setattr(batch, column.attr_name, value_aug)
         return batch
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
         if not self.keep_size:
             images = list(images)
@@ -108,14 +110,17 @@ class _AbstractPoolingBase(meta.Augmenter):
 
         return images
 
+    # Added in 0.4.0.
     def _augment_heatmaps_by_samples(self, heatmaps, samples):
         return self._augment_hms_and_segmaps_by_samples(heatmaps, samples,
                                                         "arr_0to1")
 
+    # Added in 0.4.0.
     def _augment_segmentation_maps_by_samples(self, segmaps, samples):
         return self._augment_hms_and_segmaps_by_samples(segmaps, samples,
                                                         "arr")
 
+    # Added in 0.4.0.
     def _augment_hms_and_segmaps_by_samples(self, augmentables, samples,
                                             arr_attr_name):
         if self.keep_size:
@@ -144,6 +149,7 @@ class _AbstractPoolingBase(meta.Augmenter):
 
         return augmentables
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, keypoints_on_images, samples):
         if self.keep_size:
             return keypoints_on_images
@@ -161,17 +167,20 @@ class _AbstractPoolingBase(meta.Augmenter):
 
         return keypoints_on_images
 
+    # Added in 0.4.0.
     def _augment_polygons_by_samples(self, polygons_on_images, samples):
         func = functools.partial(self._augment_keypoints_by_samples,
                                  samples=samples)
         return self._apply_to_polygons_as_keypoints(polygons_on_images, func,
                                                     recoverer=None)
 
+    # Added in 0.4.0.
     def _augment_line_strings_by_samples(self, line_strings_on_images, samples):
         func = functools.partial(self._augment_keypoints_by_samples,
                                  samples=samples)
         return self._apply_to_cbaois_as_keypoints(line_strings_on_images, func)
 
+    # Added in 0.4.0.
     def _augment_bounding_boxes_by_samples(self, bounding_boxes_on_images,
                                            samples):
         func = functools.partial(self._augment_keypoints_by_samples,

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -221,6 +221,7 @@ class Superpixels(meta.Augmenter):
         self.max_size = max_size
         self.interpolation = interpolation
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -609,6 +610,7 @@ class Voronoi(meta.Augmenter):
         self.max_size = max_size
         self.interpolation = interpolation
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -343,6 +343,7 @@ def _handle_position_parameter(position):
 
 
 # TODO this is the same as in imgaug.py, make DRY
+# Added in 0.4.0.
 def _assert_two_or_three_dims(shape):
     if hasattr(shape, "shape"):
         shape = shape.shape
@@ -355,6 +356,8 @@ def pad(arr, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
     """Pad an image-like array on its top/right/bottom/left side.
 
     This function is a wrapper around :func:`numpy.pad`.
+
+    Added in 0.4.0. (Previously named ``imgaug.imgaug.pad()``.)
 
     **Supported dtypes**:
 
@@ -558,6 +561,8 @@ def pad_to_aspect_ratio(arr, aspect_ratio, mode="constant", cval=0,
     explanation of how the required padding amounts are distributed per
     image axis.
 
+    Added in 0.4.0. (Previously named ``imgaug.imgaug.pad_to_aspect_ratio()``.)
+
     **Supported dtypes**:
 
     See :func:`~imgaug.augmenters.size.pad`.
@@ -623,6 +628,8 @@ def pad_to_multiples_of(arr, height_multiple, width_multiple, mode="constant",
     See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required padding amounts are distributed per
     image axis.
+
+    Added in 0.4.0. (Previously named ``imgaug.imgaug.pad_to_multiples_of()``.)
 
     **Supported dtypes**:
 
@@ -705,6 +712,9 @@ def compute_paddings_to_reach_aspect_ratio(arr, aspect_ratio):
     will always add such a left over pixel to the bottom (y-axis) or
     right (x-axis) side.
 
+    Added in 0.4.0. (Previously named
+    ``imgaug.imgaug.compute_paddings_to_reach_aspect_ratio()``.)
+
     Parameters
     ----------
     arr : (H,W) ndarray or (H,W,C) ndarray or tuple of int
@@ -776,6 +786,8 @@ def compute_croppings_to_reach_aspect_ratio(arr, aspect_ratio):
     If an aspect ratio cannot be reached exactly, this function will return
     rather one pixel too few than one pixel too many.
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     arr : (H,W) ndarray or (H,W,C) ndarray or tuple of int
@@ -833,6 +845,9 @@ def compute_paddings_to_reach_multiples_of(arr, height_multiple,
     See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required padding amounts are distributed per
     image axis.
+
+    Added in 0.4.0. (Previously named
+    ``imgaug.imgaug.compute_paddings_to_reach_multiples_of()``.)
 
     Parameters
     ----------
@@ -894,6 +909,8 @@ def compute_croppings_to_reach_multiples_of(arr, height_multiple,
     See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required cropping amounts are distributed per
     image axis.
+
+    Added in 0.4.0.
 
     Parameters
     ----------
@@ -959,6 +976,9 @@ def compute_paddings_to_reach_powers_of(arr, height_base, width_base,
     See :func:`~imgaug.imgaug.compute_paddings_for_aspect_ratio` for an
     explanation of how the required padding amounts are distributed per
     image axis.
+
+    Added in 0.4.0. (Previously named
+    ``imgaug.imgaug.compute_paddings_to_reach_exponents_of()``.)
 
     Parameters
     ----------
@@ -1035,6 +1055,8 @@ def compute_croppings_to_reach_powers_of(arr, height_base, width_base,
         croppings.
 
         For axes where ``1 <= S < B`` see parameter `allow_zero_exponent`.
+
+    Added in 0.4.0.
 
     Parameters
     ----------
@@ -1355,6 +1377,7 @@ class Resize(meta.Augmenter):
                 "got %s." % (type(interpolation),))
         return interpolation
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         nb_rows = batch.nb_rows
         samples = self._draw_samples(nb_rows, random_state)
@@ -1386,6 +1409,7 @@ class Resize(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
         input_was_array = False
         input_dtype = None
@@ -1409,6 +1433,7 @@ class Resize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, arr_attr_name, samples):
         result = []
         samples_h, samples_w, samples_ip = samples
@@ -1435,6 +1460,7 @@ class Resize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, kpsois, samples):
         result = []
         samples_a, samples_b, _samples_ip = samples
@@ -1937,6 +1963,7 @@ class CropAndPad(meta.Augmenter):
                 "StochasticParameter, got type %s." % (type(percent),))
         return all_sides, top, right, bottom, left
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         shapes = batch.get_rowwise_shapes()
         samples = self._draw_samples(random_state, shapes)
@@ -1969,6 +1996,7 @@ class CropAndPad(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
         result = []
         for i, image in enumerate(images):
@@ -1990,6 +2018,7 @@ class CropAndPad(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, pad_mode, pad_cval,
                                  samples):
         result = []
@@ -2013,6 +2042,7 @@ class CropAndPad(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, keypoints_on_images, samples):
         result = []
         for i, keypoints_on_image in enumerate(keypoints_on_images):
@@ -2725,6 +2755,7 @@ class PadToFixedSize(meta.Augmenter):
         self._pad_cval_heatmaps = 0.0
         self._pad_cval_segmentation_maps = 0
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # Providing the whole batch to _draw_samples() would not be necessary
         # for this augmenter. The number of rows would be sufficient. This
@@ -2758,6 +2789,7 @@ class PadToFixedSize(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
         result = []
         sizes, pad_xs, pad_ys, pad_modes, pad_cvals = samples
@@ -2779,6 +2811,7 @@ class PadToFixedSize(meta.Augmenter):
         #      some might have been larger than desired height/width)
         return result
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, keypoints_on_images, samples):
         result = []
         sizes, pad_xs, pad_ys, _, _ = samples
@@ -2797,6 +2830,7 @@ class PadToFixedSize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, samples, pad_mode,
                                  pad_cval):
         sizes, pad_xs, pad_ys, pad_modes, pad_cvals = samples
@@ -2883,6 +2917,8 @@ class CenterPadToFixedSize(PadToFixedSize):
     all image sides, while :class:`~imgaug.augmenters.size.PadToFixedSize`
     by defaults spreads them randomly.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :class:`~imgaug.augmenters.size.PadToFixedSize`.
@@ -2929,6 +2965,7 @@ class CenterPadToFixedSize(PadToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width, height, pad_mode="constant", pad_cval=0,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3083,6 +3120,7 @@ class CropToFixedSize(meta.Augmenter):
         # (0.0, 1.0) crops left and bottom, (1.0, 0.0) crops right and top.
         self.position = _handle_position_parameter(position)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # Providing the whole batch to _draw_samples() would not be necessary
         # for this augmenter. The number of rows would be sufficient. This
@@ -3114,6 +3152,7 @@ class CropToFixedSize(meta.Augmenter):
 
         return batch
 
+    # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
         result = []
         sizes, offset_xs, offset_ys = samples
@@ -3131,6 +3170,7 @@ class CropToFixedSize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_keypoints_by_samples(self, kpsois, samples):
         result = []
         sizes, offset_xs, offset_ys = samples
@@ -3148,6 +3188,7 @@ class CropToFixedSize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     def _augment_maps_by_samples(self, augmentables, samples):
         sizes, offset_xs, offset_ys = samples
         for i, (augmentable, size) in enumerate(zip(augmentables, sizes)):
@@ -3221,6 +3262,8 @@ class CenterCropToFixedSize(CropToFixedSize):
         respective axis. Hence, resulting images can be smaller than the
         provided axis sizes.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
     See :class:`~imgaug.augmenters.size.CropToFixedSize`.
@@ -3260,6 +3303,7 @@ class CenterCropToFixedSize(CropToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width, height,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3278,6 +3322,8 @@ class CropToMultiplesOf(CropToFixedSize):
         interval ``[0 .. M]``, the axis will not be changed.
         As a result, this augmenter can still produce axis sizes that are
         not multiples of the given values.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3328,6 +3374,7 @@ class CropToMultiplesOf(CropToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_multiple, height_multiple, position="uniform",
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3338,6 +3385,7 @@ class CropToMultiplesOf(CropToFixedSize):
         self.width_multiple = width_multiple
         self.height_multiple = height_multiple
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         _sizes, offset_xs, offset_ys = super(
             CropToMultiplesOf, self
@@ -3363,6 +3411,7 @@ class CropToMultiplesOf(CropToFixedSize):
 
         return sizes, offset_xs, offset_ys
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_multiple, self.height_multiple, self.position]
@@ -3376,6 +3425,8 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
     equally over all image sides, while
     :class:`~imgaug.augmenters.size.CropToMultiplesOf` by default spreads
     them randomly.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3419,6 +3470,7 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_multiple, height_multiple,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3432,6 +3484,8 @@ class CenterCropToMultiplesOf(CropToMultiplesOf):
 
 class PadToMultiplesOf(PadToFixedSize):
     """Pad images until their height/width is a multiple of a value.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3488,6 +3542,7 @@ class PadToMultiplesOf(PadToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_multiple, height_multiple,
                  pad_mode="constant", pad_cval=0,
                  position="uniform",
@@ -3501,6 +3556,7 @@ class PadToMultiplesOf(PadToFixedSize):
         self.width_multiple = width_multiple
         self.height_multiple = height_multiple
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         _sizes, pad_xs, pad_ys, pad_modes, pad_cvals = super(
             PadToMultiplesOf, self
@@ -3526,6 +3582,7 @@ class PadToMultiplesOf(PadToFixedSize):
 
         return sizes, pad_xs, pad_ys, pad_modes, pad_cvals
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_multiple, self.height_multiple,
@@ -3541,6 +3598,8 @@ class CenterPadToMultiplesOf(PadToMultiplesOf):
     equally over all image sides, while
     :class:`~imgaug.augmenters.size.PadToMultiplesOf` by default spreads them
     randomly.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3590,6 +3649,7 @@ class CenterPadToMultiplesOf(PadToMultiplesOf):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_multiple, height_multiple,
                  pad_mode="constant", pad_cval=0,
                  seed=None, name=None,
@@ -3618,6 +3678,8 @@ class CropToPowersOf(CropToFixedSize):
         If you have images with ``S < B^1``, it is recommended
         to combine this augmenter with a padding augmenter that pads each
         axis up to ``B``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3670,6 +3732,7 @@ class CropToPowersOf(CropToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_base, height_base, position="uniform",
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3680,6 +3743,7 @@ class CropToPowersOf(CropToFixedSize):
         self.width_base = width_base
         self.height_base = height_base
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         _sizes, offset_xs, offset_ys = super(
             CropToPowersOf, self
@@ -3705,6 +3769,7 @@ class CropToPowersOf(CropToFixedSize):
 
         return sizes, offset_xs, offset_ys
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_base, self.height_base, self.position]
@@ -3718,6 +3783,8 @@ class CenterCropToPowersOf(CropToPowersOf):
     equally over all image sides, while
     :class:`~imgaug.augmenters.size.CropToPowersOf` by default spreads them
     randomly.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3761,6 +3828,7 @@ class CenterCropToPowersOf(CropToPowersOf):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_base, height_base,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -3777,6 +3845,8 @@ class PadToPowersOf(PadToFixedSize):
     new size ``S'`` until ``S' = B^E`` is fulfilled, where ``B`` is a
     provided base (e.g. ``2``) and ``E`` is an exponent from the discrete
     interval ``[1 .. inf)``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3835,6 +3905,7 @@ class PadToPowersOf(PadToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_base, height_base,
                  pad_mode="constant", pad_cval=0,
                  position="uniform",
@@ -3848,6 +3919,7 @@ class PadToPowersOf(PadToFixedSize):
         self.width_base = width_base
         self.height_base = height_base
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         _sizes, pad_xs, pad_ys, pad_modes, pad_cvals = super(
             PadToPowersOf, self
@@ -3873,6 +3945,7 @@ class PadToPowersOf(PadToFixedSize):
 
         return sizes, pad_xs, pad_ys, pad_modes, pad_cvals
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.width_base, self.height_base,
@@ -3887,6 +3960,8 @@ class CenterPadToPowersOf(PadToPowersOf):
     ``position="center"`` by default, which spreads the pad amounts equally
     over all image sides, while :class:`~imgaug.augmenters.size.PadToPowersOf`
     by default spreads them randomly.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -3936,6 +4011,7 @@ class CenterPadToPowersOf(PadToPowersOf):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, width_base, height_base,
                  pad_mode="constant", pad_cval=0,
                  seed=None, name=None,
@@ -3956,6 +4032,8 @@ class CropToAspectRatio(CropToFixedSize):
     operation is stopped once the desired aspect ratio is reached or the image
     side to crop reaches a size of ``1``. If any side of the image starts
     with a size of ``0``, the image will not be changed.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4000,6 +4078,7 @@ class CropToAspectRatio(CropToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, aspect_ratio, position="uniform",
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -4009,6 +4088,7 @@ class CropToAspectRatio(CropToFixedSize):
             random_state=random_state, deterministic=deterministic)
         self.aspect_ratio = aspect_ratio
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         _sizes, offset_xs, offset_ys = super(
             CropToAspectRatio, self
@@ -4037,6 +4117,7 @@ class CropToAspectRatio(CropToFixedSize):
 
         return sizes, offset_xs, offset_ys
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.aspect_ratio, self.position]
@@ -4050,6 +4131,8 @@ class CenterCropToAspectRatio(CropToAspectRatio):
     equally over all image sides, while
     :class:`~imgaug.augmenters.size.CropToAspectRatio` by default spreads
     them randomly.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4090,6 +4173,7 @@ class CenterCropToAspectRatio(CropToAspectRatio):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, aspect_ratio,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -4104,6 +4188,8 @@ class PadToAspectRatio(PadToFixedSize):
 
     This augmenter adds either rows or columns until the image reaches
     the desired aspect ratio given in ``width / height``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4154,6 +4240,7 @@ class PadToAspectRatio(PadToFixedSize):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, aspect_ratio, pad_mode="constant", pad_cval=0,
                  position="uniform",
                  seed=None, name=None,
@@ -4165,6 +4252,7 @@ class PadToAspectRatio(PadToFixedSize):
             random_state=random_state, deterministic=deterministic)
         self.aspect_ratio = aspect_ratio
 
+    # Added in 0.4.0.
     def _draw_samples(self, batch, random_state):
         _sizes, pad_xs, pad_ys, pad_modes, pad_cvals = super(
             PadToAspectRatio, self
@@ -4190,6 +4278,7 @@ class PadToAspectRatio(PadToFixedSize):
 
         return sizes, pad_xs, pad_ys, pad_modes, pad_cvals
 
+    # Added in 0.4.0.
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
         return [self.aspect_ratio, self.pad_mode, self.pad_cval,
@@ -4204,6 +4293,8 @@ class CenterPadToAspectRatio(PadToAspectRatio):
     equally over all image sides, while
     :class:`~imgaug.augmenters.size.PadToAspectRatio` by default spreads them
     randomly.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4242,6 +4333,7 @@ class CenterPadToAspectRatio(PadToAspectRatio):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, aspect_ratio, pad_mode="constant", pad_cval=0,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -4259,6 +4351,8 @@ class CropToSquare(CropToAspectRatio):
     with ``aspect_ratio=1.0``.
 
     Images with axis sizes of ``0`` will not be altered.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4298,6 +4392,7 @@ class CropToSquare(CropToAspectRatio):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, position="uniform",
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -4322,6 +4417,8 @@ class CenterCropToSquare(CropToSquare):
     ``aspect_ratio=1.0, position="center"``.
 
     Images with axis sizes of ``0`` will not be altered.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4358,6 +4455,7 @@ class CenterCropToSquare(CropToSquare):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
         super(CenterCropToSquare, self).__init__(
@@ -4371,6 +4469,8 @@ class PadToSquare(PadToAspectRatio):
 
     This augmenter is identical to
     :class:`~imgaug.augmenters.size.PadToAspectRatio` with ``aspect_ratio=1.0``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4416,6 +4516,7 @@ class PadToSquare(PadToAspectRatio):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, pad_mode="constant", pad_cval=0, position="uniform",
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -4435,6 +4536,8 @@ class CenterPadToSquare(PadToSquare):
     by default spreads them randomly. This augmenter is thus also identical to
     :class:`~imgaug.augmenters.size.PadToAspectRatio` with
     ``aspect_ratio=1.0, position="center"``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -4469,6 +4572,7 @@ class CenterPadToSquare(PadToSquare):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, pad_mode="constant", pad_cval=0,
                  seed=None, name=None,
                  random_state="deprecated", deterministic="deprecated"):
@@ -4633,6 +4737,7 @@ class KeepSizeByResize(meta.Augmenter):
         self.interpolation_segmaps = _validate_param(interpolation_segmaps,
                                                      True)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         with batch.propagation_hooks_ctx(self, hooks, parents):
             images_were_array = None
@@ -4675,6 +4780,7 @@ class KeepSizeByResize(meta.Augmenter):
                     setattr(batch, augm_name, cbaois)
         return batch
 
+    # Added in 0.4.0.
     @classmethod
     def _keep_size_images(cls, images, shapes_orig, images_were_array,
                           samples):
@@ -4700,6 +4806,7 @@ class KeepSizeByResize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     @classmethod
     def _keep_size_maps(cls, augmentables, shapes_orig_images,
                         shapes_orig_arrs, interpolations):
@@ -4717,6 +4824,7 @@ class KeepSizeByResize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     @classmethod
     def _keep_size_keypoints(cls, kpsois_aug, shapes_orig, interpolations):
         result = []
@@ -4729,6 +4837,7 @@ class KeepSizeByResize(meta.Augmenter):
 
         return result
 
+    # Added in 0.4.0.
     @classmethod
     def _get_shapes(cls, batch):
         result = dict()

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -158,6 +158,7 @@ class FastSnowyLandscape(meta.Augmenter):
             (nb_augmentables,), rss[0])
         return thresh_samples, lmul_samples
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -365,6 +366,7 @@ class CloudLayer(meta.Augmenter):
         self.density_multiplier = iap.handle_continuous_param(
             density_multiplier, "density_multiplier")
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -873,6 +875,7 @@ class SnowflakesLayer(meta.Augmenter):
         # (height, width), same for all images
         self.gate_noise_size = (8, 8)
 
+    # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
             return batch
@@ -984,6 +987,7 @@ class SnowflakesLayer(meta.Augmenter):
             k=max(k, 3), angle=angle, direction=1.0, random_state=random_state)
         return blurer.augment_image(noise)
 
+    # Added in 0.4.0.
     @classmethod
     def _postprocess_noise(cls, noise_small_blur,
                            flake_size_uniformity_sample, nb_channels):
@@ -999,6 +1003,7 @@ class SnowflakesLayer(meta.Augmenter):
             noise_small_blur[..., np.newaxis], (1, 1, nb_channels))
         return noise_small_blur_rgb
 
+    # Added in 0.4.0.
     @classmethod
     def _blend(cls, image, speed_sample, noise_small_blur_rgb):
         # blend:
@@ -1220,6 +1225,8 @@ class Snowflakes(meta.SomeOf):
 class RainLayer(SnowflakesLayer):
     """Add a single layer of falling raindrops to images.
 
+    Added in 0.4.0.
+
     **Supported dtypes**:
 
         * ``uint8``: yes; indirectly tested (1)
@@ -1285,6 +1292,7 @@ class RainLayer(SnowflakesLayer):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, density, density_uniformity, drop_size,
                  drop_size_uniformity, angle, speed, blur_sigma_fraction,
                  blur_sigma_limits=(0.5, 3.75),
@@ -1297,10 +1305,12 @@ class RainLayer(SnowflakesLayer):
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
+    # Added in 0.4.0.
     @classmethod
     def _blur(cls, noise, sigma):
         return noise
 
+    # Added in 0.4.0.
     @classmethod
     def _postprocess_noise(cls, noise_small_blur,
                            flake_size_uniformity_sample, nb_channels):
@@ -1308,6 +1318,7 @@ class RainLayer(SnowflakesLayer):
             noise_small_blur[..., np.newaxis], (1, 1, nb_channels))
         return noise_small_blur_rgb
 
+    # Added in 0.4.0.
     @classmethod
     def _blend(cls, image, speed_sample, noise_small_blur_rgb):
         # We set the mean color based on the noise here. That's a pseudo-random
@@ -1342,6 +1353,8 @@ class Rain(meta.SomeOf):
         `speed` value to e.g. ``(0.1, 0.3)``, otherwise the drops tend to
         look like snowflakes. For larger images, you may want to increase
         the `drop_size` to e.g. ``(0.10, 0.20)``.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -1406,6 +1419,7 @@ class Rain(meta.SomeOf):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, nb_iterations=(1, 3),
                  drop_size=(0.01, 0.02),
                  speed=(0.04, 0.20),

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -485,7 +485,7 @@ def seed(entropy=None, seedval=None):
         The seed value to use.
 
     seedval : None or int, optional
-        Deprecated.
+        Deprecated since 0.4.0.
 
     """
     assert entropy is not None or seedval is not None, (
@@ -2143,6 +2143,7 @@ def do_assert(condition, message="Assertion failed."):
         raise AssertionError(str(message))
 
 
+# Added in 0.4.0.
 def _normalize_cv2_input_arr_(arr):
     flags = arr.flags
     if not flags["OWNDATA"]:
@@ -2155,6 +2156,8 @@ def _normalize_cv2_input_arr_(arr):
 
 def apply_lut(image, table):
     """Map an input image to a new one using a lookup table.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 
@@ -2181,6 +2184,8 @@ def apply_lut(image, table):
 #      isn't right now
 def apply_lut_(image, table):
     """Map an input image in-place to a new one using a lookup table.
+
+    Added in 0.4.0.
 
     **Supported dtypes**:
 

--- a/imgaug/multicore.py
+++ b/imgaug/multicore.py
@@ -29,6 +29,7 @@ elif sys.version_info[0] == 3:
 _CONTEXT = None
 
 
+# Added in 0.4.0.
 def _get_context_method():
     vinfo = sys.version_info
 
@@ -61,6 +62,7 @@ def _get_context_method():
     return method
 
 
+# Added in 0.4.0.
 def _set_context(method):
     # method=False indicates that multiprocessing module (i.e. no context)
     # should be used, e.g. because get_context() is not supported
@@ -69,14 +71,17 @@ def _set_context(method):
         else multiprocessing.get_context(method))
 
 
+# Added in 0.4.0.
 def _reset_context():
     globals()["_CONTEXT"] = None
 
 
+# Added in 0.4.0.
 def _autoset_context():
     _set_context(_get_context_method())
 
 
+# Added in 0.4.0.
 def _get_context():
     if _CONTEXT is None:
         _autoset_context()

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -156,6 +156,7 @@ def handle_discrete_param(param, name, value_range=None, tuple_to_uniform=True,
             allowed_type, allowed_type, list_str, name, type(param),))
 
 
+# Added in 0.4.0.
 def handle_categorical_string_param(param, name, valid_values=None):
     if param == ia.ALL and valid_values is not None:
         return Choice(list(valid_values))
@@ -691,6 +692,8 @@ class DeterministicList(StochasticParameter):
     will (by default) be tiled until it is long enough (i.e. the sampling
     will start again at the first element, if necessary multiple times).
 
+    Added in 0.4.0.
+
     Parameters
     ----------
     values : ndarray or iterable of number
@@ -698,6 +701,7 @@ class DeterministicList(StochasticParameter):
 
     """
 
+    # Added in 0.4.0.
     def __init__(self, values):
         super(DeterministicList, self).__init__()
 
@@ -722,6 +726,7 @@ class DeterministicList(StochasticParameter):
             elif kind == "f":
                 self.values = self.values.astype(np.float32)
 
+    # Added in 0.4.0.
     def _draw_samples(self, size, random_state):
         nb_requested = int(np.prod(size))
         values = self.values
@@ -733,9 +738,11 @@ class DeterministicList(StochasticParameter):
             values = np.tile(values, (multiplier,))
         return values[:nb_requested].reshape(size)
 
+    # Added in 0.4.0.
     def __repr__(self):
         return self.__str__()
 
+    # Added in 0.4.0.
     def __str__(self):
         if self.values.dtype.kind == "f":
             values = ["%.4f" % (value,) for value in self.values]
@@ -1743,6 +1750,8 @@ class Discretize(StochasticParameter):
 
     round : bool, optional
         Whether to round before converting to integer dtype.
+
+        Added in 0.4.0.
 
     Examples
     --------

--- a/imgaug/random.py
+++ b/imgaug/random.py
@@ -63,8 +63,10 @@ if _NP_VERSION[0] > 1 or _NP_VERSION[1] >= 17:
     # in 1.18 this was moved to numpy.random.BitGenerator
     # pylint: disable=invalid-name, no-member
     if _NP_VERSION[1] == 17:
+        # Added in 0.4.0.
         _BIT_GENERATOR_INTERFACE = np.random.bit_generator.BitGenerator
     else:
+        # Added in 0.4.0.
         _BIT_GENERATOR_INTERFACE = np.random.BitGenerator
     # pylint: enable=invalid-name, no-member
 
@@ -730,6 +732,8 @@ class RNG(object):
 
             This method is outdated in numpy. Use :func:`RNG.random` instead.
 
+        Added in 0.4.0.
+
         """
         return self.random(size=args)
 
@@ -746,6 +750,8 @@ class RNG(object):
             This method is outdated in numpy. Use :func:`RNG.integers`
             instead.
 
+        Added in 0.4.0.
+
         """
         return self.integers(low=low, high=high, size=size, dtype=dtype,
                              endpoint=False)
@@ -758,6 +764,8 @@ class RNG(object):
             This method is outdated in numpy. Use :func:`RNG.standard_normal`
             instead.
 
+        Added in 0.4.0.
+
         """
         return self.standard_normal(size=args)
 
@@ -768,6 +776,8 @@ class RNG(object):
 
             This method is outdated in numpy. Use :func:`RNG.integers`
             instead.
+
+        Added in 0.4.0.
 
         """
         if high is None:
@@ -782,6 +792,8 @@ class RNG(object):
             This method is outdated in numpy. Use :func:`RNG.uniform`
             instead.
 
+        Added in 0.4.0.
+
         """
         return self.uniform(0.0, 1.0, size=size)
 
@@ -792,6 +804,8 @@ class RNG(object):
 
             This method is outdated in numpy. Use :func:`RNG.integers`
             instead.
+
+        Added in 0.4.0.
 
         """
         import sys
@@ -1553,6 +1567,8 @@ class temporary_numpy_seed(object):
 
     The random state's internal state will be set back to the original one
     once the context finishes.
+
+    Added in 0.4.0.
 
     Parameters
     ----------

--- a/imgaug/testutils.py
+++ b/imgaug/testutils.py
@@ -47,6 +47,7 @@ class ArgCopyingMagicMock(mock.MagicMock):
             *args_copy, **kwargs_copy)
 
 
+# Added in 0.4.0.
 def assert_cbaois_equal(observed, expected, max_distance=1e-4):
     # pylint: disable=unidiomatic-typecheck
     if isinstance(observed, list) or isinstance(expected, list):
@@ -69,6 +70,7 @@ def assert_cbaois_equal(observed, expected, max_distance=1e-4):
                     assert item_obs.is_valid
 
 
+# Added in 0.4.0.
 # TODO remove this function, no longer needed since shift interfaces were
 #      standardized
 def shift_cbaoi(cbaoi, x=0, y=0, top=0, right=0, bottom=0, left=0):
@@ -142,6 +144,7 @@ def reseed(seed=0):
     random.seed(seed)
 
 
+# Added in 0.4.0.
 def runtest_pickleable_uint8_img(augmenter, shape=(15, 15, 3), iterations=3):
     image = np.mod(np.arange(int(np.prod(shape))), 256).astype(np.uint8)
     image = image.reshape(shape)
@@ -154,7 +157,11 @@ def runtest_pickleable_uint8_img(augmenter, shape=(15, 15, 3), iterations=3):
 
 
 def wrap_shift_deprecation(func, *args, **kwargs):
-    """Helper for tests of CBA shift() functions."""
+    """Helper for tests of CBA shift() functions.
+
+    Added in 0.4.0.
+
+    """
     # No deprecated arguments? Just call the functions directly.
     deprecated_kwargs = ["top", "right", "bottom", "left"]
     if not any([kwname in kwargs for kwname in deprecated_kwargs]):
@@ -182,6 +189,8 @@ class TemporaryDirectory(object):
     This context is available in ``tmpfile.TemporaryDirectory``, but only
     from 3.2+.
 
+    Added in 0.4.0.
+
     """
 
     def __init__(self, suffix="", prefix="tmp", dir=None):
@@ -199,6 +208,7 @@ class TemporaryDirectory(object):
 # https://github.com/python/cpython/blob/master/Lib/unittest/case.py
 # at commit 293dd23 (Nov 19, 2019).
 # Required at least to enable assertWarns() in python <3.2.
+# Added in 0.4.0.
 def _is_subtype(expected, basetype):
     if isinstance(expected, tuple):
         return all(_is_subtype(e, basetype) for e in expected)
@@ -209,10 +219,13 @@ def _is_subtype(expected, basetype):
 # https://github.com/python/cpython/blob/master/Lib/unittest/case.py
 # at commit 293dd23 (Nov 19, 2019).
 # Required at least to enable assertWarns() in python <3.2.
+# Added in 0.4.0.
 class _BaseTestCaseContext:
+    # Added in 0.4.0.
     def __init__(self, test_case):
         self.test_case = test_case
 
+    # Added in 0.4.0.
     def _raiseFailure(self, standardMsg):
         # pylint: disable=invalid-name, protected-access, no-member
         msg = self.test_case._formatMessage(self.msg, standardMsg)
@@ -223,8 +236,9 @@ class _BaseTestCaseContext:
 # https://github.com/python/cpython/blob/master/Lib/unittest/case.py
 # at commit 293dd23 (Nov 19, 2019).
 # Required at least to enable assertWarns() in python <3.2.
+# Added in 0.4.0.
 class _AssertRaisesBaseContext(_BaseTestCaseContext):
-
+    # Added in 0.4.0.
     def __init__(self, expected, test_case, expected_regex=None):
         _BaseTestCaseContext.__init__(self, test_case)
         self.expected = expected
@@ -235,6 +249,7 @@ class _AssertRaisesBaseContext(_BaseTestCaseContext):
         self.obj_name = None
         self.msg = None
 
+    # Added in 0.4.0.
     # pylint: disable=inconsistent-return-statements
     def handle(self, name, args, kwargs):
         """
@@ -274,12 +289,14 @@ class _AssertRaisesBaseContext(_BaseTestCaseContext):
 # https://github.com/python/cpython/blob/master/Lib/unittest/case.py
 # at commit 293dd23 (Nov 19, 2019).
 # Required at least to enable assertWarns() in python <3.2.
+# Added in 0.4.0.
 class _AssertWarnsContext(_AssertRaisesBaseContext):
     """A context manager used to implement TestCase.assertWarns* methods."""
 
     _base_type = Warning
     _base_type_str = 'a warning type or tuple of warning types'
 
+    # Added in 0.4.0.
     def __enter__(self):
         # The __warningregistry__'s need to be in a pristine state for tests
         # to work properly.
@@ -292,6 +309,7 @@ class _AssertWarnsContext(_AssertRaisesBaseContext):
         warnings.simplefilter("always", self.expected)
         return self
 
+    # Added in 0.4.0.
     def __exit__(self, exc_type, exc_value, tb):
         # pylint: disable=invalid-name, attribute-defined-outside-init
         self.warnings_manager.__exit__(exc_type, exc_value, tb)
@@ -336,6 +354,8 @@ def assertWarns(testcase, expected_warning, *args, **kwargs):
     """Context with same functionality as ``assertWarns`` in ``unittest``.
 
     Note that ``assertWarns`` is only available in python 3.2+.
+
+    Added in 0.4.0.
 
     """
     # pylint: disable=invalid-name


### PR DESCRIPTION
This patch adds the comments "Deprecated since 0.4.0" and
"Added in 0.4.0" to classes and functions.
Especially the deprecation markers are intended to make it
easier in the future to estimate whether something can be
safely deleted.