### PR TITLE
Establish compatibility with python 3.8

### DIFF
--- a/changelogs/master/20200126_python38.md
+++ b/changelogs/master/20200126_python38.md
@@ -1,0 +1,7 @@
+# Support for Python 3.8 #600
+
+The library is now tested in python 3.8 and compatible with that
+version. The latest version of `Shapely` is required for that,
+which can right now be installed via `pip install --pre Shapely`.
+(Skipping the `--pre` currently leads to an older shapely version,
+which causes an error during installation in python 3.8.)

--- a/changelogs/master/fixed/20200126_shapely_17a2.md
+++ b/changelogs/master/fixed/20200126_shapely_17a2.md
@@ -1,0 +1,3 @@
+* Fixed an issue in Shapely 1.7a2 (python 3.8) that could lead to
+  a crash in `LineString.find_intersections_with()` if there was
+  no intersection. #600

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -644,9 +644,15 @@ class LineString(object):
             intersections_points = []
             for inter in intersections:
                 if isinstance(inter, shapely.geometry.linestring.LineString):
-                    inter_start = (inter.coords[0][0], inter.coords[0][1])
-                    inter_end = (inter.coords[-1][0], inter.coords[-1][1])
-                    intersections_points.extend([inter_start, inter_end])
+                    # Since shapely 1.7a2 (tested in python 3.8),
+                    # .intersection() apprently can return LINE STRING EMPTY
+                    # (i.e. .coords is an empty list). Before that, the result
+                    # of .intersection() was just []. Hence, we first check
+                    # the length here.
+                    if len(inter.coords) > 0:
+                        inter_start = (inter.coords[0][0], inter.coords[0][1])
+                        inter_end = (inter.coords[-1][0], inter.coords[-1][1])
+                        intersections_points.extend([inter_start, inter_end])
                 else:
                     assert isinstance(inter, shapely.geometry.point.Point), (
                         "Expected to find shapely.geometry.point.Point or "

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -4008,7 +4008,7 @@ class PerspectiveTransform(meta.Augmenter):
 
         matrix_expanded = cv2.getPerspectiveTransform(rect, dst)
         max_width, max_height = dst.max(axis=0)
-        return matrix_expanded, max_width, max_height
+        return matrix_expanded, int(max_width), int(max_height)
 
     def get_parameters(self):
         """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -1282,6 +1282,12 @@ def warp_affine(image,
     if 0 in image.shape:
         return np.copy(image)
 
+    fillcolor = fillcolor if fillcolor is not None else 0
+    if ia.is_iterable(fillcolor):
+        # make sure that iterable fillcolor contains only ints
+        # otherwise we get a deprecation warning in py3.8
+        fillcolor = tuple(map(int, fillcolor))
+
     image, is_hw1 = _ensure_valid_shape(
         image, "imgaug.augmenters.pillike.warp_affine()")
 


### PR DESCRIPTION
This patch fixes a few warnings and a crash related to Shapely in python 3.8.
This establishes compatibility with that python version.
The newest version of Shapely (1.7a2) is required. This may require using
`pip install --pre Shapely` to install it.