### PR TITLE
Improve performance of Add

### DIFF
--- a/changelogs/master/improved/20200211_improve_performance_add.md
+++ b/changelogs/master/improved/20200211_improve_performance_add.md
@@ -1,0 +1,10 @@
+# Improve Performance of `Add` #???
+
+This patch improves the performance of
+`imgaug.arithmetic.add_scalar()`
+and the corresponding augmenter `Add` for `uint8` inputs.
+The function and the augmenter should be roughly 2x as fast after
+this update.
+
+Add functions:
+* `imgaug.augmenters.arithmetic.add_scalar_()`.

--- a/changelogs/master/improved/20200211_improve_performance_add.md
+++ b/changelogs/master/improved/20200211_improve_performance_add.md
@@ -1,10 +1,12 @@
-# Improve Performance of `Add` #???
+# Improve Performance of `Add` #608
 
 This patch improves the performance of
 `imgaug.arithmetic.add_scalar()`
 and the corresponding augmenter `Add` for `uint8` inputs.
-The function and the augmenter should be roughly 2x as fast after
-this update.
+The expected performance improvement is 1.5x to 6x.
+(More for image arrays with higher widths/heights than
+smaller ones. More for more channels. More for a single
+scalar added as opposed to channelwise values.)
 
 Add functions:
 * `imgaug.augmenters.arithmetic.add_scalar_()`.


### PR DESCRIPTION
This patch improves the performance of
`imgaug.arithmetic.add_scalar()`
and the corresponding augmenter `Add` for `uint8` inputs.
The function and the augmenter should be roughly 2x as fast after
this update.

Add functions:
* `imgaug.augmenters.arithmetic.add_scalar_()`.