### PR TITLE
Improve performance of RNG sampling routines

### DIFF
--- a/changelogs/master/improved/20200215_improved_sampling.md
+++ b/changelogs/master/improved/20200215_improved_sampling.md
@@ -1,0 +1,16 @@
+# Improve Performance of Gaussian and Uniform Sampling #???
+
+This patch improves the speed at which samples are drawn from
+gaussian and uniform distributions.
+In the case of gaussians, the improvement is activated for
+matrices with more than 2500 components (roughly 32x32x3 and
+above). For large matrices (224x224x3 and above) the expected
+speedup is up to 3x.
+In the case of uniform distributions, the improvement is
+activated for matrices with more than 12500 components (roughly
+64x64x3 and above). For large matrices (224x224x3 and above)
+the expected speedup is up to 2x.
+
+The dtype of the array returned by `imgaug.random.RNG.normal()`,
+`imgaug.random.RNG.uniform()` and `imgaug.random.RNG.random_sample()`
+is now always `float32` instead of `float64`.

--- a/imgaug/random.py
+++ b/imgaug/random.py
@@ -98,16 +98,16 @@ class RNG(object):
 
     Not supported sampling functions of numpy <=1.16:
 
-    * :func:`numpy.random.RandomState.rand`
-    * :func:`numpy.random.RandomState.randn`
-    * :func:`numpy.random.RandomState.randint`
-    * :func:`numpy.random.RandomState.random_integers`
-    * :func:`numpy.random.RandomState.random_sample`
-    * :func:`numpy.random.RandomState.ranf`
-    * :func:`numpy.random.RandomState.sample`
-    * :func:`numpy.random.RandomState.seed`
-    * :func:`numpy.random.RandomState.get_state`
-    * :func:`numpy.random.RandomState.set_state`
+    * `numpy.random.RandomState.rand`
+    * `numpy.random.RandomState.randn`
+    * `numpy.random.RandomState.randint`
+    * `numpy.random.RandomState.random_integers`
+    * `numpy.random.RandomState.random_sample`
+    * `numpy.random.RandomState.ranf`
+    * `numpy.random.RandomState.sample`
+    * `numpy.random.RandomState.seed`
+    * `numpy.random.RandomState.get_state`
+    * `numpy.random.RandomState.set_state`
 
     In :func:`~imgaug.random.RNG.choice`, the `axis` argument is not yet
     supported.
@@ -532,106 +532,106 @@ class RNG(object):
 
     # TODO add support for Generator's 'axis' argument
     def choice(self, a, size=None, replace=True, p=None):
-        """Call :func:`numpy.random.Generator.choice`."""
+        """Call `numpy.random.Generator.choice`."""
         # pylint: disable=invalid-name
         return self.generator.choice(a=a, size=size, replace=replace, p=p)
 
     def bytes(self, length):
-        """Call :func:`numpy.random.Generator.bytes`."""
+        """Call `numpy.random.Generator.bytes`."""
         return self.generator.bytes(length=length)
 
     # TODO mark in-place
     def shuffle(self, x):
-        """Call :func:`numpy.random.Generator.shuffle`."""
+        """Call `numpy.random.Generator.shuffle`."""
         # note that shuffle() does not allow keyword arguments
         # note that shuffle() works in-place
         self.generator.shuffle(x)
 
     def permutation(self, x):
-        """Call :func:`numpy.random.Generator.permutation`."""
+        """Call `numpy.random.Generator.permutation`."""
         # note that permutation() does not allow keyword arguments
         return self.generator.permutation(x)
 
     def beta(self, a, b, size=None):
-        """Call :func:`numpy.random.Generator.beta`."""
+        """Call `numpy.random.Generator.beta`."""
         # pylint: disable=invalid-name
         return self.generator.beta(a=a, b=b, size=size)
 
     def binomial(self, n, p, size=None):
-        """Call :func:`numpy.random.Generator.binomial`."""
+        """Call `numpy.random.Generator.binomial`."""
         return self.generator.binomial(n=n, p=p, size=size)
 
     def chisquare(self, df, size=None):
-        """Call :func:`numpy.random.Generator.chisquare`."""
+        """Call `numpy.random.Generator.chisquare`."""
         # pylint: disable=invalid-name
         return self.generator.chisquare(df=df, size=size)
 
     def dirichlet(self, alpha, size=None):
-        """Call :func:`numpy.random.Generator.dirichlet`."""
+        """Call `numpy.random.Generator.dirichlet`."""
         return self.generator.dirichlet(alpha=alpha, size=size)
 
     def exponential(self, scale=1.0, size=None):
-        """Call :func:`numpy.random.Generator.exponential`."""
+        """Call `numpy.random.Generator.exponential`."""
         return self.generator.exponential(scale=scale, size=size)
 
     def f(self, dfnum, dfden, size=None):
-        """Call :func:`numpy.random.Generator.f`."""
+        """Call `numpy.random.Generator.f`."""
         return self.generator.f(dfnum=dfnum, dfden=dfden, size=size)
 
     def gamma(self, shape, scale=1.0, size=None):
-        """Call :func:`numpy.random.Generator.gamma`."""
+        """Call `numpy.random.Generator.gamma`."""
         return self.generator.gamma(shape=shape, scale=scale, size=size)
 
     def geometric(self, p, size=None):
-        """Call :func:`numpy.random.Generator.geometric`."""
+        """Call `numpy.random.Generator.geometric`."""
         return self.generator.geometric(p=p, size=size)
 
     def gumbel(self, loc=0.0, scale=1.0, size=None):
-        """Call :func:`numpy.random.Generator.gumbel`."""
+        """Call `numpy.random.Generator.gumbel`."""
         return self.generator.gumbel(loc=loc, scale=scale, size=size)
 
     def hypergeometric(self, ngood, nbad, nsample, size=None):
-        """Call :func:`numpy.random.Generator.hypergeometric`."""
+        """Call `numpy.random.Generator.hypergeometric`."""
         return self.generator.hypergeometric(
             ngood=ngood, nbad=nbad, nsample=nsample, size=size)
 
     def laplace(self, loc=0.0, scale=1.0, size=None):
-        """Call :func:`numpy.random.Generator.laplace`."""
+        """Call `numpy.random.Generator.laplace`."""
         return self.generator.laplace(loc=loc, scale=scale, size=size)
 
     def logistic(self, loc=0.0, scale=1.0, size=None):
-        """Call :func:`numpy.random.Generator.logistic`."""
+        """Call `numpy.random.Generator.logistic`."""
         return self.generator.logistic(loc=loc, scale=scale, size=size)
 
     def lognormal(self, mean=0.0, sigma=1.0, size=None):
-        """Call :func:`numpy.random.Generator.lognormal`."""
+        """Call `numpy.random.Generator.lognormal`."""
         return self.generator.lognormal(mean=mean, sigma=sigma, size=size)
 
     def logseries(self, p, size=None):
-        """Call :func:`numpy.random.Generator.logseries`."""
+        """Call `numpy.random.Generator.logseries`."""
         return self.generator.logseries(p=p, size=size)
 
     def multinomial(self, n, pvals, size=None):
-        """Call :func:`numpy.random.Generator.multinomial`."""
+        """Call `numpy.random.Generator.multinomial`."""
         return self.generator.multinomial(n=n, pvals=pvals, size=size)
 
     def multivariate_normal(self, mean, cov, size=None, check_valid="warn",
                             tol=1e-8):
-        """Call :func:`numpy.random.Generator.multivariate_normal`."""
+        """Call `numpy.random.Generator.multivariate_normal`."""
         return self.generator.multivariate_normal(
             mean=mean, cov=cov, size=size, check_valid=check_valid, tol=tol)
 
     def negative_binomial(self, n, p, size=None):
-        """Call :func:`numpy.random.Generator.negative_binomial`."""
+        """Call `numpy.random.Generator.negative_binomial`."""
         return self.generator.negative_binomial(n=n, p=p, size=size)
 
     def noncentral_chisquare(self, df, nonc, size=None):
-        """Call :func:`numpy.random.Generator.noncentral_chisquare`."""
+        """Call `numpy.random.Generator.noncentral_chisquare`."""
         # pylint: disable=invalid-name
         return self.generator.noncentral_chisquare(df=df, nonc=nonc, size=size)
 
     def noncentral_f(self, dfnum, dfden, nonc, size=None):
-        """Call :func:`numpy.random.Generator.noncentral_f`."""
+        """Call `numpy.random.Generator.noncentral_f`."""
         return self.generator.noncentral_f(
             dfnum=dfnum, dfden=dfden, nonc=nonc, size=size)
 
@@ -653,7 +653,7 @@ class RNG(object):
         )
 
     def _normal_np(self, loc=0.0, scale=1.0, size=None):
-        """Call :func:`numpy.random.Generator.normal`.
+        """Call `numpy.random.Generator.normal`.
 
         Added in 0.5.0.
         (Extracted from normal().)
@@ -702,30 +702,30 @@ class RNG(object):
         return samples
 
     def pareto(self, a, size=None):
-        """Call :func:`numpy.random.Generator.pareto`."""
+        """Call `numpy.random.Generator.pareto`."""
         # pylint: disable=invalid-name
         return self.generator.pareto(a=a, size=size)
 
     def poisson(self, lam=1.0, size=None):
-        """Call :func:`numpy.random.Generator.poisson`."""
+        """Call `numpy.random.Generator.poisson`."""
         return self.generator.poisson(lam=lam, size=size)
 
     def power(self, a, size=None):
-        """Call :func:`numpy.random.Generator.power`."""
+        """Call `numpy.random.Generator.power`."""
         # pylint: disable=invalid-name
         return self.generator.power(a=a, size=size)
 
     def rayleigh(self, scale=1.0, size=None):
-        """Call :func:`numpy.random.Generator.rayleigh`."""
+        """Call `numpy.random.Generator.rayleigh`."""
         return self.generator.rayleigh(scale=scale, size=size)
 
     def standard_cauchy(self, size=None):
-        """Call :func:`numpy.random.Generator.standard_cauchy`."""
+        """Call `numpy.random.Generator.standard_cauchy`."""
         return self.generator.standard_cauchy(size=size)
 
     def standard_exponential(self, size=None, dtype="float32", method="zig",
                              out=None):
-        """Call :func:`numpy.random.Generator.standard_exponential`.
+        """Call `numpy.random.Generator.standard_exponential`.
 
         .. note::
 
@@ -746,7 +746,7 @@ class RNG(object):
         return result
 
     def standard_gamma(self, shape, size=None, dtype="float32", out=None):
-        """Call :func:`numpy.random.Generator.standard_gamma`.
+        """Call `numpy.random.Generator.standard_gamma`.
 
         .. note::
 
@@ -768,7 +768,7 @@ class RNG(object):
         return result
 
     def standard_normal(self, size=None, dtype="float32", out=None):
-        """Call :func:`numpy.random.Generator.standard_normal`.
+        """Call `numpy.random.Generator.standard_normal`.
 
         .. note::
 
@@ -789,12 +789,12 @@ class RNG(object):
         return result
 
     def standard_t(self, df, size=None):
-        """Call :func:`numpy.random.Generator.standard_t`."""
+        """Call `numpy.random.Generator.standard_t`."""
         # pylint: disable=invalid-name
         return self.generator.standard_t(df=df, size=size)
 
     def triangular(self, left, mode, right, size=None):
-        """Call :func:`numpy.random.Generator.triangular`."""
+        """Call `numpy.random.Generator.triangular`."""
         return self.generator.triangular(
             left=left, mode=mode, right=right, size=size)
 
@@ -814,7 +814,7 @@ class RNG(object):
         )
 
     def _uniform_np(self, low=0.0, high=1.0, size=None):
-        """Call :func:`numpy.random.Generator.uniform`.
+        """Call `numpy.random.Generator.uniform`.
 
         Added in 0.5.0.
         (Extracted from uniform().)
@@ -855,21 +855,21 @@ class RNG(object):
         return samples
 
     def vonmises(self, mu, kappa, size=None):
-        """Call :func:`numpy.random.Generator.vonmises`."""
+        """Call `numpy.random.Generator.vonmises`."""
         # pylint: disable=invalid-name
         return self.generator.vonmises(mu=mu, kappa=kappa, size=size)
 
     def wald(self, mean, scale, size=None):
-        """Call :func:`numpy.random.Generator.wald`."""
+        """Call `numpy.random.Generator.wald`."""
         return self.generator.wald(mean=mean, scale=scale, size=size)
 
     def weibull(self, a, size=None):
-        """Call :func:`numpy.random.Generator.weibull`."""
+        """Call `numpy.random.Generator.weibull`."""
         # pylint: disable=invalid-name
         return self.generator.weibull(a=a, size=size)
 
     def zipf(self, a, size=None):
-        """Call :func:`numpy.random.Generator.zipf`."""
+        """Call `numpy.random.Generator.zipf`."""
         # pylint: disable=invalid-name
         return self.generator.zipf(a=a, size=size)
 
@@ -881,7 +881,7 @@ class RNG(object):
     ##################################################################
 
     def rand(self, *args):
-        """Call :func:`numpy.random.RandomState.rand`.
+        """Call `numpy.random.RandomState.rand`.
 
         .. warning::
 
@@ -893,7 +893,7 @@ class RNG(object):
         return self.random(size=args)
 
     def randint(self, low, high=None, size=None, dtype="int32"):
-        """Call :func:`numpy.random.RandomState.randint`.
+        """Call `numpy.random.RandomState.randint`.
 
         .. note::
 
@@ -912,7 +912,7 @@ class RNG(object):
                              endpoint=False)
 
     def randn(self, *args):
-        """Call :func:`numpy.random.RandomState.randn`.
+        """Call `numpy.random.RandomState.randn`.
 
         .. warning::
 
@@ -925,7 +925,7 @@ class RNG(object):
         return self.standard_normal(size=args)
 
     def random_integers(self, low, high=None, size=None):
-        """Call :func:`numpy.random.RandomState.random_integers`.
+        """Call `numpy.random.RandomState.random_integers`.
 
         .. warning::
 
@@ -940,7 +940,7 @@ class RNG(object):
         return self.integers(low=low, high=high, size=size, endpoint=True)
 
     def random_sample(self, size):
-        """Call :func:`numpy.random.RandomState.random_sample`.
+        """Call `numpy.random.RandomState.random_sample`.
 
         .. warning::
 
@@ -953,7 +953,7 @@ class RNG(object):
         return self.uniform(0.0, 1.0, size=size)
 
     def tomaxint(self, size=None):
-        """Call :func:`numpy.random.RandomState.tomaxint`.
+        """Call `numpy.random.RandomState.tomaxint`.
 
         .. warning::
 
@@ -1641,28 +1641,28 @@ def polyfill_integers(generator, low, high=None, size=None, dtype="int32",
     ----------
     generator : numpy.random.Generator or numpy.random.RandomState
         The generator to sample from. If it is a ``RandomState``,
-        :func:`numpy.random.RandomState.randint` will be called,
-        otherwise :func:`numpy.random.Generator.integers`.
+        `numpy.random.RandomState.randint` will be called,
+        otherwise `numpy.random.Generator.integers`.
 
     low : int or array-like of ints
-        See :func:`numpy.random.Generator.integers`.
+        See `numpy.random.Generator.integers`.
 
     high : int or array-like of ints, optional
-        See :func:`numpy.random.Generator.integers`.
+        See `numpy.random.Generator.integers`.
 
     size : int or tuple of ints, optional
-        See :func:`numpy.random.Generator.integers`.
+        See `numpy.random.Generator.integers`.
 
     dtype : {str, dtype}, optional
-        See :func:`numpy.random.Generator.integers`.
+        See `numpy.random.Generator.integers`.
 
     endpoint : bool, optional
-        See :func:`numpy.random.Generator.integers`.
+        See `numpy.random.Generator.integers`.
 
     Returns
     -------
     int or ndarray of ints
-        See :func:`numpy.random.Generator.integers`.
+        See `numpy.random.Generator.integers`.
 
     """
     if hasattr(generator, "randint"):
@@ -1687,19 +1687,19 @@ def polyfill_random(generator, size, dtype="float32", out=None):
         support ``random()``, but with different interfaces.
 
     size : int or tuple of ints, optional
-        See :func:`numpy.random.Generator.random`.
+        See `numpy.random.Generator.random`.
 
     dtype : {str, dtype}, optional
-        See :func:`numpy.random.Generator.random`.
+        See `numpy.random.Generator.random`.
 
     out : ndarray, optional
-        See :func:`numpy.random.Generator.random`.
+        See `numpy.random.Generator.random`.
 
 
     Returns
     -------
     float or ndarray of floats
-        See :func:`numpy.random.Generator.random`.
+        See `numpy.random.Generator.random`.
 
     """
     if hasattr(generator, "random_sample"):

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -433,7 +433,7 @@ class TestRNG(_Base):
                         )
                         sample = sample - 5.0
                         samples.append(sample)
-                    samples = np.array(samples, dtype=np.float32)
+                    samples = np.concatenate(samples, axis=0)
 
                     observed = np.std(samples)
                     assert np.isclose(
@@ -703,8 +703,194 @@ class TestRNG(_Base):
         self._test_sampling_func("triangular", left=1.0, mode=1.5, right=2.0,
                                  size=(1,))
 
-    def test_uniform_mocked(self):
-        self._test_sampling_func("uniform", low=0.5, high=1.5, size=(1,))
+    def test_uniform_low_high(self):
+        methods = ["uniform", "_uniform_np", "_uniform_cv2"]
+        sizes = [
+            None, 1000, (1000,), (10, 100), (10, 10, 10), (10, 10, 10, 2),
+            (10, 1, 10, 2, 5)
+        ]
+
+        for method in methods:
+            for size in sizes:
+                for low in [-2.5, -0.75, 0.0, 10.2]:
+                    for high in [-1.5, 1.75, 1.0, 11.2]:
+                        if low > high:
+                            continue
+
+                        if method == "_uniform_cv2" and (
+                                size is None or ia.is_single_integer(size)):
+                            continue
+
+                        with self.subTest(method=method, size=size, low=low,
+                                          high=high):
+                            rng = iarandom.RNG(0)
+                            samples = getattr(rng, method)(
+                                low=low, high=high, size=size
+                            )
+                            assert np.all(samples >= low)
+                            assert np.all(samples < high)
+                            if size is not None and np.prod(size) >= 1000:
+                                assert np.any(np.isclose(samples, low, rtol=0,
+                                                         atol=0.1))
+                                assert np.any(np.isclose(samples, high, rtol=0,
+                                                         atol=0.1))
+                            if size is not None:
+                                assert samples.dtype.name == "float32"
+
+    def test_uniform_low_equals_high(self):
+        methods = ["uniform", "_uniform_np", "_uniform_cv2"]
+        sizes = [
+            None, 1000, (1000,), (10, 100), (10, 10, 10), (10, 10, 10, 2),
+            (10, 1, 10, 2, 5)
+        ]
+
+        for method in methods:
+            for size in sizes:
+                for value in [-2.5, -0.75, 0.0, 10.2]:
+                    if method == "_uniform_cv2" and (
+                            size is None or ia.is_single_integer(size)):
+                        continue
+
+                    with self.subTest(method=method, size=size, value=value):
+                        rng = iarandom.RNG(0)
+                        samples = getattr(rng, method)(
+                            low=value, high=value, size=size
+                        )
+                        assert np.allclose(samples, value, rtol=0,
+                                           atol=0.01)
+                        if size is not None:
+                            assert samples.dtype.name == "float32"
+
+    def test_uniform_low_high_scalar_samples(self):
+        methods = ["uniform", "_uniform_np", "_uniform_cv2"]
+
+        for method in methods:
+            for low in [-2.5, 0.0, 10.2]:
+                for high in [1.0, 11.2]:
+                    if low > high:
+                        continue
+
+                    with self.subTest(method=method, low=low, high=high):
+                        rng = iarandom.RNG(0)
+                        samples = []
+                        for _ in np.arange(2000):
+                            sample = getattr(rng, method)(
+                                low=low, high=high, size=(1,)
+                            )
+                            samples.append(sample)
+                        samples = np.concatenate(samples, axis=0)
+
+                        samples_sorted = np.sort(samples)
+                        dishomogenity = np.average(
+                            np.abs(
+                                samples_sorted[1:] - samples_sorted[:-1]
+                            )
+                        )
+                        dishomogenity_thresh = 2 * ((high - low) / 2000)
+
+                        assert np.all(samples >= low)
+                        assert np.all(samples < high)
+                        assert np.any(np.isclose(samples, low, rtol=0,
+                                                 atol=0.1))
+                        assert np.any(np.isclose(samples, high, rtol=0,
+                                                 atol=0.1))
+                        assert dishomogenity < dishomogenity_thresh
+
+    def test_uniform_size_is_single_int(self):
+        for size in [0, 1, 10]:
+            rng = iarandom.RNG(0)
+            samples = rng.uniform(low=0.5, high=1.0, size=size)
+            assert len(samples) == size
+            assert samples.dtype.name == "float32"
+
+    def test_uniform_size_is_tuple(self):
+        sizes = [
+            (0,),
+            (1,),
+            (10,),
+            (1, 0),
+            (1, 1),
+            (2, 4),
+            (32, 32),
+            (64, 64),
+            (224, 224),
+            (513, 1025),
+            (224, 224, 0),
+            (224, 224, 1),
+            (224, 224, 2),
+            (224, 224, 3),
+            (224, 224, 4),
+            (224, 224, 10),
+            (2, 5, 513),
+            (2, 5, 1025),
+            (1, 2, 3, 4, 5),
+            (1, 2, 3, 4, 5, 4, 3, 2, 1)
+        ]
+        low = 2.0
+        high = 5.0
+        for size in sizes:
+            with self.subTest(size=size):
+                rng = iarandom.RNG(0)
+                samples = rng.uniform(low=low, high=high, size=size)
+                assert samples.shape == size
+                assert samples.dtype.name == "float32"
+                if np.prod(size) > 0:
+                    assert np.all(samples >= low)
+                    assert np.all(samples < high)
+                if np.prod(size) > 1000:
+                    assert np.any(np.isclose(samples, low, rtol=0,
+                                             atol=0.1))
+                    assert np.any(np.isclose(samples, high, rtol=0,
+                                             atol=0.1))
+
+    def test_uniform_same_seed_leads_to_same_results(self):
+        size = (100,)
+        for seed in [0, 10, 2**30]:
+            with self.subTest(seed=seed):
+                samples1 = iarandom.RNG(seed).uniform(
+                    low=2.0, high=5.0, size=size
+                )
+                samples2 = iarandom.RNG(seed).uniform(
+                    low=2.0, high=5.0, size=size
+                )
+                samples3 = iarandom.RNG(seed).uniform(
+                    low=2.0, high=5.0, size=size
+                )
+
+                assert np.allclose(samples1, samples2, rtol=0, atol=0.01)
+                assert np.allclose(samples2, samples3, rtol=0, atol=0.01)
+
+    def test_uniform_different_seeds_lead_to_different_results(self):
+        size = (100,)
+        for seed in [0, 10, 2**30]:
+            with self.subTest(seed=seed):
+                samples1 = iarandom.RNG(seed+0).uniform(
+                    low=2.0, high=5.0, size=size
+                )
+                samples2 = iarandom.RNG(seed+1).uniform(
+                    low=2.0, high=5.0, size=size
+                )
+                samples3 = iarandom.RNG(seed+2).uniform(
+                    low=2.0, high=5.0, size=size
+                )
+
+                assert not np.allclose(samples1, samples2, rtol=0, atol=0.01)
+                assert not np.allclose(samples1, samples3, rtol=0, atol=0.01)
+                assert not np.allclose(samples2, samples3, rtol=0, atol=0.01)
+
+    def test_uniform_consecutive_calls_produce_different_results(self):
+        size = (100,)
+        for seed in [0, 10, 2**30]:
+            with self.subTest(seed=seed):
+                rng = iarandom.RNG(0)
+
+                samples1 = rng.uniform(low=2.0, high=5.0, size=size)
+                samples2 = rng.uniform(low=2.0, high=5.0, size=size)
+                samples3 = rng.uniform(low=2.0, high=5.0, size=size)
+
+                assert not np.allclose(samples1, samples2, rtol=0, atol=0.01)
+                assert not np.allclose(samples1, samples3, rtol=0, atol=0.01)
+                assert not np.allclose(samples2, samples3, rtol=0, atol=0.01)
 
     def test_vonmises_mocked(self):
         self._test_sampling_func("vonmises", mu=1.0, kappa=1.5, size=(1,))
@@ -798,7 +984,7 @@ class TestRNG(_Base):
 
     def test_random_sample(self):
         result = iarandom.RNG(0).random_sample((10, 20, 3))
-        assert result.dtype.name == "float64"
+        assert result.dtype.name == "float32"
         assert result.shape == (10, 20, 3)
         assert np.all(result >= 0.0)
         assert np.all(result <= 1.0)

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -233,7 +233,7 @@ class TestRNG(_Base):
         mock_is_global.return_value = False
         mock_copy.return_value = "foo"
         result = rng.copy_unless_global_rng()
-        assert result is "foo"
+        assert result == "foo"
         mock_is_global.assert_called_once_with()
         mock_copy.assert_called_once_with()
 
@@ -380,8 +380,165 @@ class TestRNG(_Base):
         self._test_sampling_func("noncentral_f", dfnum=0.5, dfden=1.5,
                                  nonc=2.0, size=(1,))
 
-    def test_normal_mocked(self):
-        self._test_sampling_func("normal", loc=0.5, scale=1.0, size=(1,))
+    def test_normal_loc(self):
+        for size in [None, 1, (1,), (1, 2, 3), (4, 3, 2, 1)]:
+            for loc in [-1.5, -1, -0.5, 0.0, 0.1, 10]:
+                with self.subTest(size=size, loc=loc):
+                    rng = iarandom.RNG(0)
+                    samples = rng.normal(loc=loc, scale=0.0001, size=size)
+                    assert np.allclose(samples, loc, rtol=0, atol=0.025)
+                    if size is not None:
+                        assert samples.dtype.name == "float32"
+
+    def test_normal_scale(self):
+        methods = ["normal", "_normal_np", "_normal_cv2"]
+
+        for method in methods:
+            for scale in [0.001, 1.0, 8.5, 10.0, 50.0, 100.0]:
+                with self.subTest(method=method, scale=scale):
+                    rng = iarandom.RNG(0)
+                    samples = getattr(rng, method)(
+                        loc=5.0, scale=scale, size=(1000,)
+                    )
+                    samples = samples - 5.0
+
+                    observed = np.std(samples)
+                    assert np.isclose(
+                        observed,
+                        scale,
+                        rtol=0,
+                        atol=max(scale*0.1, 0.01)
+                    )
+                    assert samples.dtype.name == "float32"
+
+                    # no samples beyond mean +/- 100*sigma
+                    assert np.all(samples > -100 * scale)
+                    assert np.all(samples < 100 * scale)
+
+                    # at least one value beyond mean +/- 1*sigma
+                    assert np.any(samples < -1 * scale)
+                    assert np.any(samples > 1 * scale)
+
+    def test_normal_scale_with_scalar_samples(self):
+        methods = ["normal", "_normal_np", "_normal_cv2"]
+
+        for method in methods:
+            for scale in [0.5, 8.5, 10.0, 50.5, 100.0]:
+                with self.subTest(method=method, scale=scale):
+                    rng = iarandom.RNG(0)
+                    samples = []
+                    for _ in np.arange(2000):
+                        sample = getattr(rng, method)(
+                            loc=5.0, scale=scale, size=(1,)
+                        )
+                        sample = sample - 5.0
+                        samples.append(sample)
+                    samples = np.array(samples, dtype=np.float32)
+
+                    observed = np.std(samples)
+                    assert np.isclose(
+                        observed,
+                        scale,
+                        rtol=0,
+                        atol=max(scale*0.1, 0.01)
+                    )
+                    assert samples.dtype.name == "float32"
+
+                    # no samples beyond mean +/- 100*sigma
+                    assert np.all(samples > -100 * scale)
+                    assert np.all(samples < 100 * scale)
+
+                    # at least one value beyond mean +/- 1*sigma
+                    assert np.any(samples < -1 * scale)
+                    assert np.any(samples > 1 * scale)
+
+    def test_normal_size_is_single_int(self):
+        for size in [0, 1, 10]:
+            rng = iarandom.RNG(0)
+            samples = rng.normal(loc=0.0, scale=1.0, size=size)
+            assert len(samples) == size
+            assert samples.dtype.name == "float32"
+
+    def test_normal_size_is_tuple(self):
+        sizes = [
+            (0,),
+            (1,),
+            (10,),
+            (1, 0),
+            (1, 1),
+            (2, 4),
+            (32, 32),
+            (64, 64),
+            (224, 224),
+            (513, 1025),
+            (224, 224, 0),
+            (224, 224, 1),
+            (224, 224, 2),
+            (224, 224, 3),
+            (224, 224, 4),
+            (224, 224, 10),
+            (2, 5, 513),
+            (2, 5, 1025),
+            (1, 2, 3, 4, 5),
+            (1, 2, 3, 4, 5, 4, 3, 2, 1)
+        ]
+        for size in sizes:
+            with self.subTest(size=size):
+                rng = iarandom.RNG(0)
+                samples = rng.normal(loc=1.0, scale=0.0001, size=size)
+                assert samples.shape == size
+                assert samples.dtype.name == "float32"
+                if np.prod(size) > 0:
+                    assert np.allclose(samples, 1.0, rtol=0, atol=0.01)
+
+    def test_normal_same_seed_leads_to_same_results(self):
+        size = (100,)
+        for seed in [0, 10, 2**30]:
+            with self.subTest(seed=seed):
+                samples1 = iarandom.RNG(seed).normal(
+                    loc=1.0, scale=5.0, size=size
+                )
+                samples2 = iarandom.RNG(seed).normal(
+                    loc=1.0, scale=5.0, size=size
+                )
+                samples3 = iarandom.RNG(seed).normal(
+                    loc=1.0, scale=5.0, size=size
+                )
+
+                assert np.allclose(samples1, samples2, rtol=0, atol=0.01)
+                assert np.allclose(samples2, samples3, rtol=0, atol=0.01)
+
+    def test_normal_different_seeds_lead_to_different_results(self):
+        size = (100,)
+        for seed in [0, 10, 2**30]:
+            with self.subTest(seed=seed):
+                samples1 = iarandom.RNG(seed+0).normal(
+                    loc=1.0, scale=5.0, size=size
+                )
+                samples2 = iarandom.RNG(seed+1).normal(
+                    loc=1.0, scale=5.0, size=size
+                )
+                samples3 = iarandom.RNG(seed+2).normal(
+                    loc=1.0, scale=5.0, size=size
+                )
+
+                assert not np.allclose(samples1, samples2, rtol=0, atol=0.01)
+                assert not np.allclose(samples1, samples3, rtol=0, atol=0.01)
+                assert not np.allclose(samples2, samples3, rtol=0, atol=0.01)
+
+    def test_normal_consecutive_calls_produce_different_results(self):
+        size = (100,)
+        for seed in [0, 10, 2**30]:
+            with self.subTest(seed=seed):
+                rng = iarandom.RNG(0)
+
+                samples1 = rng.normal(loc=1.0, scale=5.0, size=size)
+                samples2 = rng.normal(loc=1.0, scale=5.0, size=size)
+                samples3 = rng.normal(loc=1.0, scale=5.0, size=size)
+
+                assert not np.allclose(samples1, samples2, rtol=0, atol=0.01)
+                assert not np.allclose(samples1, samples3, rtol=0, atol=0.01)
+                assert not np.allclose(samples2, samples3, rtol=0, atol=0.01)
 
     def test_pareto_mocked(self):
         self._test_sampling_func("pareto", a=0.5, size=(1,))


### PR DESCRIPTION
This patch improves the speed at which samples are drawn from
gaussian distributions. The improvement is activate for matrices
with more than 2500 components (roughly 32x32x3 and above).
For large matrices (224x224x3 and above) the expected speedup is
up to 3x.

This patch also improves the performance of sampling using
RNG.uniform().
The speedup is activated for matrices with 12500+ components
and is around 2x for large images (224x224x3).