### PR TITLE
Improve performance of multiply_scalar()

### DIFF
--- a/changelogs/master/improved/20200216_improve_multiply_scalar_perf.md
+++ b/changelogs/master/improved/20200216_improve_multiply_scalar_perf.md
@@ -1,0 +1,12 @@
+# Improve Performance of `multiply_scalar()` #???
+
+This patch improves the performance of
+`imgaug.augmenters.arithmetic.multiply_scalar()`. The function
+is now roughly up to 8x faster for small images (32x32x3),
+marginally faster at about 1.05x for large images (224x224x3,
+increase of ~1.05) and decently faster at about 1.35x for very
+large images (512x512x3, increase of ~1.35x).
+This change affects `Multiply`.
+
+Add functions:
+* `imgaug.augmenters.arithmetic.multiply_scalar_()`.

--- a/changelogs/master/improved/20200216_improve_multiply_scalar_perf.md
+++ b/changelogs/master/improved/20200216_improve_multiply_scalar_perf.md
@@ -1,12 +1,10 @@
-# Improve Performance of `multiply_scalar()` #???
+# Improve Performance of `multiply_scalar()` #614
 
 This patch improves the performance of
-`imgaug.augmenters.arithmetic.multiply_scalar()`. The function
-is now roughly up to 8x faster for small images (32x32x3),
-marginally faster at about 1.05x for large images (224x224x3,
-increase of ~1.05) and decently faster at about 1.35x for very
-large images (512x512x3, increase of ~1.35x).
-This change affects `Multiply`.
+`imgaug.augmenters.arithmetic.multiply_scalar()` for
+`uint8` inputs. The function is now between 1.2x and 7x
+faster (more for smaller images and channelwise
+multipliers). This change affects `Multiply`.
 
 Add functions:
 * `imgaug.augmenters.arithmetic.multiply_scalar_()`.

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -579,13 +579,9 @@ def _multiply_scalar_to_uint8_lut_(image, multiplier):
         value_range = np.broadcast_to(value_range[:, np.newaxis],
                                       (256, nb_channels))
         value_range = value_range * multiplier[np.newaxis, :]
-        value_range = np.clip(value_range, 0, 255, out=value_range)
-        value_range = value_range.astype(image.dtype, copy=False)
     else:
-        value_range *= multiplier
-        if multiplier < 0 or multiplier > 1:
-            value_range = np.clip(value_range, 0, 255, out=value_range)
-        value_range = value_range.astype(image.dtype, copy=False)
+        value_range = value_range * multiplier
+    value_range = np.clip(value_range, 0, 255).astype(image.dtype)
     return ia.apply_lut_(image, value_range)
 
 

--- a/test/augmenters/test_color.py
+++ b/test/augmenters/test_color.py
@@ -771,7 +771,7 @@ class TestMultiplyAndAddToBrightness(unittest.TestCase):
         expected = cv2.cvtColor(image, cv2.COLOR_RGB2HSV).astype(np.float32)
         expected[:, :, 2] *= 1.2
         expected = cv2.cvtColor(expected.astype(np.uint8), cv2.COLOR_HSV2RGB)
-        assert np.array_equal(image_aug, expected)
+        assert np.allclose(image_aug, expected, rtol=0, atol=1.01)
 
     def test_multiply_and_add_example_image(self):
         aug = iaa.MultiplyAndAddToBrightness(mul=1.2, add=10,
@@ -785,7 +785,7 @@ class TestMultiplyAndAddToBrightness(unittest.TestCase):
         expected[:, :, 2] *= 1.2
         expected[:, :, 2] += 10
         expected = cv2.cvtColor(expected.astype(np.uint8), cv2.COLOR_HSV2RGB)
-        assert np.array_equal(image_aug, expected)
+        assert np.allclose(image_aug, expected, rtol=0, atol=1.01)
 
     def test___str__(self):
         params = [


### PR DESCRIPTION
This patch improves the performance of
`imgaug.augmenters.arithmetic.multiply_scalar()` for
`uint8` inputs. The function is now between 1.2x and 7x
faster (more for smaller images and channelwise
multipliers). This change affects `Multiply`.

Add functions:
* `imgaug.augmenters.arithmetic.multiply_scalar_()`.