### PR TITLE
Fix missing fallback to keypoint augmentation in legacy augmenters

### DIFF
--- a/changelogs/master/fixed/20200217_legacy_kp_aug_fallback.md
+++ b/changelogs/master/fixed/20200217_legacy_kp_aug_fallback.md
@@ -1,0 +1,4 @@
+* Fixed legacy augmenters (i.e. no `_augment_batch_()`
+  implemented) not automatically falling back to
+  `_augment_keypoints()` for the augmentation of bounding
+  boxes, polygons and line strings. #617 #618

--- a/changelogs/master/fixed/20200217_legacy_kp_aug_fallback.md
+++ b/changelogs/master/fixed/20200217_legacy_kp_aug_fallback.md
@@ -1,4 +1,4 @@
-* Fixed legacy augmenters (i.e. no `_augment_batch_()`
+* Fix legacy augmenters (i.e. no `_augment_batch_()`
   implemented) not automatically falling back to
   `_augment_keypoints()` for the augmentation of bounding
   boxes, polygons and line strings. #617 #618

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -1361,7 +1361,12 @@ class Augmenter(object):
             The augmented bounding boxes.
 
         """
-        return bounding_boxes_on_images
+        return self._augment_cbaois_as_keypoints(
+            bounding_boxes_on_images,
+            random_state=random_state,
+            parents=parents,
+            hooks=hooks
+        )
 
     def _augment_polygons(self, polygons_on_images, random_state, parents,
                           hooks):
@@ -1403,7 +1408,12 @@ class Augmenter(object):
             The augmented polygons.
 
         """
-        return polygons_on_images
+        return self._augment_cbaois_as_keypoints(
+            polygons_on_images,
+            random_state=random_state,
+            parents=parents,
+            hooks=hooks
+        )
 
     def _augment_line_strings(self, line_strings_on_images, random_state,
                               parents, hooks):
@@ -1446,7 +1456,12 @@ class Augmenter(object):
             The augmented line strings.
 
         """
-        return line_strings_on_images
+        return self._augment_cbaois_as_keypoints(
+            line_strings_on_images,
+            random_state=random_state,
+            parents=parents,
+            hooks=hooks
+        )
 
     def _augment_bounding_boxes_as_keypoints(self, bounding_boxes_on_images,
                                              random_state, parents, hooks):


### PR DESCRIPTION
This patch fixes legacy augmenters (i.e. no `_augment_batch_()` implemented) not automatically falling back to `_augment_keypoints()` for the augmentation of bounding boxes, polygons and line strings (in the case that no dedicated functions are defined for these inputs).

fixes #617 