### PR TITLE
Vectorize CropAndPad

### DIFF
--- a/changelogs/master/improved/20200217_vectorize_cropandpad.md
+++ b/changelogs/master/improved/20200217_vectorize_cropandpad.md
@@ -1,0 +1,10 @@
+# Vectorize `CropAndPad` #619
+
+This patch vectorizes parts of `CropAndPad`, especially the
+sampling process, leading to an improved performance for large
+batches.
+
+Previously, cropping an image below a height and/or width of
+`1` would be prevented by `CropAndPad` *and* a warning was
+raised if it was tried. That warning was now removed, but
+height/width of at least `1` is still ensured.


### PR DESCRIPTION
This patch vectorizes parts of `CropAndPad`, especially the
sampling process, leading to an improved performance for large
batches.

Previously, cropping an image below a height and/or width of
`1` would be prevented by `CropAndPad` *and* a warning was
raised if it was tried. That warning was now removed, but
height/width of at least `1` is still ensured.