### PR TITLE
Improve performance of pooling

### DIFF
--- a/changelogs/master/improved/20200221_reworked_pooling.md
+++ b/changelogs/master/improved/20200221_reworked_pooling.md
@@ -1,0 +1,28 @@
+# Reworked Pooling #622
+
+This patch improves the performance of pooling operations.
+
+For `uint8` arrays, `max_pool()` and `min_pool()` are now
+between 3x and 8x faster. The improvements are more
+significant for larger images and smaller kernel sizes.
+In-place versions of `max_pool()` and `min_pool()` are also
+added. Both `MaxPooling` and `MinPooling` now use these
+functions.
+
+The performance of `avg_pool()` for `uint8` is improved by
+roughly 4x to 15x. (More for larger images and smaller
+kernel sizes.)
+
+The performance of `median_pool()` for `uint8` images is
+improved by roughly 1.7x to 7x, if the kernel size is 3
+or 5 or if the kernel size is 7, 9, 11, 13 and the image
+size is 32x32 or less. In both cases the kernel also has to be
+symmetric.
+In the case of a kernel size of 3, the performance improvement
+is most significant for larger images. In the case of 5, it
+is fairly even over all kernel sizes. In the case of 7 or higher,
+it is more significant for smaller images.
+
+Add functions:
+* `imgaug.imgaug.min_pool_()`.
+* `imgaug.imgaug.max_pool_()`.

--- a/changelogs/master/improved/20200221_reworked_pooling.md
+++ b/changelogs/master/improved/20200221_reworked_pooling.md
@@ -1,4 +1,4 @@
-# Reworked Pooling #622
+# Improved Performance of Pooling Operations #622
 
 This patch improves the performance of pooling operations.
 

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -559,9 +559,7 @@ class MinPooling(_AbstractPoolingBase):
             random_state=random_state, deterministic=deterministic)
 
     def _pool_image(self, image, kernel_size_h, kernel_size_w):
-        # TODO extend pool to support pad_mode and set it here
-        #      to reflection padding
-        return ia.min_pool(
+        return ia.min_pool_(
             image,
             (kernel_size_h, kernel_size_w)
         )

--- a/imgaug/augmenters/pooling.py
+++ b/imgaug/augmenters/pooling.py
@@ -436,9 +436,7 @@ class MaxPooling(_AbstractPoolingBase):
             random_state=random_state, deterministic=deterministic)
 
     def _pool_image(self, image, kernel_size_h, kernel_size_w):
-        # TODO extend max_pool to support pad_mode and set it here
-        #      to reflection padding
-        return ia.max_pool(
+        return ia.max_pool_(
             image,
             (kernel_size_h, kernel_size_w)
         )

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -2104,6 +2104,7 @@ def _minmax_pool_uint8_(arr, block_size, func, pad_mode, pad_cval):
         if block_size[0] <= 30 and block_size[1] <= 30:
             globals()["_POOLING_KERNELS_CACHE"][block_size] = kernel
 
+    # TODO why was this done with image flips instead of kernel flips?
     arr = cv2.flip(arr, -1)
     arr = func(arr, kernel, iterations=1)
     arr = cv2.flip(arr, -1)

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -2088,8 +2088,8 @@ def _minmax_pool_uint8_(arr, block_size, func, pad_mode, pad_cval):
 
     ndim_in = arr.ndim
 
-    s = arr.shape
-    if s[0] % block_size[0] != 0 or s[1] % block_size[1] != 0:
+    shape = arr.shape
+    if shape[0] % block_size[0] != 0 or shape[1] % block_size[1] != 0:
         arr = pad_to_multiples_of(
             arr,
             height_multiple=block_size[0],

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -2201,8 +2201,8 @@ def _median_pool_cv2(arr, block_size, pad_mode, pad_cval):
 
     ndim_in = arr.ndim
 
-    s = arr.shape
-    if s[0] % block_size != 0 or s[1] % block_size != 0:
+    shape = arr.shape
+    if shape[0] % block_size != 0 or shape[1] % block_size != 0:
         arr = pad_to_multiples_of(
             arr,
             height_multiple=block_size,

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -1919,6 +1919,8 @@ def max_pool_(arr, block_size, pad_mode="edge", pad_cval=0,
     Defaults to ``pad_mode="edge"`` to ensure that padded values do not affect
     the maximum, even if the dtype was something else than ``uint8``.
 
+    Added in 0.5.0.
+
     **Supported dtypes**:
 
         See :func:`~imgaug.imgaug.pool`.
@@ -2019,6 +2021,8 @@ def min_pool_(arr, block_size, pad_mode="edge", pad_cval=255,
 
     Defaults to ``pad_mode="edge"`` to ensure that padded values do not affect
     the minimum, even if the dtype was something else than ``uint8``.
+
+    Added in 0.5.0.
 
     **Supported dtypes**:
 

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -1843,8 +1843,8 @@ def _avg_pool_uint8(arr, block_size, pad_mode="reflect", pad_cval=128):
 
     ndim_in = arr.ndim
 
-    s = arr.shape
-    if s[0] % block_size[0] != 0 or s[1] % block_size[1] != 0:
+    shape = arr.shape
+    if shape[0] % block_size[0] != 0 or shape[1] % block_size[1] != 0:
         arr = pad_to_multiples_of(
             arr,
             height_multiple=block_size[0],

--- a/test/augmenters/test_pooling.py
+++ b/test/augmenters/test_pooling.py
@@ -677,6 +677,52 @@ class TestAveragePooling(unittest.TestCase, _TestPoolingAugmentersBase):
         assert image_aug.shape == (1, 2, 3)
         assert np.all(diff <= 1)
 
+    def test_augment_images__kernel_size_is_two__view(self):
+        aug = iaa.AveragePooling(2, keep_size=False)
+
+        image = np.uint8([
+            [50-2, 50-1, 120-4, 120+4],
+            [50+1, 50+2, 120+1, 120-1],
+            [0, 0, 0, 0]
+        ])
+        image = np.tile(image[:, :, np.newaxis], (1, 1, 3))
+        image = image[:2, :, :]
+        assert not image.flags["OWNDATA"]
+        assert image.flags["C_CONTIGUOUS"]
+
+        expected = np.uint8([
+            [50, 120]
+        ])
+        expected = np.tile(expected[:, :, np.newaxis], (1, 1, 3))
+
+        image_aug = aug.augment_image(image)
+
+        diff = np.abs(image_aug.astype(np.int32) - expected)
+        assert image_aug.dtype.name == "uint8"
+        assert image_aug.shape == (1, 2, 3)
+        assert np.all(diff <= 1)
+
+    def test_augment_images__kernel_size_is_two__non_contiguous(self):
+        aug = iaa.AveragePooling(2, keep_size=False)
+
+        image = np.array([
+            [50-2, 50-1, 120-4, 120+4],
+            [50+1, 50+2, 120+1, 120-1]
+        ], dtype=np.uint8, order="F")
+        assert image.flags["OWNDATA"]
+        assert not image.flags["C_CONTIGUOUS"]
+
+        expected = np.uint8([
+            [50, 120]
+        ])
+
+        image_aug = aug.augment_image(image)
+
+        diff = np.abs(image_aug.astype(np.int32) - expected)
+        assert image_aug.dtype.name == "uint8"
+        assert image_aug.shape == (1, 2)
+        assert np.all(diff <= 1)
+
     def test_augment_images__kernel_size_is_two__four_channels(self):
         aug = iaa.AveragePooling(2, keep_size=False)
 

--- a/test/test_imgaug.py
+++ b/test/test_imgaug.py
@@ -1413,10 +1413,12 @@ def test_avg_pool():
     arr_pooled = ia.avg_pool(arr, 2)
     assert arr_pooled.shape == (2, 2)
     assert arr_pooled.dtype == arr.dtype.type
-    assert arr_pooled[0, 0] == int(np.average([0, 1, 4, 5]))
-    assert arr_pooled[0, 1] == int(np.average([2, 3, 6, 7]))
-    assert arr_pooled[1, 0] == int(np.average([8, 9, 12, 13]))
-    assert arr_pooled[1, 1] == int(np.average([10, 11, 14, 15]))
+    # add 1e-4 here to force 0.5 to be rounded up, as that's how OpenCV
+    # handles it
+    assert arr_pooled[0, 0] == int(np.round(1e-4 + np.average([0, 1, 4, 5])))
+    assert arr_pooled[0, 1] == int(np.round(1e-4 + np.average([2, 3, 6, 7])))
+    assert arr_pooled[1, 0] == int(np.round(1e-4 + np.average([8, 9, 12, 13])))
+    assert arr_pooled[1, 1] == int(np.round(1e-4 + np.average([10, 11, 14, 15])))
 
 
 # TODO add test that verifies the default padding mode

--- a/test/test_imgaug.py
+++ b/test/test_imgaug.py
@@ -1482,6 +1482,115 @@ def test_median_pool():
     assert arr_pooled[1, 1] == int(np.median([10, 11, 14, 15]))
 
 
+# TODO add test that verifies the default padding mode
+def test_median_pool_ksize_1_3():
+    # very basic test, as median_pool() just calls pool(), which is tested in
+    # test_pool()
+    arr = np.uint8([
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+        [12, 13, 14, 15]
+    ])
+
+    arr_pooled = ia.median_pool(arr, (1, 3))
+
+    assert arr_pooled.shape == (4, 2)
+    assert arr_pooled.dtype == arr.dtype.type
+    assert arr_pooled[0, 0] == int(np.median([0, 1, 2]))
+    assert arr_pooled[0, 1] == int(np.median([3, 2, 1]))
+    assert arr_pooled[1, 0] == int(np.median([4, 5, 6]))
+    assert arr_pooled[1, 1] == int(np.median([7, 6, 5]))
+    assert arr_pooled[2, 0] == int(np.median([8, 9, 10]))
+    assert arr_pooled[2, 1] == int(np.median([11, 10, 9]))
+    assert arr_pooled[3, 0] == int(np.median([12, 13, 14]))
+    assert arr_pooled[3, 1] == int(np.median([15, 14, 13]))
+
+
+def test_median_pool_ksize_3():
+    # After padding:
+    # [5, 4, 5, 6, 7, 6],
+    # [1, 0, 1, 2, 3, 2],
+    # [5, 4, 5, 6, 7, 6],
+    # [9, 8, 9, 10, 11, 10],
+    # [13, 12, 13, 14, 15, 14],
+    # [9, 8, 9, 10, 11, 10]
+    arr = np.uint8([
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+        [12, 13, 14, 15]
+    ])
+
+    arr_pooled = ia.median_pool(arr, 3)
+
+    assert arr_pooled.shape == (2, 2)
+    assert arr_pooled.dtype == arr.dtype.type
+    assert arr_pooled[0, 0] == int(np.median([5, 4, 5, 1, 0, 1, 5, 4, 5]))
+    assert arr_pooled[0, 1] == int(np.median([6, 7, 6, 2, 3, 2, 6, 7, 6]))
+    assert arr_pooled[1, 0] == int(np.median([9, 8, 9, 13, 12, 13, 9, 8, 9]))
+    assert arr_pooled[1, 1] == int(np.median([10, 11, 10, 14, 15, 13, 10, 11,
+                                              10]))
+
+
+def test_median_pool_ksize_3_view():
+    # After padding:
+    # [5, 4, 5, 6, 7, 6],
+    # [1, 0, 1, 2, 3, 2],
+    # [5, 4, 5, 6, 7, 6],
+    # [9, 8, 9, 10, 11, 10],
+    # [13, 12, 13, 14, 15, 14],
+    # [9, 8, 9, 10, 11, 10]
+    arr = np.uint8([
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+        [12, 13, 14, 15],
+        [0, 0, 0, 0]
+    ])
+
+    arr_in = arr[0:4, :]
+    assert arr_in.flags["OWNDATA"] is False
+    assert arr_in.flags["C_CONTIGUOUS"] is True
+    arr_pooled = ia.median_pool(arr_in, 3)
+
+    assert arr_pooled.shape == (2, 2)
+    assert arr_pooled.dtype == arr.dtype.type
+    assert arr_pooled[0, 0] == int(np.median([5, 4, 5, 1, 0, 1, 5, 4, 5]))
+    assert arr_pooled[0, 1] == int(np.median([6, 7, 6, 2, 3, 2, 6, 7, 6]))
+    assert arr_pooled[1, 0] == int(np.median([9, 8, 9, 13, 12, 13, 9, 8, 9]))
+    assert arr_pooled[1, 1] == int(np.median([10, 11, 10, 14, 15, 13, 10, 11,
+                                              10]))
+
+
+def test_median_pool_ksize_3_non_contiguous():
+    # After padding:
+    # [5, 4, 5, 6, 7, 6],
+    # [1, 0, 1, 2, 3, 2],
+    # [5, 4, 5, 6, 7, 6],
+    # [9, 8, 9, 10, 11, 10],
+    # [13, 12, 13, 14, 15, 14],
+    # [9, 8, 9, 10, 11, 10]
+    arr = np.array([
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+        [12, 13, 14, 15]
+    ], dtype=np.uint8, order="F")
+
+    assert arr.flags["OWNDATA"] is True
+    assert arr.flags["C_CONTIGUOUS"] is False
+    arr_pooled = ia.median_pool(arr, 3)
+
+    assert arr_pooled.shape == (2, 2)
+    assert arr_pooled.dtype == arr.dtype.type
+    assert arr_pooled[0, 0] == int(np.median([5, 4, 5, 1, 0, 1, 5, 4, 5]))
+    assert arr_pooled[0, 1] == int(np.median([6, 7, 6, 2, 3, 2, 6, 7, 6]))
+    assert arr_pooled[1, 0] == int(np.median([9, 8, 9, 13, 12, 13, 9, 8, 9]))
+    assert arr_pooled[1, 1] == int(np.median([10, 11, 10, 14, 15, 13, 10, 11,
+                                              10]))
+
+
 def test_draw_grid():
     # bool
     dtype = bool


### PR DESCRIPTION
This patch improves the performance of pooling operations.

For `uint8` arrays, `max_pool()` and `min_pool()` are now
between 3x and 8x faster. The improvements are more
significant for larger images and smaller kernel sizes.
In-place versions of `max_pool()` and `min_pool()` are also
added. Both `MaxPooling` and `MinPooling` now use these
functions.

The performance of `avg_pool()` for `uint8` is improved by
roughly 4x to 15x. (More for larger images and smaller
kernel sizes.)

The performance of `median_pool()` for `uint8` images is
improved by roughly 1.7x to 7x, if the kernel size is 3
or 5 or if the kernel size is 7, 9, 11, 13 and the image
size is 32x32 or less. In both cases the kernel also has to be
symmetric.
In the case of a kernel size of 3, the performance improvement
is most significant for larger images. In the case of 5, it
is fairly even over all kernel sizes. In the case of 7 or higher,
it is more significant for smaller images.

Add functions:
* `imgaug.imgaug.min_pool_()`.
* `imgaug.imgaug.max_pool_()`.