### PR TITLE
Enforce stricter shape handling in augmentables

### DIFF
--- a/changelogs/master/changed/20200222_shape_handling.md
+++ b/changelogs/master/changed/20200222_shape_handling.md
@@ -1,0 +1,34 @@
+# Stricter Shape Handling in Augmentables #623
+
+Various methods of augmentables have so far accepted tuples
+of integers or numpy arrays for `shape` parameters. This was
+the case for e.g. `BoundingBoxesOnImage.__init__(bbs, shape)`
+or `Polygon.clip_out_of_image(image)`. This tolerant handling
+of shapes conveys some risk that an input is actually a
+numpy representation of a shape, i.e. the equivalent of
+`numpy.array(shape_tuple)`.
+
+To decrease the risk of such an input leading to bugs, arrays
+are no longer recommended inputs for `shape` in
+`KeypointsOnImage.__init__`, `BoundingBoxesOnImage.__init__`,
+`LineStringsOnImage.__init__`, and `PolygonsOnImage.__init__`.
+Their usage in these methods will now raise a deprecation warning.
+
+In all other methods of augmentables that currently accept
+image-like numpy arrays and shape tuples for parameters,
+only arrays that are 2-dimensional or 3-dimensional are from
+now on accepted. Other arrays (e.g. 1-dimensional ones)
+will be rejected with an assertion error.
+
+Add functions:
+* `imgaug.augmentables.utils.normalize_imglike_shape()`.
+
+List of deprecations:
+* `numpy.ndarray` as value of parameter `shape` in
+  `KeypointsOnImage.__init__`.
+* `numpy.ndarray` as value of parameter `shape` in
+  `BoundingBoxesOnImage.__init__`.
+* `numpy.ndarray` as value of parameter `shape` in
+  `LineStringsOnImage.__init__`.
+* `numpy.ndarray` as value of parameter `shape` in
+  `PolygonsOnImage.__init__`.

--- a/imgaug/augmentables/bbs.py
+++ b/imgaug/augmentables/bbs.py
@@ -11,7 +11,7 @@ from .. import imgaug as ia
 from .base import IAugmentable
 from .utils import (normalize_shape, project_coords,
                     _remove_out_of_image_fraction_,
-                    _normalize_shift_args)
+                    _normalize_shift_args, _handle_on_image_shape)
 
 
 # TODO functions: square(), to_aspect_ratio(), contains_point()
@@ -1360,10 +1360,10 @@ class BoundingBoxesOnImage(IAugmentable):
     bounding_boxes : list of imgaug.augmentables.bbs.BoundingBox
         List of bounding boxes on the image.
 
-    shape : tuple of int or ndarray
-        The shape of the image on which the objects are placed.
-        Either an image with shape ``(H,W,[C])`` or a ``tuple`` denoting
-        such an image shape.
+    shape : tuple of int
+        The shape of the image on which the objects are placed, i.e. the
+        result of ``image.shape``.
+        Should include the number of channels, not only height and width.
 
     Examples
     --------
@@ -1380,7 +1380,7 @@ class BoundingBoxesOnImage(IAugmentable):
     """
     def __init__(self, bounding_boxes, shape):
         self.bounding_boxes = bounding_boxes
-        self.shape = normalize_shape(shape)
+        self.shape = _handle_on_image_shape(shape, self)
 
     @property
     def items(self):

--- a/imgaug/augmentables/bbs.py
+++ b/imgaug/augmentables/bbs.py
@@ -9,9 +9,13 @@ import skimage.measure
 
 from .. import imgaug as ia
 from .base import IAugmentable
-from .utils import (normalize_shape, project_coords,
-                    _remove_out_of_image_fraction_,
-                    _normalize_shift_args, _handle_on_image_shape)
+from .utils import (
+    normalize_imglike_shape,
+    project_coords,
+    _remove_out_of_image_fraction_,
+    _normalize_shift_args,
+    _handle_on_image_shape
+)
 
 
 # TODO functions: square(), to_aspect_ratio(), contains_point()
@@ -456,7 +460,7 @@ class BoundingBox(object):
             Can be ``0.0``.
 
         """
-        shape = normalize_shape(image)
+        shape = normalize_imglike_shape(image)
         height, width = shape[0:2]
         bb_image = BoundingBox(x1=0, y1=0, x2=width, y2=height)
         inter = self.intersection(bb_image, default=None)
@@ -492,7 +496,7 @@ class BoundingBox(object):
         """
         area = self.area
         if area == 0:
-            shape = normalize_shape(image)
+            shape = normalize_imglike_shape(image)
             height, width = shape[0:2]
             y1_outside = self.y1 < 0 or self.y1 >= height
             x1_outside = self.x1 < 0 or self.x1 >= width
@@ -518,7 +522,7 @@ class BoundingBox(object):
             ``False`` otherwise.
 
         """
-        shape = normalize_shape(image)
+        shape = normalize_imglike_shape(image)
         height, width = shape[0:2]
         return (
             self.x1 >= 0
@@ -545,7 +549,7 @@ class BoundingBox(object):
             ``False`` otherwise.
 
         """
-        shape = normalize_shape(image)
+        shape = normalize_imglike_shape(image)
         height, width = shape[0:2]
         eps = np.finfo(np.float32).eps
         img_bb = BoundingBox(x1=0, x2=width-eps, y1=0, y2=height-eps)
@@ -611,7 +615,7 @@ class BoundingBox(object):
             The object may have been modified in-place.
 
         """
-        shape = normalize_shape(image)
+        shape = normalize_imglike_shape(image)
 
         height, width = shape[0:2]
         assert height > 0, (
@@ -1470,7 +1474,7 @@ class BoundingBoxesOnImage(IAugmentable):
 
         """
         # pylint: disable=invalid-name
-        on_shape = normalize_shape(image)
+        on_shape = normalize_imglike_shape(image)
         if on_shape[0:2] == self.shape[0:2]:
             self.shape = on_shape  # channels may differ
             return self

--- a/imgaug/augmentables/heatmaps.py
+++ b/imgaug/augmentables/heatmaps.py
@@ -88,8 +88,6 @@ class HeatmapsOnImage(IAugmentable):
         else:
             self.arr_0to1 = (arr - min_value) / (max_value - min_value)
 
-        # don't allow arrays here as an alternative to tuples as input
-        # as allowing arrays introduces risk to mix up 'arr' and 'shape' args
         self.shape = shape
 
         self.min_value = min_value

--- a/imgaug/augmentables/kps.py
+++ b/imgaug/augmentables/kps.py
@@ -7,8 +7,12 @@ import six.moves as sm
 
 from .. import imgaug as ia
 from .base import IAugmentable
-from .utils import (normalize_shape, project_coords,
-                    _remove_out_of_image_fraction_)
+from .utils import (
+    normalize_shape,
+    project_coords,
+    _remove_out_of_image_fraction_,
+    _handle_on_image_shape
+)
 
 
 def compute_geometric_median(points=None, eps=1e-5, X=None):
@@ -612,10 +616,10 @@ class KeypointsOnImage(IAugmentable):
     keypoints : list of imgaug.augmentables.kps.Keypoint
         List of keypoints on the image.
 
-    shape : tuple of int or ndarray
-        The shape of the image on which the objects are placed.
-        Either an image with shape ``(H,W,[C])`` or a ``tuple`` denoting
-        such an image shape.
+    shape : tuple of int
+        The shape of the image on which the objects are placed, i.e. the
+        result of ``image.shape``.
+        Should include the number of channels, not only height and width.
 
     Examples
     --------
@@ -630,7 +634,7 @@ class KeypointsOnImage(IAugmentable):
 
     def __init__(self, keypoints, shape):
         self.keypoints = keypoints
-        self.shape = normalize_shape(shape)
+        self.shape = _handle_on_image_shape(shape, self)
 
     @property
     def items(self):

--- a/imgaug/augmentables/kps.py
+++ b/imgaug/augmentables/kps.py
@@ -8,7 +8,7 @@ import six.moves as sm
 from .. import imgaug as ia
 from .base import IAugmentable
 from .utils import (
-    normalize_shape,
+    normalize_imglike_shape,
     project_coords,
     _remove_out_of_image_fraction_,
     _handle_on_image_shape
@@ -236,7 +236,7 @@ class Keypoint(object):
             otherwise.
 
         """
-        shape = normalize_shape(image)
+        shape = normalize_imglike_shape(image)
         height, width = shape[0:2]
         y_inside = (0 <= self.y < height)
         x_inside = (0 <= self.x < width)
@@ -719,7 +719,7 @@ class KeypointsOnImage(IAugmentable):
 
         """
         # pylint: disable=invalid-name
-        on_shape = normalize_shape(image)
+        on_shape = normalize_imglike_shape(image)
         if on_shape[0:2] == self.shape[0:2]:
             self.shape = on_shape  # channels may differ
             return self

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -11,7 +11,7 @@ import cv2
 from .. import imgaug as ia
 from .base import IAugmentable
 from .utils import (
-    normalize_shape,
+    normalize_imglike_shape,
     project_coords_,
     interpolate_points,
     _remove_out_of_image_fraction_,
@@ -194,7 +194,7 @@ class LineString(object):
         # pylint: disable=misplaced-comparison-constant
         if len(self.coords) == 0:
             return np.zeros((0,), dtype=bool)
-        shape = normalize_shape(image)
+        shape = normalize_imglike_shape(image)
         height, width = shape[0:2]
         x_within = np.logical_and(0 <= self.xx, self.xx < width)
         y_within = np.logical_and(0 <= self.yy, self.yy < height)
@@ -542,7 +542,7 @@ class LineString(object):
         # to get rounded to height/width by shapely, which can cause problems
         # when first clipping and then calling is_fully_within_image()
         # returning false
-        height, width = normalize_shape(image)[0:2]
+        height, width = normalize_imglike_shape(image)[0:2]
         eps = 1e-3
         edges = [
             LineString([(0.0, 0.0), (width - eps, 0.0)]),
@@ -1760,7 +1760,7 @@ class LineStringsOnImage(IAugmentable):
 
         """
         # pylint: disable=invalid-name
-        on_shape = normalize_shape(image)
+        on_shape = normalize_imglike_shape(image)
         if on_shape[0:2] == self.shape[0:2]:
             self.shape = on_shape  # channels may differ
             return self

--- a/imgaug/augmentables/lines.py
+++ b/imgaug/augmentables/lines.py
@@ -10,11 +10,14 @@ import cv2
 
 from .. import imgaug as ia
 from .base import IAugmentable
-from .utils import (normalize_shape,
-                    project_coords_,
-                    interpolate_points,
-                    _remove_out_of_image_fraction_,
-                    _normalize_shift_args)
+from .utils import (
+    normalize_shape,
+    project_coords_,
+    interpolate_points,
+    _remove_out_of_image_fraction_,
+    _normalize_shift_args,
+    _handle_on_image_shape
+)
 
 
 # TODO Add Line class and make LineString a list of Line elements
@@ -1695,7 +1698,7 @@ class LineStringsOnImage(IAugmentable):
                 ", ".join([str(type(v)) for v in line_strings])
             ))
         self.line_strings = line_strings
-        self.shape = normalize_shape(shape)
+        self.shape = _handle_on_image_shape(shape, self)
 
     @property
     def items(self):

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -13,11 +13,14 @@ import skimage.measure
 from .. import imgaug as ia
 from .. import random as iarandom
 from .base import IAugmentable
-from .utils import (normalize_shape,
-                    interpolate_points,
-                    _remove_out_of_image_fraction_,
-                    project_coords_,
-                    _normalize_shift_args)
+from .utils import (
+    normalize_shape,
+    interpolate_points,
+    _remove_out_of_image_fraction_,
+    project_coords_,
+    _normalize_shift_args,
+    _handle_on_image_shape
+)
 
 
 def recover_psois_(psois, psois_orig, recoverer, random_state):
@@ -1433,10 +1436,10 @@ class PolygonsOnImage(IAugmentable):
     polygons : list of imgaug.augmentables.polys.Polygon
         List of polygons on the image.
 
-    shape : tuple of int or ndarray
-        The shape of the image on which the objects are placed.
-        Either an image with shape ``(H,W,[C])`` or a ``tuple`` denoting
-        such an image shape.
+    shape : tuple of int
+        The shape of the image on which the objects are placed, i.e. the
+        result of ``image.shape``.
+        Should include the number of channels, not only height and width.
 
     Examples
     --------
@@ -1453,7 +1456,7 @@ class PolygonsOnImage(IAugmentable):
 
     def __init__(self, polygons, shape):
         self.polygons = polygons
-        self.shape = normalize_shape(shape)
+        self.shape = _handle_on_image_shape(shape, self)
 
     @property
     def items(self):

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -14,7 +14,7 @@ from .. import imgaug as ia
 from .. import random as iarandom
 from .base import IAugmentable
 from .utils import (
-    normalize_shape,
+    normalize_imglike_shape,
     interpolate_points,
     _remove_out_of_image_fraction_,
     project_coords_,
@@ -1517,7 +1517,7 @@ class PolygonsOnImage(IAugmentable):
 
         """
         # pylint: disable=invalid-name
-        on_shape = normalize_shape(image)
+        on_shape = normalize_imglike_shape(image)
         if on_shape[0:2] == self.shape[0:2]:
             self.shape = on_shape  # channels may differ
             return self

--- a/imgaug/augmentables/segmaps.py
+++ b/imgaug/augmentables/segmaps.py
@@ -158,9 +158,6 @@ class SegmentationMapsOnImage(IAugmentable):
             arr = arr.astype(np.int32)
 
         self.arr = arr
-
-        # don't allow arrays here as an alternative to tuples as input
-        # as allowing arrays introduces risk to mix up 'arr' and 'shape' args
         self.shape = shape
 
         if nb_classes is not None:

--- a/imgaug/augmentables/utils.py
+++ b/imgaug/augmentables/utils.py
@@ -37,6 +37,7 @@ def deepcopy_fast(obj):
     return copylib.deepcopy(obj)
 
 
+# Added in 0.5.0.
 def _handle_on_image_shape(shape, obj):
     if hasattr(shape, "shape"):
         ia.warn_deprecated(
@@ -59,7 +60,6 @@ def _handle_on_image_shape(shape, obj):
     return shape
 
 
-# TODO integrate into keypoints
 def normalize_shape(shape):
     """Normalize a shape ``tuple`` or ``array`` to a shape ``tuple``.
 
@@ -79,6 +79,36 @@ def normalize_shape(shape):
     assert ia.is_np_array(shape), (
         "Expected tuple of ints or array, got %s." % (type(shape),))
     return shape.shape
+
+
+def normalize_imglike_shape(shape):
+    """Normalize a shape tuple or image-like ``array`` to a shape tuple.
+
+    Added in 0.5.0.
+
+    Parameters
+    ----------
+    shape : tuple of int or ndarray
+        The input to normalize. May optionally be an array. If it is an
+        array, it must be 2-dimensional (height, width) or 3-dimensional
+        (height, width, channels). Otherwise an error will be raised.
+
+    Returns
+    -------
+    tuple of int
+        Shape ``tuple``.
+
+    """
+    if isinstance(shape, tuple):
+        return shape
+    assert ia.is_np_array(shape), (
+        "Expected tuple of ints or array, got %s." % (type(shape),))
+    shape = shape.shape
+    assert len(shape) in [2, 3], (
+        "Expected image array to be 2-dimensional or 3-dimensional, got "
+        "%d-dimensional input of shape %s." % (len(shape), shape)
+    )
+    return shape
 
 
 def project_coords_(coords, from_shape, to_shape):

--- a/imgaug/augmentables/utils.py
+++ b/imgaug/augmentables/utils.py
@@ -37,6 +37,28 @@ def deepcopy_fast(obj):
     return copylib.deepcopy(obj)
 
 
+def _handle_on_image_shape(shape, obj):
+    if hasattr(shape, "shape"):
+        ia.warn_deprecated(
+            "Providing a numpy array for parameter `shape` in "
+            "`%s` is deprecated. Please provide a shape tuple, "
+            "i.e. a tuple of integers denoting (height, width, [channels]). "
+            "Use something similar to `image.shape` to convert an array "
+            "to a shape tuple." % (
+                obj.__class__.__name__,
+            )
+        )
+        shape = normalize_shape(shape)
+    else:
+        assert isinstance(shape, tuple), (
+            "Expected to get a tuple of integers or a numpy array "
+            "(deprecated) for parameter `shape` in `%s`. Got type %s." % (
+                obj.__class__.__name__, type(shape).__name__
+            )
+        )
+    return shape
+
+
 # TODO integrate into keypoints
 def normalize_shape(shape):
     """Normalize a shape ``tuple`` or ``array`` to a shape ``tuple``.

--- a/imgaug/testutils.py
+++ b/imgaug/testutils.py
@@ -350,7 +350,13 @@ def assertWarns(testcase, expected_warning, *args, **kwargs):
 
     Added in 0.4.0.
 
+    Example
+    -------
+    >>> def test_foo(self):
+    >>>     with assertWarns(self, UserWarning):
+    >>>         pass
+
     """
     # pylint: disable=invalid-name
     context = _AssertWarnsContext(expected_warning, testcase)
-    return context.handle('assertWarns', args, kwargs)
+    return context.handle("assertWarns", args, kwargs)

--- a/test/augmentables/test_bbs.py
+++ b/test/augmentables/test_bbs.py
@@ -18,7 +18,7 @@ import numpy as np
 import imgaug as ia
 import imgaug.random as iarandom
 from imgaug.augmentables.bbs import _LabelOnImageDrawer
-from imgaug.testutils import wrap_shift_deprecation
+from imgaug.testutils import wrap_shift_deprecation, assertWarns
 
 
 class TestBoundingBox_project_(unittest.TestCase):
@@ -1440,7 +1440,8 @@ class TestBoundingBoxesOnImage(unittest.TestCase):
         image = np.zeros((40, 50, 3), dtype=np.uint8)
         bb1 = ia.BoundingBox(y1=10, x1=20, y2=30, x2=40)
         bb2 = ia.BoundingBox(y1=15, x1=25, y2=35, x2=45)
-        bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=image)
+        with assertWarns(self, ia.DeprecationWarning):
+            bbsoi = ia.BoundingBoxesOnImage([bb1, bb2], shape=image)
         assert bbsoi.bounding_boxes == [bb1, bb2]
         assert bbsoi.shape == (40, 50, 3)
 

--- a/test/augmentables/test_kps.py
+++ b/test/augmentables/test_kps.py
@@ -14,6 +14,7 @@ except ImportError:
 
 import numpy as np
 import imgaug as ia
+from imgaug.testutils import assertWarns
 
 
 class TestKeypoint_project_(unittest.TestCase):
@@ -611,10 +612,11 @@ class TestKeypointsOnImage(unittest.TestCase):
     def test_shape_is_array(self):
         image = np.zeros((10, 20, 3), dtype=np.uint8)
         kps = [ia.Keypoint(x=1, y=2), ia.Keypoint(x=3, y=4)]
-        kpi = ia.KeypointsOnImage(
-            keypoints=kps,
-            shape=image
-        )
+        with assertWarns(self, ia.DeprecationWarning):
+            kpi = ia.KeypointsOnImage(
+                keypoints=kps,
+                shape=image
+            )
         assert kpi.shape == (10, 20, 3)
 
     def test_draw_on_image(self):

--- a/test/augmentables/test_lines.py
+++ b/test/augmentables/test_lines.py
@@ -15,7 +15,7 @@ except ImportError:
 import numpy as np
 
 import imgaug as ia
-from imgaug.testutils import reseed, wrap_shift_deprecation
+from imgaug.testutils import reseed, wrap_shift_deprecation, assertWarns
 from imgaug.augmentables.lines import LineString, LineStringsOnImage
 from imgaug.augmentables.kps import Keypoint
 from imgaug.augmentables.heatmaps import HeatmapsOnImage
@@ -2166,6 +2166,16 @@ class TestLineStringsOnImage(unittest.TestCase):
             LineString([]),
             LineString([(0, 0), (5, 0)])
         ], shape=(10, 10, 3))
+        assert len(lsoi.line_strings) == 2
+        assert lsoi.shape == (10, 10, 3)
+
+    def test___init___shape_is_array(self):
+        image = np.zeros((10, 10, 3), dtype=np.uint8)
+        with assertWarns(self, ia.DeprecationWarning):
+            lsoi = LineStringsOnImage([
+                LineString([]),
+                LineString([(0, 0), (5, 0)])
+            ], shape=image)
         assert len(lsoi.line_strings) == 2
         assert lsoi.shape == (10, 10, 3)
 

--- a/test/augmentables/test_polys.py
+++ b/test/augmentables/test_polys.py
@@ -20,7 +20,7 @@ import shapely.geometry
 
 import imgaug as ia
 import imgaug.random as iarandom
-from imgaug.testutils import reseed, wrap_shift_deprecation
+from imgaug.testutils import reseed, wrap_shift_deprecation, assertWarns
 from imgaug.augmentables.polys import _ConcavePolygonRecoverer
 
 
@@ -2326,10 +2326,11 @@ class TestPolygonsOnImage___init__(unittest.TestCase):
 
     def test_with_zero_polygons_and_shape_given_as_array(self):
         # shape given as numpy array
-        poly_oi = ia.PolygonsOnImage(
-            [],
-            shape=np.zeros((10, 10, 3), dtype=np.uint8)
-        )
+        with assertWarns(self, ia.DeprecationWarning):
+            poly_oi = ia.PolygonsOnImage(
+                [],
+                shape=np.zeros((10, 10, 3), dtype=np.uint8)
+            )
         assert poly_oi.shape == (10, 10, 3)
 
     def test_with_zero_polygons_and_shape_given_as_2d_tuple(self):

--- a/test/augmentables/test_utils.py
+++ b/test/augmentables/test_utils.py
@@ -15,8 +15,11 @@ except ImportError:
 import numpy as np
 
 from imgaug.augmentables.utils import (
-    interpolate_points, interpolate_point_pair,
-    interpolate_points_by_max_distance
+    interpolate_points,
+    interpolate_point_pair,
+    interpolate_points_by_max_distance,
+    normalize_shape,
+    normalize_imglike_shape
 )
 
 
@@ -301,3 +304,58 @@ class Test_interpolate_points_by_max_distance(unittest.TestCase):
                 [0, 0]
             ])
         )
+
+
+class Test_normalize_shape(unittest.TestCase):
+    def test_shape_tuple(self):
+        shape_out = normalize_shape((1, 2))
+        assert shape_out == (1, 2)
+
+    def test_shape_tuple_3d(self):
+        shape_out = normalize_shape((1, 2, 3))
+        assert shape_out == (1, 2, 3)
+
+    def test_array_1d(self):
+        arr = np.zeros((5,), dtype=np.uint8)
+        shape_out = normalize_shape(arr)
+        assert shape_out == (5,)
+
+    def test_array_2d(self):
+        arr = np.zeros((1, 2), dtype=np.uint8)
+        shape_out = normalize_shape(arr)
+        assert shape_out == (1, 2)
+
+    def test_array_3d(self):
+        arr = np.zeros((1, 2, 3), dtype=np.uint8)
+        shape_out = normalize_shape(arr)
+        assert shape_out == (1, 2, 3)
+
+
+class Test_normalize_imglike_shape(unittest.TestCase):
+    def test_shape_tuple(self):
+        shape_out = normalize_imglike_shape((1, 2))
+        assert shape_out == (1, 2)
+
+    def test_shape_tuple_3d(self):
+        shape_out = normalize_imglike_shape((1, 2, 3))
+        assert shape_out == (1, 2, 3)
+
+    def test_array_1d_fails(self):
+        arr = np.zeros((5,), dtype=np.uint8)
+        with self.assertRaises(AssertionError):
+            _ = normalize_imglike_shape(arr)
+
+    def test_array_2d(self):
+        arr = np.zeros((1, 2), dtype=np.uint8)
+        shape_out = normalize_imglike_shape(arr)
+        assert shape_out == (1, 2)
+
+    def test_array_3d(self):
+        arr = np.zeros((1, 2, 3), dtype=np.uint8)
+        shape_out = normalize_imglike_shape(arr)
+        assert shape_out == (1, 2, 3)
+
+    def test_array_4d_fails(self):
+        arr = np.zeros((1, 2, 3, 4), dtype=np.uint8)
+        with self.assertRaises(AssertionError):
+            _ = normalize_imglike_shape(arr)


### PR DESCRIPTION
Various methods of augmentables have so far accepted tuples
of integers or numpy arrays for `shape` parameters. This was
the case for e.g. `BoundingBoxesOnImage.__init__(bbs, shape)`
or `Polygon.clip_out_of_image(image)`. This tolerant handling
of shapes conveys some risk that an input is actually a
numpy representation of a shape, i.e. the equivalent of
`numpy.array(shape_tuple)`.

To decrease the risk of such an input leading to bugs, arrays
are no longer recommended inputs for `shape` in
`KeypointsOnImage.__init__`, `BoundingBoxesOnImage.__init__`,
`LineStringsOnImage.__init__`, and `PolygonsOnImage.__init__`.
Their usage in these methods will now raise a deprecation warning.

In all other methods of augmentables that currently accept
image-like numpy arrays and shape tuples for parameters,
only arrays that are 2-dimensional or 3-dimensional are from
now on accepted. Other arrays (e.g. 1-dimensional ones)
will be rejected with an assertion error.

Add functions:
* `imgaug.augmentables.utils.normalize_imglike_shape()`.

List of deprecations:
* `numpy.ndarray` as value of parameter `shape` in
  `KeypointsOnImage.__init__`.
* `numpy.ndarray` as value of parameter `shape` in
  `BoundingBoxesOnImage.__init__`.
* `numpy.ndarray` as value of parameter `shape` in
  `LineStringsOnImage.__init__`.
* `numpy.ndarray` as value of parameter `shape` in
  `PolygonsOnImage.__init__`.

This resolves #616.