### PR TITLE
Improve Performance of ElasticTransformation

### DIFF
--- a/changelogs/master/improved/20200223_faster_elastic_tf.md
+++ b/changelogs/master/improved/20200223_faster_elastic_tf.md
@@ -1,0 +1,19 @@
+# Improved Performance of `ElasticTransformation` #624
+
+This patch applies various performance-related changes to
+`ElasticTransformation`. These cover: (a) the re-use of
+generated random samples for multiple images in the same
+batch (with some adjustments so that they are not identical),
+(b) the caching of generated and re-useable arrays,
+(c) a performance-optimized smoothing method for the
+underlying displacement maps and (d) the use of nearest
+neighbour interpolation (`order=0`) instead of cubic
+interpolation (`order=3`) as the new default parameter
+for `order`.
+
+These changes lead to a speedup of about 3x to 4x (more
+for larger images) at a slight loss of visual
+quality (mainly from `order=0`) and variety (due to the
+re-use of random samples within each batch).
+The new smoothing method leads to slightly stronger
+displacements for larger `sigma` values.

--- a/checks/check_elastic_transformation.py
+++ b/checks/check_elastic_transformation.py
@@ -25,6 +25,13 @@ def main():
     augs_cv2 = aug_cv2.augment_images([image] * 8)
     ia.imshow(ia.draw_grid(augs_scipy + augs_cv2, rows=2))
 
+    # check behaviour for multiple consecutive batches
+    aug = iaa.ElasticTransformation(alpha=(5, 100), sigma=(3, 5))
+    images1 = aug(images=[np.copy(image) for _ in range(10)])
+    images2 = aug(images=[np.copy(image) for _ in range(10)])
+    images3 = aug(images=[np.copy(image) for _ in range(10)])
+    ia.imshow(ia.draw_grid(images1 + images2 + images3, rows=3))
+
     print("alpha=vary, sigma=0.25")
     augs = [iaa.ElasticTransformation(alpha=alpha, sigma=0.25) for alpha in np.arange(0.0, 50.0, 0.1)]
     images_aug = [aug.augment_image(image) for aug in augs]

--- a/checks/check_segmentation_maps.py
+++ b/checks/check_segmentation_maps.py
@@ -106,6 +106,21 @@ def main():
         ])
     )
 
+    print("ElasticTransformation alpha=200, sig=20...")
+    aug = iaa.ElasticTransformation(alpha=200.0, sigma=20.0)
+    aug_det = aug.to_deterministic()
+    quokka_aug = aug_det.augment_image(quokka)
+    segmaps_aug = aug_det.augment_segmentation_maps(segmap)
+    segmaps_drawn = segmap.draw_on_image(quokka)[0]
+    segmaps_aug_drawn = segmaps_aug.draw_on_image(quokka_aug)[0]
+
+    ia.imshow(
+        np.hstack([
+            segmaps_drawn,
+            segmaps_aug_drawn
+        ])
+    )
+
     print("CopAndPad mode=constant...")
     aug = iaa.CropAndPad(px=(-10, 10, 15, -15), pad_mode="constant", pad_cval=128)
     aug_det = aug.to_deterministic()

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -4812,6 +4812,7 @@ class ElasticTransformation(meta.Augmenter):
                 cval = float(cval)
             else:
                 cval = int(cval)
+
             border_mode = self._MAPPING_MODE_SCIPY_CV2[mode]
             interpolation = self._MAPPING_ORDER_SCIPY_CV2[order]
 
@@ -4937,7 +4938,7 @@ class _ElasticTfShiftMapGenerator(object):
                     dx_i, dy_i = self._flip(dx_i, dy_i,
                                             (dx_lr, dx_ud, dy_lr, dy_ud))
                     dx_i, dy_i = self._mul_alpha(dx_i, dy_i, alphas_c[i])
-                    yield self._smoothen(dx_i, dy_i, sigmas_c[i])
+                    yield self._smoothen_(dx_i, dy_i, sigmas_c[i])
 
     # Added in 0.5.0.
     @classmethod
@@ -4963,7 +4964,7 @@ class _ElasticTfShiftMapGenerator(object):
 
     # Added in 0.5.0.
     @classmethod
-    def _smoothen(cls, dx, dy, sigma):
+    def _smoothen_(cls, dx, dy, sigma):
         if sigma < 1.5:
             dx = blur_lib.blur_gaussian_(dx, sigma)
             dy = blur_lib.blur_gaussian_(dy, sigma)

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -7547,7 +7547,7 @@ class TestElasticTransformation(unittest.TestCase):
                 assert hm_aug.shape == (80, 80)
                 assert hm_aug.arr_0to1.shape == (40, 40, 1)
                 # TODO this is a fairly low threshold, why is that the case?
-                assert (same / img_aug_mask.size) >= 0.92
+                assert (same / img_aug_mask.size) >= 0.9
 
     # -----------
     # segmaps alignment
@@ -7597,7 +7597,7 @@ class TestElasticTransformation(unittest.TestCase):
         same = np.sum(img_aug_mask == segmaps_aug_mask[:, :, 0])
         assert segmaps_aug.shape == (80, 80)
         assert segmaps_aug.arr.shape == (40, 40, 1)
-        assert (same / img_aug_mask.size) >= 0.94
+        assert (same / img_aug_mask.size) >= 0.93
 
     # ---------
     # unusual channel numbers

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -6850,7 +6850,7 @@ class TestElasticTransformation(unittest.TestCase):
 
     def test_images_nonsquare(self):
         # test basic funtionality with non-square images
-        aug = iaa.ElasticTransformation(alpha=0.5, sigma=0.25)
+        aug = iaa.ElasticTransformation(alpha=2.0, sigma=0.25, order=3)
         img_nonsquare = np.zeros((50, 100), dtype=np.uint8) + 255
         img_nonsquare = np.pad(img_nonsquare, ((100, 100), (100, 100)),
                                mode="constant", constant_values=0)

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -6836,7 +6836,7 @@ class TestElasticTransformation(unittest.TestCase):
     # -----------
     def test_images(self):
         # test basic funtionality
-        aug = iaa.ElasticTransformation(alpha=0.5, sigma=0.25)
+        aug = iaa.ElasticTransformation(alpha=5, sigma=0.25)
 
         observed = aug.augment_image(self.image)
 
@@ -7010,26 +7010,29 @@ class TestElasticTransformation(unittest.TestCase):
 
     def test_sigma_is_stochastic_parameter(self):
         # test sigma being iap.Choice
-        aug = iaa.ElasticTransformation(alpha=3.0,
-                                        sigma=iap.Choice([0.01, 5.0]))
-        seen = [0, 0]
-        for _ in sm.xrange(100):
-            observed = aug.augment_image(self.image)
+        for order in [0, 1, 3]:
+            with self.subTest(order=order):
+                aug = iaa.ElasticTransformation(alpha=50.0,
+                                                sigma=iap.Choice([0.001, 5.0]),
+                                                order=order)
+                seen = [0, 0]
+                for _ in sm.xrange(100):
+                    observed = aug.augment_image(self.image)
 
-            observed_std_hori = np.std(
-                observed.astype(np.float32)[:, 1:]
-                - observed.astype(np.float32)[:, :-1])
-            observed_std_vert = np.std(
-                observed.astype(np.float32)[1:, :]
-                - observed.astype(np.float32)[:-1, :])
-            observed_std = (observed_std_hori + observed_std_vert) / 2
+                    observed_std_hori = np.std(
+                        observed.astype(np.float32)[:, 1:]
+                        - observed.astype(np.float32)[:, :-1])
+                    observed_std_vert = np.std(
+                        observed.astype(np.float32)[1:, :]
+                        - observed.astype(np.float32)[:-1, :])
+                    observed_std = (observed_std_hori + observed_std_vert) / 2
 
-            if observed_std > 10.0:
-                seen[0] += 1
-            else:
-                seen[1] += 1
-        assert seen[0] > 10
-        assert seen[1] > 10
+                    if observed_std > 25.0:
+                        seen[0] += 1
+                    else:
+                        seen[1] += 1
+                assert seen[0] > 10
+                assert seen[1] > 10
 
     # -----------
     # cval
@@ -7491,50 +7494,60 @@ class TestElasticTransformation(unittest.TestCase):
     # -----------
     def test_image_heatmaps_alignment(self):
         # test alignment between images and heatmaps
-        img = np.zeros((80, 80), dtype=np.uint8)
-        img[:, 30:50] = 255
-        img[30:50, :] = 255
-        hm = HeatmapsOnImage(img.astype(np.float32)/255.0, shape=(80, 80))
-        aug = iaa.ElasticTransformation(alpha=60.0, sigma=4.0, mode="constant",
-                                        cval=0)
-        aug_det = aug.to_deterministic()
+        for order in [0, 1, 3]:
+            with self.subTest(order=order):
+                img = np.zeros((80, 80), dtype=np.uint8)
+                img[:, 30:50] = 255
+                img[30:50, :] = 255
+                hm = HeatmapsOnImage(img.astype(np.float32)/255.0, shape=(80, 80))
+                aug = iaa.ElasticTransformation(
+                    alpha=60.0,
+                    sigma=4.0,
+                    mode="constant",
+                    cval=0,
+                    order=order
+                )
+                aug_det = aug.to_deterministic()
 
-        img_aug = aug_det.augment_image(img)
-        hm_aug = aug_det.augment_heatmaps([hm])[0]
+                img_aug = aug_det.augment_image(img)
+                hm_aug = aug_det.augment_heatmaps([hm])[0]
 
-        img_aug_mask = img_aug > 255*0.1
-        hm_aug_mask = hm_aug.arr_0to1 > 0.1
-        same = np.sum(img_aug_mask == hm_aug_mask[:, :, 0])
-        assert hm_aug.shape == (80, 80)
-        assert hm_aug.arr_0to1.shape == (80, 80, 1)
-        assert (same / img_aug_mask.size) >= 0.99
+                img_aug_mask = img_aug > 255*0.1
+                hm_aug_mask = hm_aug.arr_0to1 > 0.1
+                same = np.sum(img_aug_mask == hm_aug_mask[:, :, 0])
+                assert hm_aug.shape == (80, 80)
+                assert hm_aug.arr_0to1.shape == (80, 80, 1)
+                assert (same / img_aug_mask.size) >= 0.97
 
     def test_image_heatmaps_alignment_if_heatmaps_smaller_than_image(self):
         # test alignment between images and heatmaps
         # here with heatmaps that are smaller than the image
-        img = np.zeros((80, 80), dtype=np.uint8)
-        img[:, 30:50] = 255
-        img[30:50, :] = 255
-        img_small = ia.imresize_single_image(
-            img, (40, 40), interpolation="nearest")
-        hm = HeatmapsOnImage(
-            img_small.astype(np.float32)/255.0,
-            shape=(80, 80))
-        aug = iaa.ElasticTransformation(
-            alpha=60.0, sigma=4.0, mode="constant", cval=0)
-        aug_det = aug.to_deterministic()
+        for order in [0, 1, 3]:
+            with self.subTest(order=order):
+                img = np.zeros((80, 80), dtype=np.uint8)
+                img[:, 30:50] = 255
+                img[30:50, :] = 255
+                img_small = ia.imresize_single_image(
+                    img, (40, 40), interpolation="nearest")
+                hm = HeatmapsOnImage(
+                    img_small.astype(np.float32)/255.0,
+                    shape=(80, 80))
+                aug = iaa.ElasticTransformation(
+                    alpha=60.0, sigma=4.0, mode="constant", cval=0)
+                aug_det = aug.to_deterministic()
 
-        img_aug = aug_det.augment_image(img)
-        hm_aug = aug_det.augment_heatmaps([hm])[0]
+                img_aug = aug_det.augment_image(img)
+                hm_aug = aug_det.augment_heatmaps([hm])[0]
 
-        img_aug_mask = img_aug > 255*0.1
-        hm_aug_mask = ia.imresize_single_image(
-            hm_aug.arr_0to1, (80, 80), interpolation="nearest"
-        ) > 0.1
-        same = np.sum(img_aug_mask == hm_aug_mask[:, :, 0])
-        assert hm_aug.shape == (80, 80)
-        assert hm_aug.arr_0to1.shape == (40, 40, 1)
-        assert (same / img_aug_mask.size) >= 0.94
+                img_aug_mask = img_aug > 255*0.1
+                hm_aug_mask = ia.imresize_single_image(
+                    hm_aug.arr_0to1, (80, 80), interpolation="nearest"
+                ) > 0.1
+                same = np.sum(img_aug_mask == hm_aug_mask[:, :, 0])
+                assert hm_aug.shape == (80, 80)
+                assert hm_aug.arr_0to1.shape == (40, 40, 1)
+                # TODO this is a fairly low threshold, why is that the case?
+                assert (same / img_aug_mask.size) >= 0.92
 
     # -----------
     # segmaps alignment

--- a/test/augmenters/test_meta.py
+++ b/test/augmenters/test_meta.py
@@ -2966,7 +2966,7 @@ class TestAugmenter_augment_batches(unittest.TestCase):
                 mode=ia.ALL,
                 cval=(0, 255)),
             iaa.PiecewiseAffine(scale=(0.1, 0.3)),
-            iaa.ElasticTransformation(alpha=0.5)
+            iaa.ElasticTransformation(alpha=2.0)
         ]
 
         nb_iterations = 100

--- a/test/augmenters/test_mixed_files.py
+++ b/test/augmenters/test_mixed_files.py
@@ -73,7 +73,7 @@ def test_determinism():
                    rotate=(-20, 20), shear=(-20, 20), order=ia.ALL,
                    mode=ia.ALL, cval=(0, 255)),
         iaa.PiecewiseAffine(scale=(0.1, 0.3)),
-        iaa.ElasticTransformation(alpha=0.5)
+        iaa.ElasticTransformation(alpha=10.0)
     ]
 
     augs_affect_geometry = [


### PR DESCRIPTION
This patch applies various performance-related changes to
`ElasticTransformation`. These cover: (a) the re-use of
generated random samples for multiple images in the same
batch (with some adjustments so that they are not identical),
(b) the caching of generated and re-useable arrays,
(c) a performance-optimized smoothing method for the
underlying displacement maps and (d) the use of nearest
neighbour interpolation (`order=0`) instead of cubic
interpolation (`order=3`) as the new default parameter
for `order`.

These changes lead to a speedup of about 3x to 4x (more
for larger images) at a slight loss of visual
quality (mainly from `order=0`) and variety (due to the
re-use of random samples within each batch).
The new smoothing method leads to slightly stronger
displacements for larger `sigma` values.