### PR TITLE
Fix imageio dependency broken in python <3.5

### DIFF
--- a/changelogs/master/fixed/20200225_fix_imageio.md
+++ b/changelogs/master/fixed/20200225_fix_imageio.md
@@ -1,0 +1,4 @@
+* Fixed a broken `imageio` dependency. The package no longer
+  supports python 3.4 and earlier and will fail to install in the
+  latest version. The dependency is now set to be more
+  restrictive for older python versions. #627 #628

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ Pillow
 matplotlib
 scikit-image>=0.14.2
 opencv-python-headless
-imageio
+# imageio versions past 2.6.1 do not support <3.5 anymore
+imageio<=2.6.1; python_version<'3.5'
+imageio; python_version>='3.5'
 Shapely

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ INSTALL_REQUIRES = [
     "matplotlib",
     "scikit-image>=0.14.2",
     "opencv-python-headless",
-    "imageio",
-    "Shapely",
+    "imageio<=2.6.1; python_version<'3.5'",
+    "imageio; python_version>='3.5'",
+    "Shapely"
 ]
 
 ALT_INSTALL_REQUIRES = {


### PR DESCRIPTION
This patch fixes a broken dependency in python 2.7. imageio in
the latest version no longer supports python <3.5.
The version is hence restricted to <=2.6.1 for python <3.5.

fixes #627 