### PR TITLE
Improve Convolution Filters

### DIFF
--- a/changelogs/master/improved/20200229_convolve.md
+++ b/changelogs/master/improved/20200229_convolve.md
@@ -1,0 +1,18 @@
+# Improved Convolution Filters #632
+
+This patch reworks the backend of all convolutional
+filters. It extracts the convolution logic out of
+`Convolve` and moves it into the new function
+`imgaug.augmenters.convolutional.convolve_()` (with
+non-in-place version `convolve()`).
+
+The logic is also reworked so that fewer convolution
+function calls and more in-place modification is
+used. This should lead to an improved performance.
+
+These changes also affect `Sharpen`, `Emboss`,
+`EdgeDetect`, `DirectedEdgeDetect` and `MotionBlur`.
+
+Add functions:
+* `imgaug.augmenters.convolutional.convolve_()`
+* `imgaug.augmenters.convolutional.convolve()`


### PR DESCRIPTION
This patch reworks the backend of all convolutional
filters. It extracts the convolution logic out of
`Convolve` and moves it into the new function
`imgaug.augmenters.convolutional.convolve_()` (with
non-in-place version `convolve()`).

The logic is also reworked so that fewer convolution
function calls and more in-place modification is
used. This should lead to an improved performance.

These changes also affect `Sharpen`, `Emboss`,
`EdgeDetect`, `DirectedEdgeDetect` and `MotionBlur`.

Add functions:
* `imgaug.augmenters.convolutional.convolve_()`
* `imgaug.augmenters.convolutional.convolve()`