### PR TITLE
Add Automatic Prefetching of Random Number Samples

### DIFF
--- a/changelogs/master/improved/20200308_prefetching.md
+++ b/changelogs/master/improved/20200308_prefetching.md
@@ -1,0 +1,50 @@
+# Added Automatic Prefetching of Random Number Samples #???
+
+This patch adds automatic prefetching of random samples,
+which performs a single large random sampling call instead
+of many smaller ones. This seems to improve the
+performance of most augmenters by 5% to 40% for longer
+augmentation sessions (50+ consecutive batches of 128
+examples each). A few augmenters seem to have gotten
+slightly slower, though these might be measuring errors.
+
+The prefetching is done by adding a new parameter,
+`imgaug.parameters.AutoPrefetcher`, which prefetches
+samples from a child parameter.
+
+The change is expected to have for most augmenters a
+slight negative performance impact if the augmenters
+are used only once and not for multiple batches. For a
+few augmenters there might be sizeable negative
+peformance impact (due to prefetching falsely being
+performed). The negative impact can be avoided in
+these cases by wrapping the augmentation calls in
+`with imgaug.parameters.no_prefetching(): ...`.
+
+This patch also adds the property `prefetchable` to
+`StochasticParameter`, which defaults to `False` and
+determines whether the parameter's outputs may be
+prefetched.
+
+It further adds to
+`handle_continuous_param()`, `handle_discrete_param()`.
+`handle_categorical_string_param()`,
+`handle_discrete_kernel_size_param()` and
+`handle_probability_param()` in `imgaug.parameters` the
+new argument `prefetch`. If set to `True` (the default),
+these functions may now partially or fully wrap their
+results in `AutoPrefetcher`.
+
+Add functions:
+* `imgaug.random.RNG.create_if_not_rng_()`
+* `imgaug.parameters.toggle_prefetching()`
+* `imgaug.testutils.is_parameter_instance()`
+* `imgaug.testutils.remove_prefetching()`
+
+Add properties:
+* `imgaug.parameters.StochasticParameter.prefetchable`
+
+Add classes:
+* `imgaug.parameters.toggled_prefetching()` (context)
+* `imgaug.parameters.no_prefetching()` (context)
+* `imgaug.parameters.AutoPrefetcher`

--- a/changelogs/master/improved/20200308_prefetching.md
+++ b/changelogs/master/improved/20200308_prefetching.md
@@ -1,4 +1,4 @@
-# Added Automatic Prefetching of Random Number Samples #???
+# Added Automatic Prefetching of Random Number Samples #634
 
 This patch adds automatic prefetching of random samples,
 which performs a single large random sampling call instead

--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -2248,7 +2248,7 @@ class _ConcavePolygonRecoverer(object):
         if polygon.is_valid:
             return polygon
 
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         rss = random_state.duplicate(3)
 
         # remove consecutive duplicate points

--- a/imgaug/augmenters/arithmetic.py
+++ b/imgaug/augmenters/arithmetic.py
@@ -1876,7 +1876,7 @@ class Add(meta.Augmenter):
 
         self.value = iap.handle_continuous_param(
             value, "value", value_range=None, tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True, prefetch=True)
         self.per_channel = iap.handle_probability_param(
             per_channel, "per_channel")
 

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -2593,7 +2593,7 @@ class StochasticParameterMaskGen(IBatchwiseMaskGenerator):
 
         """
         shapes = batch.get_rowwise_shapes()
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         per_channel = self.per_channel.draw_samples((len(shapes),),
                                                     random_state=random_state)
 
@@ -2763,7 +2763,7 @@ class SomeColorsMaskGen(IBatchwiseMaskGenerator):
         assert batch.images is not None, (
             "Can only generate masks for batches that contain images, but "
             "got a batch without images.")
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         samples = self._draw_samples(batch, random_state=random_state)
 
         return [self._draw_mask(image, i, samples)
@@ -2947,7 +2947,7 @@ class _LinearGradientMaskGen(IBatchwiseMaskGenerator):
         Added in 0.4.0.
 
         """
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         shapes = batch.get_rowwise_shapes()
         samples = self._draw_samples(len(shapes), random_state=random_state)
 
@@ -3327,7 +3327,7 @@ class RegularGridMaskGen(IBatchwiseMaskGenerator):
         Added in 0.4.0.
 
         """
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         shapes = batch.get_rowwise_shapes()
         nb_rows, nb_cols, alpha = self._draw_samples(len(shapes),
                                                      random_state=random_state)
@@ -3489,7 +3489,7 @@ class CheckerboardMaskGen(IBatchwiseMaskGenerator):
 
         """
         # pylint: disable=protected-access
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         shapes = batch.get_rowwise_shapes()
         nb_rows, nb_cols, _alpha = self.grid._draw_samples(
             len(shapes), random_state=random_state)
@@ -3639,7 +3639,7 @@ class SegMapClassIdsMaskGen(IBatchwiseMaskGenerator):
         assert batch.segmentation_maps is not None, (
             "Can only generate masks for batches that contain segmentation "
             "maps, but got a batch without them.")
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         class_ids = self._draw_samples(batch.nb_rows,
                                        random_state=random_state)
 
@@ -3803,7 +3803,7 @@ class BoundingBoxesMaskGen(IBatchwiseMaskGenerator):
         assert batch.bounding_boxes is not None, (
             "Can only generate masks for batches that contain bounding boxes, "
             "but got a batch without them.")
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
 
         if self.labels is None:
             return [self.generate_mask(bbsoi, None)
@@ -3908,7 +3908,7 @@ class InvertMaskGen(IBatchwiseMaskGenerator):
         Added in 0.4.0.
 
         """
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         masks = self.child.draw_masks(batch, random_state=random_state)
         p = self.p.draw_samples(len(masks), random_state=random_state)
         for mask, p_i in zip(masks, p):

--- a/imgaug/augmenters/blur.py
+++ b/imgaug/augmenters/blur.py
@@ -758,6 +758,10 @@ class AverageBlur(meta.Augmenter):
                 "Expected int, tuple/list with 2 entries or "
                 "StochasticParameter. Got %s." % (type(k),))
 
+        self.k = iap._wrap_leafs_of_param_in_prefetchers(
+            self.k, iap._NB_PREFETCH
+        )
+
     # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is None:
@@ -878,6 +882,9 @@ class MedianBlur(meta.Augmenter):
             assert all([ki % 2 != 0 for ki in k]), (
                 "Expected all values in iterable k to be odd, but at least "
                 "one was not. Add or subtract 1 to/from that value.")
+        self.k = iap._wrap_leafs_of_param_in_prefetchers(
+            self.k, iap._NB_PREFETCH
+        )
 
     # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):

--- a/imgaug/augmenters/collections.py
+++ b/imgaug/augmenters/collections.py
@@ -190,7 +190,7 @@ class RandAugment(meta.Sequential):
                  random_state="deprecated", deterministic="deprecated"):
         # pylint: disable=invalid-name
         seed = seed if random_state == "deprecated" else random_state
-        rng = iarandom.RNG(seed)
+        rng = iarandom.RNG.create_if_not_rng_(seed)
 
         # we don't limit the value range to 10 here, because the paper
         # gives several examples of using more than 10 for M

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -1921,7 +1921,7 @@ class MultiplyHueAndSaturation(WithHueAndSaturation):
         if seed is None:
             rss = [None] * 5
         else:
-            rss = iarandom.RNG(seed).derive_rngs_(5)
+            rss = iarandom.RNG.create_if_not_rng_(seed).derive_rngs_(5)
 
         children = []
         if mul is not None:
@@ -2890,6 +2890,9 @@ class ChangeColorspace(meta.Augmenter):
             raise Exception("Expected to_colorspace to be string, list of "
                             "strings or StochasticParameter, got %s." % (
                                 type(to_colorspace),))
+        self.to_colorspace = iap._wrap_leafs_of_param_in_prefetchers(
+            self.to_colorspace, iap._NB_PREFETCH_STRINGS
+        )
 
         assert ia.is_string(from_colorspace), (
             "Expected from_colorspace to be a single string, "

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -82,6 +82,7 @@ _PI = 3.141592653589793
 _RAD_PER_DEGREE = _PI / 180
 
 
+@iap._prefetchable
 def _handle_order_arg(order, backend):
     # Peformance in skimage for Affine:
     #  1.0x order 0
@@ -126,6 +127,7 @@ def _handle_order_arg(order, backend):
         "StochasticParameter, got %s." % (type(order),))
 
 
+@iap._prefetchable
 def _handle_cval_arg(cval):
     if cval == ia.ALL:
         # TODO change this so that it is dynamically created per image
@@ -142,6 +144,7 @@ def _handle_cval_arg(cval):
 
 # currently used for Affine and PiecewiseAffine
 # TODO use iap.handle_categorical_string_param() here
+@iap._prefetchable_str
 def _handle_mode_arg(mode):
     if mode == ia.ALL:
         return iap.Choice(["constant", "edge", "symmetric", "reflect", "wrap"])
@@ -570,7 +573,7 @@ def generate_jigsaw_destinations(nb_rows, nb_cols, max_steps, seed,
     """
     assert connectivity in (4, 8), (
         "Expected connectivity of 4 or 8, got %d." % (connectivity,))
-    random_state = iarandom.RNG(seed)
+    random_state = iarandom.RNG.create_if_not_rng_(seed)
     steps = random_state.integers(0, max_steps, size=(nb_rows, nb_cols),
                                   endpoint=True)
     directions = random_state.integers(0, connectivity,
@@ -3685,6 +3688,7 @@ class PerspectiveTransform(meta.Augmenter):
     # TODO unify this somehow with the global _handle_mode_arg() that is
     #      currently used for Affine and PiecewiseAffine
     @classmethod
+    @iap._prefetchable_str
     def _handle_mode_arg(cls, mode):
         available_modes = [cv2.BORDER_REPLICATE, cv2.BORDER_CONSTANT]
         available_modes_str = ["replicate", "constant"]
@@ -4362,6 +4366,7 @@ class ElasticTransformation(meta.Augmenter):
         self._last_meshgrid = None
 
     @classmethod
+    @iap._prefetchable
     def _handle_order_arg(cls, order):
         if order == ia.ALL:
             return iap.Choice([0, 1, 2, 3, 4, 5])
@@ -4370,6 +4375,7 @@ class ElasticTransformation(meta.Augmenter):
             list_to_choice=True, allow_floats=False)
 
     @classmethod
+    @iap._prefetchable_str
     def _handle_mode_arg(cls, mode):
         if mode == ia.ALL:
             return iap.Choice(["constant", "nearest", "reflect", "wrap"])

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -1318,7 +1318,7 @@ class RegularGridPointsSampler(IPointsSampler):
             tuple_to_uniform=True, list_to_choice=True, allow_floats=False)
 
     def sample_points(self, images, random_state):
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         _verify_sample_points_images(images)
 
         n_rows_lst, n_cols_lst = self._draw_samples(images, random_state)
@@ -1452,7 +1452,7 @@ class RelativeRegularGridPointsSampler(IPointsSampler):
 
     def sample_points(self, images, random_state):
         # pylint: disable=protected-access
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         _verify_sample_points_images(images)
 
         n_rows, n_cols = self._draw_samples(images, random_state)
@@ -1563,7 +1563,7 @@ class DropoutPointsSampler(IPointsSampler):
         return p_drop
 
     def sample_points(self, images, random_state):
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         _verify_sample_points_images(images)
 
         rss = random_state.duplicate(2)
@@ -1650,7 +1650,7 @@ class UniformPointsSampler(IPointsSampler):
             tuple_to_uniform=True, list_to_choice=True, allow_floats=False)
 
     def sample_points(self, images, random_state):
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         _verify_sample_points_images(images)
 
         rss = random_state.duplicate(2)
@@ -1741,7 +1741,7 @@ class SubsamplingPointsSampler(IPointsSampler):
                     "returned.")
 
     def sample_points(self, images, random_state):
-        random_state = iarandom.RNG(random_state)
+        random_state = iarandom.RNG.create_if_not_rng_(random_state)
         _verify_sample_points_images(images)
 
         rss = random_state.duplicate(len(images) + 1)

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -263,6 +263,7 @@ def _int_r(value):
 
 
 # TODO somehow integrate this with pad()
+@iap._prefetchable_str
 def _handle_pad_mode_param(pad_mode):
     pad_modes_available = {
         "constant", "edge", "linear_ramp", "maximum", "mean", "median",
@@ -286,6 +287,7 @@ def _handle_pad_mode_param(pad_mode):
         "StochasticParameter, got %s." % (type(pad_mode),))
 
 
+@iap._prefetchable
 def _handle_position_parameter(position):
     if position == "uniform":
         return iap.Uniform(0.0, 1.0), iap.Uniform(0.0, 1.0)
@@ -1279,6 +1281,7 @@ class Resize(meta.Augmenter):
         self.interpolation = self._handle_interpolation_arg(interpolation)
 
     @classmethod
+    @iap._prefetchable_str
     def _handle_size_arg(cls, size, subcall):
         def _dict_to_size_tuple(val1, val2):
             kaa = "keep-aspect-ratio"
@@ -1843,6 +1846,7 @@ class CropAndPad(meta.Augmenter):
         self._pad_cval_segmentation_maps = 0
 
     @classmethod
+    @iap._prefetchable
     def _handle_px_and_percent_args(cls, px, percent):
         # pylint: disable=invalid-name
         all_sides = None
@@ -4684,6 +4688,7 @@ class KeepSizeByResize(meta.Augmenter):
             random_state=random_state, deterministic=deterministic)
         self.children = children
 
+        @iap._prefetchable_str
         def _validate_param(val, allow_same_as_images):
             valid_ips_and_resize = ia.IMRESIZE_VALID_INTERPOLATIONS \
                                   + [KeepSizeByResize.NO_RESIZE]

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -229,7 +229,7 @@ def handle_continuous_param(param, name, value_range=None,
         _check_value_range(param[1], name, value_range)
         result = Uniform(param[0], param[1])
     elif (list_to_choice and ia.is_iterable(param)
-            and not isinstance(param, tuple)):
+          and not isinstance(param, tuple)):
         assert all([ia.is_single_number(v) for v in param]), (
             "Expected iterable parameter '%s' to only contain numbers, "
             "got %s." % (name, [type(v) for v in param],))

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -10,6 +10,8 @@ import copy as copy_module
 from collections import defaultdict
 from abc import ABCMeta, abstractmethod
 import tempfile
+from functools import reduce, wraps
+from operator import mul as mul_op
 
 import numpy as np
 import six
@@ -23,6 +25,144 @@ from . import imgaug as ia
 from . import dtypes as iadt
 from . import random as iarandom
 from .external.opensimplex import OpenSimplex
+
+
+# Added in 0.5.0.
+_PREFETCHING_ENABLED = True
+# Added in 0.5.0.
+_NB_PREFETCH = 10000
+# Added in 0.5.0.
+_NB_PREFETCH_STRINGS = 1000
+
+
+# Added in 0.5.0.
+def _prefetchable(func):
+    @wraps(func)
+    def _inner(*args, **kwargs):
+        param = func(*args, **kwargs)
+        return _wrap_leafs_of_param_in_prefetchers(param, _NB_PREFETCH)
+    return _inner
+
+
+# Added in 0.5.0.
+def _prefetchable_str(func):
+    @wraps(func)
+    def _inner(*args, **kwargs):
+        param = func(*args, **kwargs)
+        return _wrap_leafs_of_param_in_prefetchers(param, _NB_PREFETCH_STRINGS)
+    return _inner
+
+
+# Added in 0.5.0.
+def _wrap_param_in_prefetchers(param, nb_prefetch):
+    for key, value in param.__dict__.items():
+        if isinstance(value, StochasticParameter):
+            param.__dict__[key] = _wrap_param_in_prefetchers(value, nb_prefetch)
+
+    if param.prefetchable:
+        return AutoPrefetcher(param, nb_prefetch)
+    return param
+
+
+# Added in 0.5.0.
+def _wrap_leafs_of_param_in_prefetchers(param, nb_prefetch):
+    param_wrapped, did_wrap_any_child = \
+        _wrap_leafs_of_param_in_prefetchers_recursive(
+            param, nb_prefetch
+        )
+    return param_wrapped
+
+
+# Added in 0.5.0.
+def _wrap_leafs_of_param_in_prefetchers_recursive(param, nb_prefetch):
+    if isinstance(param, (list, tuple)):
+        result = []
+        did_wrap_any_child = False
+        for param_i in param:
+            param_i_wrapped, did_wrap_any_child_i = \
+                _wrap_leafs_of_param_in_prefetchers_recursive(
+                    param_i, nb_prefetch
+                )
+            result.append(param_i_wrapped)
+            did_wrap_any_child = did_wrap_any_child or did_wrap_any_child_i
+
+        if not did_wrap_any_child:
+            return param, False
+        if isinstance(param, tuple):
+            return tuple(result), did_wrap_any_child
+        return result, did_wrap_any_child
+    elif not isinstance(param, StochasticParameter):
+        return param, False
+
+    did_wrap_any_child = False
+    for key, value in param.__dict__.items():
+        param_wrapped, did_wrap_i = \
+            _wrap_leafs_of_param_in_prefetchers_recursive(
+                value, nb_prefetch
+            )
+
+        param.__dict__[key] = param_wrapped
+        did_wrap_any_child = did_wrap_any_child or did_wrap_i
+
+    if param.prefetchable and not did_wrap_any_child and _PREFETCHING_ENABLED:
+        return AutoPrefetcher(param, nb_prefetch), True
+    return param, did_wrap_any_child
+
+
+def toggle_prefetching(enabled):
+    """Toggle prefetching on or off.
+
+    Added in 0.5.0.
+
+    Parameters
+    ----------
+    enabled : bool
+        Whether enabled is activated (``True``) or off (``False``).
+
+    """
+    global _PREFETCHING_ENABLED
+    _PREFETCHING_ENABLED = enabled
+
+
+class toggled_prefetching(object):  # pylint: disable=invalid-name
+    """Context that toggles prefetching on or off depending on a flag.
+
+    Added in 0.5.0.
+
+    Parameters
+    ----------
+    enabled : bool
+        Whether enabled is activated (``True``) or off (``False``).
+
+    """
+
+    # Added in 0.5.0.
+    def __init__(self, enabled):
+        self.enabled = enabled
+        self._old_state = None
+
+    # Added in 0.5.0.
+    def __enter__(self):
+        global _PREFETCHING_ENABLED
+        self._old_state = _PREFETCHING_ENABLED
+        _PREFETCHING_ENABLED = self.enabled
+
+    # Added in 0.5.0.
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        global _PREFETCHING_ENABLED
+        _PREFETCHING_ENABLED = self._old_state
+
+
+class no_prefetching(toggled_prefetching):  # pylint: disable=invalid-name
+    """Context that deactviates prefetching.
+
+    Added in 0.5.0.
+
+    """
+
+    # Added in 0.5.0.
+    def __init__(self):
+        super(no_prefetching, self).__init__(False)
 
 
 def _check_value_range(value, name, value_range):
@@ -67,12 +207,14 @@ def _check_value_range(value, name, value_range):
 # FIXME this uses _check_value_range, which checks for a<=x<=b, but a produced
 #       Uniform parameter has value range a<=x<b.
 def handle_continuous_param(param, name, value_range=None,
-                            tuple_to_uniform=True, list_to_choice=True):
+                            tuple_to_uniform=True, list_to_choice=True,
+                            prefetch=True):
+    result = None
+
     if ia.is_single_number(param):
         _check_value_range(param, name, value_range)
-        return Deterministic(param)
-
-    if tuple_to_uniform and isinstance(param, tuple):
+        result = Deterministic(param)
+    elif tuple_to_uniform and isinstance(param, tuple):
         assert len(param) == 2, (
             "Expected parameter '%s' with type tuple to have exactly two "
             "entries, but got %d." % (name, len(param)))
@@ -81,19 +223,22 @@ def handle_continuous_param(param, name, value_range=None,
             "numbers, got %s." % (name, [type(v) for v in param],))
         _check_value_range(param[0], name, value_range)
         _check_value_range(param[1], name, value_range)
-        return Uniform(param[0], param[1])
-
-    if (list_to_choice and ia.is_iterable(param)
+        result = Uniform(param[0], param[1])
+    elif (list_to_choice and ia.is_iterable(param)
             and not isinstance(param, tuple)):
         assert all([ia.is_single_number(v) for v in param]), (
             "Expected iterable parameter '%s' to only contain numbers, "
             "got %s." % (name, [type(v) for v in param],))
         for param_i in param:
             _check_value_range(param_i, name, value_range)
-        return Choice(param)
+        result = Choice(param)
+    elif isinstance(param, StochasticParameter):
+        result = param
 
-    if isinstance(param, StochasticParameter):
-        return param
+    if result is not None:
+        if prefetch:
+            return _wrap_leafs_of_param_in_prefetchers(result, _NB_PREFETCH)
+        return result
 
     allowed_type = "number"
     list_str = ", list of %s" % (allowed_type,) if list_to_choice else ""
@@ -104,13 +249,15 @@ def handle_continuous_param(param, name, value_range=None,
 
 
 def handle_discrete_param(param, name, value_range=None, tuple_to_uniform=True,
-                          list_to_choice=True, allow_floats=True):
+                          list_to_choice=True, allow_floats=True,
+                          prefetch=True):
+    result = None
+
     if (ia.is_single_integer(param)
             or (allow_floats and ia.is_single_float(param))):
         _check_value_range(param, name, value_range)
-        return Deterministic(int(param))
-
-    if tuple_to_uniform and isinstance(param, tuple):
+        result = Deterministic(int(param))
+    elif tuple_to_uniform and isinstance(param, tuple):
         assert len(param) == 2, (
             "Expected parameter '%s' with type tuple to have exactly two "
             "entries, but got %d." % (name, len(param)))
@@ -127,9 +274,8 @@ def handle_discrete_param(param, name, value_range=None, tuple_to_uniform=True,
 
         _check_value_range(param[0], name, value_range)
         _check_value_range(param[1], name, value_range)
-        return DiscreteUniform(int(param[0]), int(param[1]))
-
-    if (list_to_choice and ia.is_iterable(param)
+        result = DiscreteUniform(int(param[0]), int(param[1]))
+    elif (list_to_choice and ia.is_iterable(param)
             and not isinstance(param, tuple)):
         is_valid_types = all([
             ia.is_single_number(v)
@@ -144,10 +290,14 @@ def handle_discrete_param(param, name, value_range=None, tuple_to_uniform=True,
 
         for param_i in param:
             _check_value_range(param_i, name, value_range)
-        return Choice([int(param_i) for param_i in param])
+        result = Choice([int(param_i) for param_i in param])
+    elif isinstance(param, StochasticParameter):
+        result = param
 
-    if isinstance(param, StochasticParameter):
-        return param
+    if result is not None:
+        if prefetch:
+            return _wrap_leafs_of_param_in_prefetchers(result, _NB_PREFETCH)
+        return result
 
     allowed_type = "number" if allow_floats else "int"
     list_str = ", list of %s" % (allowed_type,) if list_to_choice else ""
@@ -158,18 +308,19 @@ def handle_discrete_param(param, name, value_range=None, tuple_to_uniform=True,
 
 
 # Added in 0.4.0.
-def handle_categorical_string_param(param, name, valid_values=None):
-    if param == ia.ALL and valid_values is not None:
-        return Choice(list(valid_values))
+def handle_categorical_string_param(param, name, valid_values=None,
+                                    prefetch=True):
+    result = None
 
-    if ia.is_string(param):
+    if param == ia.ALL and valid_values is not None:
+        result = Choice(list(valid_values))
+    elif ia.is_string(param):
         if valid_values is not None:
             assert param in valid_values, (
                 "Expected parameter '%s' to be one of: %s. Got: %s." % (
                     name, ", ".join(list(valid_values)), param))
-        return Deterministic(param)
-
-    if isinstance(param, list):
+        result = Deterministic(param)
+    elif isinstance(param, list):
         assert all([ia.is_string(val) for val in param]), (
             "Expected list provided for parameter '%s' to only contain "
             "strings, got types: %s." % (
@@ -180,10 +331,16 @@ def handle_categorical_string_param(param, name, valid_values=None):
                 "the following allowed strings: %s. Got strings: %s." % (
                     name, ", ".join(valid_values), ", ".join(param)
                 ))
-        return Choice(param)
+        result = Choice(param)
+    elif isinstance(param, StochasticParameter):
+        result = param
 
-    if isinstance(param, StochasticParameter):
-        return param
+    # we currently prefetch only 1k values here instead of 10k, because
+    # strings might be rather long
+    if result is not None:
+        if prefetch:
+            return _wrap_leafs_of_param_in_prefetchers(result, _NB_PREFETCH_STRINGS)
+        return result
 
     raise Exception(
         "Expected parameter '%s' to be%s a string, a list of "
@@ -194,13 +351,13 @@ def handle_categorical_string_param(param, name, valid_values=None):
 
 
 def handle_discrete_kernel_size_param(param, name, value_range=(1, None),
-                                      allow_floats=True):
+                                      allow_floats=True, prefetch=True):
+    result = None, None
     if (ia.is_single_integer(param)
             or (allow_floats and ia.is_single_float(param))):
         _check_value_range(param, name, value_range)
-        return Deterministic(int(param)), None
-
-    if isinstance(param, tuple):
+        result = Deterministic(int(param)), None
+    elif isinstance(param, tuple):
         assert len(param) == 2, (
             "Expected parameter '%s' with type tuple to have exactly two "
             "entries, but got %d." % (name, len(param)))
@@ -209,24 +366,22 @@ def handle_discrete_kernel_size_param(param, name, value_range=(1, None),
                                           for param_i in param]))):
             _check_value_range(param[0], name, value_range)
             _check_value_range(param[1], name, value_range)
-            return DiscreteUniform(int(param[0]), int(param[1])), None
+            result = DiscreteUniform(int(param[0]), int(param[1])), None
+        elif all([isinstance(param_i, StochasticParameter)
+                  for param_i in param]):
+            result = param[0], param[1]
+        else:
+            handled = (
+                handle_discrete_param(
+                    param[0], "%s[0]" % (name,), value_range,
+                    allow_floats=allow_floats),
+                handle_discrete_param(
+                    param[1], "%s[1]" % (name,), value_range,
+                    allow_floats=allow_floats)
+            )
 
-        if all([isinstance(param_i, StochasticParameter)
-                for param_i in param]):
-            return param[0], param[1]
-
-        handled = (
-            handle_discrete_param(
-                param[0], "%s[0]" % (name,), value_range,
-                allow_floats=allow_floats),
-            handle_discrete_param(
-                param[1], "%s[1]" % (name,), value_range,
-                allow_floats=allow_floats)
-        )
-
-        return handled
-
-    if ia.is_iterable(param) and not isinstance(param, tuple):
+            result = handled
+    elif ia.is_iterable(param) and not isinstance(param, tuple):
         is_valid_types = all([
             ia.is_single_number(v)
             if allow_floats else ia.is_single_integer(v)
@@ -240,10 +395,18 @@ def handle_discrete_kernel_size_param(param, name, value_range=(1, None),
 
         for param_i in param:
             _check_value_range(param_i, name, value_range)
-        return Choice([int(param_i) for param_i in param]), None
+        result = Choice([int(param_i) for param_i in param]), None
+    elif isinstance(param, StochasticParameter):
+        result = param, None
 
-    if isinstance(param, StochasticParameter):
-        return param, None
+    result_pf = []
+    for v in result:
+        if v is not None and prefetch:
+            v = _wrap_leafs_of_param_in_prefetchers(v, _NB_PREFETCH)
+        result_pf.append(v)
+
+    if result_pf != [None, None]:
+        return tuple(result_pf)
 
     raise Exception(
         "Expected int, tuple/list with 2 entries or StochasticParameter. "
@@ -251,21 +414,21 @@ def handle_discrete_kernel_size_param(param, name, value_range=(1, None),
 
 
 def handle_probability_param(param, name, tuple_to_uniform=False,
-                             list_to_choice=False):
+                             list_to_choice=False, prefetch=True):
     eps = 1e-6
 
-    if param in [True, False, 0, 1]:
-        return Deterministic(int(param))
+    result = None
 
-    if ia.is_single_number(param):
+    if param in [True, False, 0, 1]:
+        result = Deterministic(int(param))
+    elif ia.is_single_number(param):
         assert 0.0 <= param <= 1.0, (
             "Expected probability of parameter '%s' to be in the interval "
             "[0.0, 1.0], got %.4f." % (name, param,))
         if 0.0-eps < param < 0.0+eps or 1.0-eps < param < 1.0+eps:
             return Deterministic(int(np.round(param)))
-        return Binomial(param)
-
-    if tuple_to_uniform and isinstance(param, tuple):
+        result = Binomial(param)
+    elif tuple_to_uniform and isinstance(param, tuple):
         assert all([ia.is_single_number(v) for v in param]), (
             "Expected parameter '%s' of type tuple to only contain numbers, "
             "got %s." % (name, [type(v) for v in param],))
@@ -276,9 +439,8 @@ def handle_probability_param(param, name, tuple_to_uniform=False,
             "Expected parameter '%s' of type tuple to contain two "
             "probabilities in the interval [0.0, 1.0]. "
             "Got values %.4f and %.4f." % (name, param[0], param[1]))
-        return Binomial(Uniform(param[0], param[1]))
-
-    if list_to_choice and ia.is_iterable(param):
+        result = Binomial(Uniform(param[0], param[1]))
+    elif list_to_choice and ia.is_iterable(param):
         assert all([ia.is_single_number(v) for v in param]), (
             "Expected iterable parameter '%s' to only contain numbers, "
             "got %s." % (name, [type(v) for v in param],))
@@ -286,10 +448,14 @@ def handle_probability_param(param, name, tuple_to_uniform=False,
             "Expected iterable parameter '%s' to only contain probabilities "
             "in the interval [0.0, 1.0], got values %s." % (
                 name, ", ".join(["%.4f" % (p_i,) for p_i in param])))
-        return Binomial(Choice(param))
+        result = Binomial(Choice(param))
+    elif isinstance(param, StochasticParameter):
+        result = param
 
-    if isinstance(param, StochasticParameter):
-        return param
+    if result is not None:
+        if prefetch:
+            return _wrap_leafs_of_param_in_prefetchers(result, _NB_PREFETCH)
+        return result
 
     raise Exception(
         "Expected boolean or number or StochasticParameter for %s, "
@@ -367,6 +533,22 @@ class StochasticParameter(object):
     def __init__(self):
         pass
 
+    @property
+    def prefetchable(self):
+        """Determines whether this parameter may be prefetched.
+
+        Added in 0.5.0.
+
+        Returns
+        -------
+        bool
+            Whether to allow prefetching of this parameter's samples.
+            This should usually only be ``True`` for parameters that actually
+            perform random sampling, i.e. depend on an RNG.
+
+        """
+        return False
+
     def draw_sample(self, random_state=None):
         """
         Draws a single sample value from this parameter.
@@ -409,7 +591,8 @@ class StochasticParameter(object):
             to match `size`.
 
         """
-        random_state = iarandom.RNG(random_state)
+        if not isinstance(random_state, iarandom.RNG):
+            random_state = iarandom.RNG(random_state)
         samples = self._draw_samples(
             size if not ia.is_single_integer(size) else tuple([size]),
             random_state)
@@ -629,6 +812,120 @@ class StochasticParameter(object):
         return data
 
 
+class AutoPrefetcher(StochasticParameter):
+    """Parameter that prefetches random samples from a child parameter.
+
+    This parameter will fetch ``N`` random samples in one big swoop and then
+    return ``M`` of these samples upon each call, with ``M << N``.
+    This improves the sampling efficiency by performing as few sampling
+    calls as possible.
+
+    This parameter will only start to prefetch after the first call.
+    In some cases this prevents inefficiencies when augmenters are only used
+    once. (Though this only works if the respective augmenter performs
+    a single sampling call per batch and not one call per image.)
+
+    This parameter will throw away its prefetched samples if a new RNG
+    is provided (compared to the previous call). It will however ignore the
+    state of the RNG.
+
+    This parameter should only wrap leaf nodes. In something like
+    ``Add(1, Normal(Uniform(0, 1), Uniform(0, 2)))`` it should only be applied
+    to the two ``Uniform`` instaces. Otherwise, only a single sample of
+    ``Uniform(0, 1)`` might be taken and influence thousands of samples of
+    ``Normal``.
+
+    Note that the samples returned by this parameter are part of a larger
+    array. In-place changes to these samples should hence be performed with
+    some caution.
+
+    Added in 0.5.0.
+
+    """
+
+    # Added in 0.5.0.
+    def __init__(self, other_param, nb_prefetch):
+        super(AutoPrefetcher, self).__init__()
+        self.other_param = other_param
+        self.nb_prefetch = nb_prefetch
+
+        self.samples = None
+        self.index = 0
+        self.last_rng_idx = None
+
+    # Added in 0.5.0.
+    def _draw_samples(self, size, random_state):
+        if not _PREFETCHING_ENABLED:
+            return self.other_param.draw_samples(size, random_state)
+
+        if self.last_rng_idx is None or random_state._idx != self.last_rng_idx:
+            self.last_rng_idx = random_state._idx
+            self.samples = None
+            return self.other_param.draw_samples(size, random_state)
+
+        self.last_rng_idx = random_state._idx
+
+        nb_components = reduce(mul_op, size)
+
+        if nb_components >= self.nb_prefetch:
+            return self.other_param.draw_samples(size, random_state)
+
+        if self.samples is None:
+            self._prefetch(random_state)
+
+        leftover = len(self.samples) - self.index - nb_components
+        if leftover <= 0:
+            self._prefetch(random_state)
+
+        samples = self.samples[self.index:self.index+nb_components]
+        self.index += nb_components
+
+        return samples.reshape(size)
+
+    # Added in 0.5.0.
+    def _prefetch(self, random_state):
+        samples = self.other_param.draw_samples((self.nb_prefetch,),
+                                                random_state)
+        if self.samples is None:
+            self.samples = samples
+        else:
+            self.samples = np.concatenate([
+                self.samples[self.index:], samples
+            ], axis=0)
+        self.index = 0
+
+    # Added in 0.5.0.
+    def __getattr__(self, attr):
+        other_param = super(
+            AutoPrefetcher, self
+        ).__getattribute__("other_param")
+        return getattr(other_param, attr)
+
+    # Added in 0.5.0.
+    def __repr__(self):
+        return self.__str__()
+
+    # Added in 0.5.0.
+    def __str__(self):
+        has_samples = (self.samples is not None)
+        return (
+            "AutoPrefetcher("
+            "nb_prefetch=%d, "
+            "samples=%s (dtype %s), "
+            "index=%d, "
+            "last_rng_idx=%s, "
+            "other_param=%s"
+            ")" % (
+                self.nb_prefetch,
+                self.samples.shape if has_samples else "None",
+                self.samples.dtype.name if has_samples else "None",
+                self.index,
+                self.last_rng_idx,
+                str(self.other_param)
+            )
+        )
+
+
 class Deterministic(StochasticParameter):
     """Parameter that is a constant value.
 
@@ -799,6 +1096,12 @@ class Choice(StochasticParameter):
                 "got %d and %d." % (len(a), len(p)))
         self.p = p
 
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
+
     def _draw_samples(self, size, random_state):
         if any([isinstance(a_i, StochasticParameter) for a_i in self.a]):
             rngs = random_state.duplicate(1+len(self.a))
@@ -900,6 +1203,12 @@ class Binomial(StochasticParameter):
         super(Binomial, self).__init__()
         self.p = handle_continuous_param(p, "p")
 
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
+
     def _draw_samples(self, size, random_state):
         p = self.p.draw_sample(random_state=random_state)
         assert 0 <= p <= 1.0, (
@@ -957,6 +1266,12 @@ class DiscreteUniform(StochasticParameter):
 
         self.a = handle_discrete_param(a, "a")
         self.b = handle_discrete_param(b, "b")
+
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
 
     def _draw_samples(self, size, random_state):
         # pylint: disable=invalid-name
@@ -1016,6 +1331,12 @@ class Poisson(StochasticParameter):
 
         self.lam = handle_continuous_param(lam, "lam")
 
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
+
     def _draw_samples(self, size, random_state):
         lam = self.lam.draw_sample(random_state=random_state)
         lam = max(lam, 0)
@@ -1071,6 +1392,12 @@ class Normal(StochasticParameter):
         self.loc = handle_continuous_param(loc, "loc")
         self.scale = handle_continuous_param(scale, "scale",
                                              value_range=(0, None))
+
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
 
     def _draw_samples(self, size, random_state):
         loc = self.loc.draw_sample(random_state=random_state)
@@ -1149,6 +1476,12 @@ class TruncatedNormal(StochasticParameter):
         self.low = handle_continuous_param(low, "low")
         self.high = handle_continuous_param(high, "high")
 
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
+
     def _draw_samples(self, size, random_state):
         # pylint: disable=invalid-name
         loc = self.loc.draw_sample(random_state=random_state)
@@ -1224,6 +1557,12 @@ class Laplace(StochasticParameter):
         self.scale = handle_continuous_param(scale, "scale",
                                              value_range=(0, None))
 
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
+
     def _draw_samples(self, size, random_state):
         loc = self.loc.draw_sample(random_state=random_state)
         scale = self.scale.draw_sample(random_state=random_state)
@@ -1275,6 +1614,12 @@ class ChiSquare(StochasticParameter):
 
         self.df = handle_discrete_param(df, "df", value_range=(1, None))
 
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
+
     def _draw_samples(self, size, random_state):
         # pylint: disable=invalid-name
         df = self.df.draw_sample(random_state=random_state)
@@ -1324,6 +1669,12 @@ class Weibull(StochasticParameter):
         super(Weibull, self).__init__()
 
         self.a = handle_continuous_param(a, "a", value_range=(0.0001, None))
+
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
 
     def _draw_samples(self, size, random_state):
         # pylint: disable=invalid-name
@@ -1381,6 +1732,12 @@ class Uniform(StochasticParameter):
 
         self.a = handle_continuous_param(a, "a")
         self.b = handle_continuous_param(b, "b")
+
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
 
     def _draw_samples(self, size, random_state):
         # pylint: disable=invalid-name
@@ -1444,6 +1801,12 @@ class Beta(StochasticParameter):
         assert ia.is_single_number(epsilon), (
             "Expected epsilon to a number, got type %s." % (type(epsilon),))
         self.epsilon = epsilon
+
+    # Added in 0.5.0.
+    @property
+    def prefetchable(self):
+        """See :func:`StochasticParameter.prefetchable`."""
+        return True
 
     def _draw_samples(self, size, random_state):
         alpha = self.alpha.draw_sample(random_state=random_state)
@@ -1846,8 +2209,9 @@ class Multiply(StochasticParameter):
     def __init__(self, other_param, val, elementwise=False):
         super(Multiply, self).__init__()
 
-        self.other_param = handle_continuous_param(other_param, "other_param")
-        self.val = handle_continuous_param(val, "val")
+        self.other_param = handle_continuous_param(other_param, "other_param",
+                                                   prefetch=False)
+        self.val = handle_continuous_param(val, "val", prefetch=False)
         self.elementwise = elementwise
 
     def _draw_samples(self, size, random_state):
@@ -1926,8 +2290,9 @@ class Divide(StochasticParameter):
     def __init__(self, other_param, val, elementwise=False):
         super(Divide, self).__init__()
 
-        self.other_param = handle_continuous_param(other_param, "other_param")
-        self.val = handle_continuous_param(val, "val")
+        self.other_param = handle_continuous_param(other_param, "other_param",
+                                                   prefetch=False)
+        self.val = handle_continuous_param(val, "val", prefetch=False)
         self.elementwise = elementwise
 
     def _draw_samples(self, size, random_state):
@@ -2018,8 +2383,9 @@ class Add(StochasticParameter):
     def __init__(self, other_param, val, elementwise=False):
         super(Add, self).__init__()
 
-        self.other_param = handle_continuous_param(other_param, "other_param")
-        self.val = handle_continuous_param(val, "val")
+        self.other_param = handle_continuous_param(other_param, "other_param",
+                                                   prefetch=False)
+        self.val = handle_continuous_param(val, "val", prefetch=False)
         self.elementwise = elementwise
 
     def _draw_samples(self, size, random_state):
@@ -2093,8 +2459,9 @@ class Subtract(StochasticParameter):
     def __init__(self, other_param, val, elementwise=False):
         super(Subtract, self).__init__()
 
-        self.other_param = handle_continuous_param(other_param, "other_param")
-        self.val = handle_continuous_param(val, "val")
+        self.other_param = handle_continuous_param(other_param, "other_param",
+                                                   prefetch=False)
+        self.val = handle_continuous_param(val, "val", prefetch=False)
         self.elementwise = elementwise
 
     def _draw_samples(self, size, random_state):
@@ -2169,8 +2536,9 @@ class Power(StochasticParameter):
     def __init__(self, other_param, val, elementwise=False):
         super(Power, self).__init__()
 
-        self.other_param = handle_continuous_param(other_param, "other_param")
-        self.val = handle_continuous_param(val, "val")
+        self.other_param = handle_continuous_param(other_param, "other_param",
+                                                   prefetch=False)
+        self.val = handle_continuous_param(val, "val", prefetch=False)
         self.elementwise = elementwise
 
     def _draw_samples(self, size, random_state):
@@ -2733,8 +3101,10 @@ class Sigmoid(StochasticParameter):
         _assert_arg_is_stoch_param("other_param", other_param)
         self.other_param = other_param
 
-        self.threshold = handle_continuous_param(threshold, "threshold")
-        self.activated = handle_probability_param(activated, "activated")
+        self.threshold = handle_continuous_param(threshold, "threshold",
+                                                 prefetch=False)
+        self.activated = handle_probability_param(activated, "activated",
+                                                  prefetch=False)
 
         assert ia.is_single_number(mul), (
             "Expected 'mul' to be a number, got type %s." % (type(mul),))

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -121,6 +121,7 @@ def toggle_prefetching(enabled):
         Whether enabled is activated (``True``) or off (``False``).
 
     """
+    # pylint: disable=global-statement
     global _PREFETCHING_ENABLED
     _PREFETCHING_ENABLED = enabled
 

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -66,7 +66,7 @@ def _wrap_param_in_prefetchers(param, nb_prefetch):
 
 # Added in 0.5.0.
 def _wrap_leafs_of_param_in_prefetchers(param, nb_prefetch):
-    param_wrapped, did_wrap_any_child = \
+    param_wrapped, _did_wrap_any_child = \
         _wrap_leafs_of_param_in_prefetchers_recursive(
             param, nb_prefetch
         )
@@ -91,7 +91,8 @@ def _wrap_leafs_of_param_in_prefetchers_recursive(param, nb_prefetch):
         if isinstance(param, tuple):
             return tuple(result), did_wrap_any_child
         return result, did_wrap_any_child
-    elif not isinstance(param, StochasticParameter):
+
+    if not isinstance(param, StochasticParameter):
         return param, False
 
     did_wrap_any_child = False
@@ -143,12 +144,14 @@ class toggled_prefetching(object):  # pylint: disable=invalid-name
 
     # Added in 0.5.0.
     def __enter__(self):
+        # pylint: disable=global-statement
         global _PREFETCHING_ENABLED
         self._old_state = _PREFETCHING_ENABLED
         _PREFETCHING_ENABLED = self.enabled
 
     # Added in 0.5.0.
     def __exit__(self, exception_type, exception_value, exception_traceback):
+        # pylint: disable=global-statement
         global _PREFETCHING_ENABLED
         _PREFETCHING_ENABLED = self._old_state
 
@@ -276,7 +279,7 @@ def handle_discrete_param(param, name, value_range=None, tuple_to_uniform=True,
         _check_value_range(param[1], name, value_range)
         result = DiscreteUniform(int(param[0]), int(param[1]))
     elif (list_to_choice and ia.is_iterable(param)
-            and not isinstance(param, tuple)):
+          and not isinstance(param, tuple)):
         is_valid_types = all([
             ia.is_single_number(v)
             if allow_floats else ia.is_single_integer(v)
@@ -352,6 +355,8 @@ def handle_categorical_string_param(param, name, valid_values=None,
 
 def handle_discrete_kernel_size_param(param, name, value_range=(1, None),
                                       allow_floats=True, prefetch=True):
+    # pylint: disable=invalid-name
+
     result = None, None
     if (ia.is_single_integer(param)
             or (allow_floats and ia.is_single_float(param))):
@@ -855,6 +860,7 @@ class AutoPrefetcher(StochasticParameter):
 
     # Added in 0.5.0.
     def _draw_samples(self, size, random_state):
+        # pylint: disable=protected-access
         if not _PREFETCHING_ENABLED:
             return self.other_param.draw_samples(size, random_state)
 

--- a/imgaug/random.py
+++ b/imgaug/random.py
@@ -151,6 +151,7 @@ class RNG(object):
     # TODO add maybe a __new__ here that feeds-through an RNG input without
     #      wrapping it in RNG(rng_input)?
     def __init__(self, generator):
+        # pylint: disable=protected-access
         global _RNG_IDX
 
         if isinstance(generator, RNG):

--- a/imgaug/random.py
+++ b/imgaug/random.py
@@ -151,7 +151,7 @@ class RNG(object):
     # TODO add maybe a __new__ here that feeds-through an RNG input without
     #      wrapping it in RNG(rng_input)?
     def __init__(self, generator):
-        # pylint: disable=protected-access
+        # pylint: disable=protected-access, global-statement
         global _RNG_IDX
 
         if isinstance(generator, RNG):

--- a/test/augmenters/test_arithmetic.py
+++ b/test/augmenters/test_arithmetic.py
@@ -28,7 +28,8 @@ from imgaug.testutils import (
     keypoints_equal,
     reseed,
     runtest_pickleable_uint8_img,
-    assertWarns
+    assertWarns,
+    is_parameter_instance
 )
 import imgaug.augmenters.arithmetic as arithmetic_lib
 import imgaug.augmenters.contrast as contrast_lib
@@ -1427,14 +1428,13 @@ class TestAdd(unittest.TestCase):
         # test get_parameters()
         aug = iaa.Add(value=1, per_channel=False)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
+        is_parameter_instance(params[0], iap.Deterministic)
+        is_parameter_instance(params[1], iap.Deterministic)
         assert params[0].value == 1
         assert params[1].value == 0
 
     def test_heatmaps(self):
         # test heatmaps (not affected by augmenter)
-        base_img = np.ones((3, 3, 1), dtype=np.uint8) * 100
         aug = iaa.Add(value=10)
         hm = ia.quokka_heatmap()
         hm_aug = aug.augment_heatmaps([hm])[0]
@@ -1917,8 +1917,8 @@ class TestAddElementwise(unittest.TestCase):
         # test get_parameters()
         aug = iaa.AddElementwise(value=1, per_channel=False)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
+        is_parameter_instance(params[0], iap.Deterministic)
+        is_parameter_instance(params[1], iap.Deterministic)
         assert params[0].value == 1
         assert params[1].value == 0
 
@@ -2344,8 +2344,8 @@ class TestCutout(unittest.TestCase):
     def test___init___defaults(self):
         aug = iaa.Cutout()
         assert aug.nb_iterations.value == 1
-        assert isinstance(aug.position[0], iap.Uniform)
-        assert isinstance(aug.position[1], iap.Uniform)
+        assert is_parameter_instance(aug.position[0], iap.Uniform)
+        assert is_parameter_instance(aug.position[1], iap.Uniform)
         assert np.isclose(aug.size.value, 0.2)
         assert aug.squared.value == 1
         assert aug.fill_mode.value == "constant"
@@ -2916,19 +2916,19 @@ class TestDropout2d(unittest.TestCase):
 
     def test___init___defaults(self):
         aug = iaa.Dropout2d()
-        assert isinstance(aug.p, iap.Binomial)
+        assert is_parameter_instance(aug.p, iap.Binomial)
         assert np.isclose(aug.p.p.value, 1-0.1)
         assert aug.nb_keep_channels == 1
 
     def test___init___p_is_float(self):
         aug = iaa.Dropout2d(p=0.7)
-        assert isinstance(aug.p, iap.Binomial)
+        assert is_parameter_instance(aug.p, iap.Binomial)
         assert np.isclose(aug.p.p.value, 0.3)
         assert aug.nb_keep_channels == 1
 
     def test___init___nb_keep_channels_is_int(self):
         aug = iaa.Dropout2d(p=0, nb_keep_channels=2)
-        assert isinstance(aug.p, iap.Binomial)
+        assert is_parameter_instance(aug.p, iap.Binomial)
         assert np.isclose(aug.p.p.value, 1.0)
         assert aug.nb_keep_channels == 2
 
@@ -3173,7 +3173,7 @@ class TestDropout2d(unittest.TestCase):
     def test_get_parameters(self):
         aug = iaa.Dropout2d(p=0.7, nb_keep_channels=2)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Binomial)
+        is_parameter_instance(params[0], iap.Binomial)
         assert np.isclose(params[0].p.value, 0.3)
         assert params[1] == 2
 
@@ -3272,7 +3272,7 @@ class TestTotalDropout(unittest.TestCase):
 
     def test___init___p(self):
         aug = iaa.TotalDropout(p=0)
-        assert isinstance(aug.p, iap.Binomial)
+        assert is_parameter_instance(aug.p, iap.Binomial)
         assert np.isclose(aug.p.p.value, 1.0)
 
     def test_p_is_1(self):
@@ -3789,8 +3789,8 @@ class TestMultiply(unittest.TestCase):
         # test get_parameters()
         aug = iaa.Multiply(mul=1, per_channel=False)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
+        is_parameter_instance(params[0], iap.Deterministic)
+        is_parameter_instance(params[1], iap.Deterministic)
         assert params[0].value == 1
         assert params[1].value == 0
 
@@ -4288,8 +4288,8 @@ class TestMultiplyElementwise(unittest.TestCase):
         # test get_parameters()
         aug = iaa.MultiplyElementwise(mul=1, per_channel=False)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
+        is_parameter_instance(params[0], iap.Deterministic)
+        is_parameter_instance(params[1], iap.Deterministic)
         assert params[0].value == 1
         assert params[1].value == 0
 
@@ -4761,10 +4761,10 @@ class TestReplaceElementwise(unittest.TestCase):
         # test get_parameters()
         aug = iaa.ReplaceElementwise(mask=0.5, replacement=2, per_channel=False)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Binomial)
-        assert isinstance(params[0].p, iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
-        assert isinstance(params[2], iap.Deterministic)
+        is_parameter_instance(params[0], iap.Binomial)
+        is_parameter_instance(params[0].p, iap.Deterministic)
+        is_parameter_instance(params[1], iap.Deterministic)
+        is_parameter_instance(params[2], iap.Deterministic)
         assert 0.5 - 1e-6 < params[0].p.value < 0.5 + 1e-6
         assert params[1].value == 2
         assert params[2].value == 0
@@ -6406,7 +6406,7 @@ class TestJpegCompression(unittest.TestCase):
 
     def test___init__(self):
         aug = iaa.JpegCompression([0, 100])
-        assert isinstance(aug.compression, iap.Choice)
+        assert is_parameter_instance(aug.compression, iap.Choice)
         assert len(aug.compression.a) == 2
         assert aug.compression.a[0] == 0
         assert aug.compression.a[1] == 100

--- a/test/augmenters/test_blend.py
+++ b/test/augmenters/test_blend.py
@@ -27,7 +27,7 @@ from imgaug import dtypes as iadt
 from imgaug.augmenters import blend
 from imgaug.testutils import (
     keypoints_equal, reseed, assert_cbaois_equal,
-    runtest_pickleable_uint8_img)
+    runtest_pickleable_uint8_img, is_parameter_instance)
 from imgaug.augmentables.heatmaps import HeatmapsOnImage
 from imgaug.augmentables.segmaps import SegmentationMapsOnImage
 from imgaug.augmentables.batches import _BatchInAugmentation
@@ -1067,8 +1067,8 @@ class TestBlendAlpha(unittest.TestCase):
         bg = iaa.Sequential([iaa.Add(1)])
         aug = iaa.BlendAlpha(0.65, fg, bg, per_channel=1)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
+        assert params[0] is aug.factor
+        assert params[1] is aug.per_channel
         assert 0.65 - 1e-6 < params[0].value < 0.65 + 1e-6
         assert params[1].value == 1
 
@@ -3213,8 +3213,8 @@ class TestSegMapClassIdsMaskGen(unittest.TestCase):
 
     def test___init___class_ids_stochastic(self):
         gen = iaa.SegMapClassIdsMaskGen([0, 1, 3], nb_sample_classes=2)
-        assert isinstance(gen.class_ids, iap.Choice)
-        assert isinstance(gen.nb_sample_classes, iap.Deterministic)
+        assert is_parameter_instance(gen.class_ids, iap.Choice)
+        assert is_parameter_instance(gen.nb_sample_classes, iap.Deterministic)
 
     def test_draw_masks__fixed_class_ids(self):
         segmap_arr = np.zeros((3, 2, 2), dtype=np.int32)
@@ -3373,8 +3373,8 @@ class TestBoundingBoxesMaskGen(unittest.TestCase):
 
     def test___init___labels_stochastic(self):
         gen = iaa.BoundingBoxesMaskGen(["person", "car"], nb_sample_labels=2)
-        assert isinstance(gen.labels, iap.Choice)
-        assert isinstance(gen.nb_sample_labels, iap.Deterministic)
+        assert is_parameter_instance(gen.labels, iap.Choice)
+        assert is_parameter_instance(gen.nb_sample_labels, iap.Deterministic)
 
     def test_draw_masks__labels_is_none(self):
         bbs = [ia.BoundingBox(x1=1, y1=1, x2=5, y2=5, label="bb1"),

--- a/test/augmenters/test_color.py
+++ b/test/augmenters/test_color.py
@@ -23,7 +23,8 @@ import imgaug.random as iarandom
 from imgaug import augmenters as iaa
 from imgaug import parameters as iap
 import imgaug.augmenters.meta as meta
-from imgaug.testutils import reseed, runtest_pickleable_uint8_img
+from imgaug.testutils import (reseed, runtest_pickleable_uint8_img,
+                              is_parameter_instance)
 import imgaug.augmenters.color as colorlib
 
 
@@ -623,11 +624,15 @@ class TestWithBrightnessChannels(unittest.TestCase):
         expected_child = iaa.Sequential([child], name="foo-then")
         expected = (
             "WithBrightnessChannels("
-            "to_colorspace=Deterministic(HSV), "
+            "to_colorspace=%s, "
             "from_colorspace=RGB, "
             "name=foo, "
             "children=%s, "
-            "deterministic=False)" % (str(expected_child),))
+            "deterministic=False)" % (
+                str(aug.to_colorspace),
+                str(expected_child),
+            )
+        )
         assert aug_str == expected
 
     def test_get_children_lists(self):
@@ -810,11 +815,16 @@ class TestMultiplyAndAddToBrightness(unittest.TestCase):
                     "MultiplyAndAddToBrightness("
                     "mul=%s, "
                     "add=%s, "
-                    "to_colorspace=Deterministic(HSV), "
+                    "to_colorspace=%s, "
                     "from_colorspace=RGB, "
                     "random_order=True, "
                     "name=foo, "
-                    "deterministic=False)" % (str(exp_mul), str(exp_add),))
+                    "deterministic=False)" % (
+                        exp_mul,
+                        exp_add,
+                        str(aug.to_colorspace)
+                    )
+                )
                 assert aug_str == expected
 
     def test_pickleable(self):
@@ -1054,10 +1064,11 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
         assert isinstance(aug.children, iaa.Sequential)
         assert len(aug.children) == 1
         assert isinstance(aug.children[0], iaa.Multiply)
-        assert isinstance(aug.children[0].mul, iap.Uniform)
+        assert is_parameter_instance(aug.children[0].mul, iap.Uniform)
         assert np.isclose(aug.children[0].mul.a.value, 0.9)
         assert np.isclose(aug.children[0].mul.b.value, 1.1)
-        assert isinstance(aug.children[0].per_channel, iap.Deterministic)
+        assert is_parameter_instance(aug.children[0].per_channel,
+                                     iap.Deterministic)
         assert aug.children[0].per_channel.value == 1
 
     def test_returns_correct_objects__mul_hue(self):
@@ -1069,7 +1080,8 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
         assert aug.children[0].channels == [0]
         assert len(aug.children[0].children) == 1
         assert isinstance(aug.children[0].children[0], iaa.Multiply)
-        assert isinstance(aug.children[0].children[0].mul, iap.Uniform)
+        assert is_parameter_instance(aug.children[0].children[0].mul,
+                                     iap.Uniform)
         assert np.isclose(aug.children[0].children[0].mul.a.value, 0.9)
         assert np.isclose(aug.children[0].children[0].mul.b.value, 1.1)
 
@@ -1082,7 +1094,8 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
         assert aug.children[0].channels == [1]
         assert len(aug.children[0].children) == 1
         assert isinstance(aug.children[0].children[0], iaa.Multiply)
-        assert isinstance(aug.children[0].children[0].mul, iap.Uniform)
+        assert is_parameter_instance(aug.children[0].children[0].mul,
+                                     iap.Uniform)
         assert np.isclose(aug.children[0].children[0].mul.a.value, 0.9)
         assert np.isclose(aug.children[0].children[0].mul.b.value, 1.1)
 
@@ -1097,7 +1110,8 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
         assert aug.children[0].channels == [0]
         assert len(aug.children[0].children) == 1
         assert isinstance(aug.children[0].children[0], iaa.Multiply)
-        assert isinstance(aug.children[0].children[0].mul, iap.Uniform)
+        assert is_parameter_instance(aug.children[0].children[0].mul,
+                                     iap.Uniform)
         assert np.isclose(aug.children[0].children[0].mul.a.value, 0.9)
         assert np.isclose(aug.children[0].children[0].mul.b.value, 1.1)
 
@@ -1105,7 +1119,8 @@ class TestMultiplyHueAndSaturation(unittest.TestCase):
         assert aug.children[1].channels == [1]
         assert len(aug.children[0].children) == 1
         assert isinstance(aug.children[1].children[0], iaa.Multiply)
-        assert isinstance(aug.children[1].children[0].mul, iap.Uniform)
+        assert is_parameter_instance(aug.children[1].children[0].mul,
+                                     iap.Uniform)
         assert np.isclose(aug.children[1].children[0].mul.a.value, 0.8)
         assert np.isclose(aug.children[1].children[0].mul.b.value, 1.2)
 
@@ -1331,7 +1346,8 @@ class TestMultiplyHue(unittest.TestCase):
         assert aug.children[0].channels == [0]
         assert len(aug.children[0].children) == 1
         assert isinstance(aug.children[0].children[0], iaa.Multiply)
-        assert isinstance(aug.children[0].children[0].mul, iap.Uniform)
+        assert is_parameter_instance(aug.children[0].children[0].mul,
+                                     iap.Uniform)
         assert np.isclose(aug.children[0].children[0].mul.a.value, 0.9)
         assert np.isclose(aug.children[0].children[0].mul.b.value, 1.1)
 
@@ -1353,7 +1369,8 @@ class TestMultiplySaturation(unittest.TestCase):
         assert aug.children[0].channels == [1]
         assert len(aug.children[0].children) == 1
         assert isinstance(aug.children[0].children[0], iaa.Multiply)
-        assert isinstance(aug.children[0].children[0].mul, iap.Uniform)
+        assert is_parameter_instance(aug.children[0].children[0].mul,
+                                     iap.Uniform)
         assert np.isclose(aug.children[0].children[0].mul.a.value, 0.9)
         assert np.isclose(aug.children[0].children[0].mul.b.value, 1.1)
 
@@ -1478,24 +1495,24 @@ class TestAddToHueAndSaturation(unittest.TestCase):
 
     def test___init__(self):
         aug = iaa.AddToHueAndSaturation((-20, 20))
-        assert isinstance(aug.value, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.value, iap.DiscreteUniform)
         assert aug.value.a.value == -20
         assert aug.value.b.value == 20
         assert aug.value_hue is None
         assert aug.value_saturation is None
-        assert isinstance(aug.per_channel, iap.Deterministic)
+        assert is_parameter_instance(aug.per_channel, iap.Deterministic)
         assert aug.per_channel.value == 0
 
     def test___init___value_none(self):
         aug = iaa.AddToHueAndSaturation(value_hue=(-20, 20),
                                         value_saturation=[0, 5, 10])
         assert aug.value is None
-        assert isinstance(aug.value_hue, iap.DiscreteUniform)
-        assert isinstance(aug.value_saturation, iap.Choice)
+        assert is_parameter_instance(aug.value_hue, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.value_saturation, iap.Choice)
         assert aug.value_hue.a.value == -20
         assert aug.value_hue.b.value == 20
         assert aug.value_saturation.a == [0, 5, 10]
-        assert isinstance(aug.per_channel, iap.Deterministic)
+        assert is_parameter_instance(aug.per_channel, iap.Deterministic)
         assert aug.per_channel.value == 0
 
     def test___init___per_channel(self):
@@ -1503,7 +1520,7 @@ class TestAddToHueAndSaturation(unittest.TestCase):
         assert aug.value is None
         assert aug.value_hue is not None
         assert aug.value_saturation is not None
-        assert isinstance(aug.per_channel, iap.Binomial)
+        assert is_parameter_instance(aug.per_channel, iap.Binomial)
         assert np.isclose(aug.per_channel.p.value, 0.5)
 
     def test__generate_lut_table(self):
@@ -1769,12 +1786,12 @@ class TestAddToHueAndSaturation(unittest.TestCase):
     def test_get_parameters(self):
         aug = iaa.AddToHueAndSaturation((-20, 20), per_channel=0.5)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.DiscreteUniform)
+        assert is_parameter_instance(params[0], iap.DiscreteUniform)
         assert params[0].a.value == -20
         assert params[0].b.value == 20
         assert params[1] is None
         assert params[2] is None
-        assert isinstance(params[3], iap.Binomial)
+        assert is_parameter_instance(params[3], iap.Binomial)
         assert np.isclose(params[3].p.value, 0.5)
 
     def test_get_parameters_value_hue_and_value_saturation(self):
@@ -1782,12 +1799,12 @@ class TestAddToHueAndSaturation(unittest.TestCase):
                                         value_saturation=5)
         params = aug.get_parameters()
         assert params[0] is None
-        assert isinstance(params[1], iap.DiscreteUniform)
+        assert is_parameter_instance(params[1], iap.DiscreteUniform)
         assert params[1].a.value == -20
         assert params[1].b.value == 20
-        assert isinstance(params[2], iap.Deterministic)
+        assert is_parameter_instance(params[2], iap.Deterministic)
         assert params[2].value == 5
-        assert isinstance(params[3], iap.Deterministic)
+        assert is_parameter_instance(params[3], iap.Deterministic)
         assert params[3].value == 0
 
     def test_pickleable(self):
@@ -1801,7 +1818,7 @@ class TestAddToHue(unittest.TestCase):
     def test_returns_correct_class(self):
         aug = iaa.AddToHue((-20, 20))
         assert isinstance(aug, iaa.AddToHueAndSaturation)
-        assert isinstance(aug.value_hue, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.value_hue, iap.DiscreteUniform)
         assert aug.value_hue.a.value == -20
         assert aug.value_hue.b.value == 20
 
@@ -1814,7 +1831,7 @@ class TestAddToSaturation(unittest.TestCase):
     def test_returns_correct_class(self):
         aug = iaa.AddToSaturation((-20, 20))
         assert isinstance(aug, iaa.AddToHueAndSaturation)
-        assert isinstance(aug.value_saturation, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.value_saturation, iap.DiscreteUniform)
         assert aug.value_saturation.a.value == -20
         assert aug.value_saturation.b.value == 20
 
@@ -1901,7 +1918,7 @@ class TestChangeColorTemperature(unittest.TestCase):
 
     def test___init___defaults(self):
         aug = iaa.ChangeColorTemperature()
-        assert isinstance(aug.kelvin, iap.Uniform)
+        assert is_parameter_instance(aug.kelvin, iap.Uniform)
         assert aug.kelvin.a.value == 1000
         assert aug.kelvin.b.value == 11000
         assert aug.from_colorspace == iaa.CSPACE_RGB
@@ -1912,19 +1929,20 @@ class TestChangeColorTemperature(unittest.TestCase):
 
     def test___init___kelvin_is_tuple(self):
         aug = iaa.ChangeColorTemperature((2000, 3000))
-        assert isinstance(aug.kelvin, iap.Uniform)
+        assert is_parameter_instance(aug.kelvin, iap.Uniform)
         assert aug.kelvin.a.value == 2000
         assert aug.kelvin.b.value == 3000
 
     def test___init___kelvin_is_list(self):
         aug = iaa.ChangeColorTemperature([1000, 2000, 3000])
-        assert isinstance(aug.kelvin, iap.Choice)
+        assert is_parameter_instance(aug.kelvin, iap.Choice)
         assert aug.kelvin.a == [1000, 2000, 3000]
 
     def test___init___kelvin_is_stochastic_param(self):
         param = iap.Deterministic(5000)
         aug = iaa.ChangeColorTemperature(param)
-        assert aug.kelvin is param
+        assert is_parameter_instance(aug.kelvin, iap.Deterministic)
+        assert aug.kelvin.value == 5000
 
     @mock.patch("imgaug.augmenters.color.change_color_temperatures_")
     def test_mocked(self, mock_ccts):
@@ -1986,7 +2004,7 @@ class TestKMeansColorQuantization(unittest.TestCase):
 
     def test___init___defaults(self):
         aug = self.augmenter()
-        assert isinstance(aug.n_colors, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.n_colors, iap.DiscreteUniform)
         assert aug.n_colors.a.value == 2
         assert aug.n_colors.b.value == 16
         assert aug.from_colorspace == iaa.CSPACE_RGB
@@ -2004,7 +2022,7 @@ class TestKMeansColorQuantization(unittest.TestCase):
             max_size=None,
             interpolation="cubic"
         )
-        assert isinstance(aug.n_colors, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.n_colors, iap.DiscreteUniform)
         assert aug.n_colors.a.value == 5
         assert aug.n_colors.b.value == 8
         assert aug.from_colorspace == iaa.CSPACE_BGR
@@ -2260,7 +2278,7 @@ class TestKMeansColorQuantization(unittest.TestCase):
             interpolation="cubic"
         )
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.DiscreteUniform)
+        assert is_parameter_instance(params[0], iap.DiscreteUniform)
         assert params[0].a.value == 5
         assert params[0].b.value == 8
         assert params[1] == iaa.CSPACE_BGR
@@ -2422,7 +2440,7 @@ class TestUniformColorQuantization(TestKMeansColorQuantization):
 
     def test___init___defaults(self):
         aug = self.augmenter()
-        assert isinstance(aug.n_colors, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.n_colors, iap.DiscreteUniform)
         assert aug.n_colors.a.value == 2
         assert aug.n_colors.b.value == 16
         assert aug.from_colorspace == iaa.CSPACE_RGB
@@ -2438,7 +2456,7 @@ class TestUniformColorQuantization(TestKMeansColorQuantization):
             max_size=128,
             interpolation="cubic"
         )
-        assert isinstance(aug.n_colors, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.n_colors, iap.DiscreteUniform)
         assert aug.n_colors.a.value == 5
         assert aug.n_colors.b.value == 8
         assert aug.from_colorspace == iaa.CSPACE_BGR
@@ -2565,7 +2583,7 @@ class TestUniformColorQuantizationToNBits(unittest.TestCase):
 
     def test___init___defaults(self):
         aug = self.augmenter()
-        assert isinstance(aug.counts, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.counts, iap.DiscreteUniform)
         assert aug.counts.a.value == 1
         assert aug.counts.b.value == 8
         assert aug.from_colorspace == iaa.CSPACE_RGB
@@ -2581,7 +2599,7 @@ class TestUniformColorQuantizationToNBits(unittest.TestCase):
             max_size=128,
             interpolation="cubic"
         )
-        assert isinstance(aug.counts, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.counts, iap.DiscreteUniform)
         assert aug.counts.a.value == 5
         assert aug.counts.b.value == 8
         assert aug.from_colorspace == iaa.CSPACE_BGR

--- a/test/augmenters/test_contrast.py
+++ b/test/augmenters/test_contrast.py
@@ -26,7 +26,8 @@ from imgaug import parameters as iap
 from imgaug import dtypes as iadt
 from imgaug.augmenters import contrast as contrast_lib
 from imgaug.testutils import (ArgCopyingMagicMock, keypoints_equal, reseed,
-                              runtest_pickleable_uint8_img, assertWarns)
+                              runtest_pickleable_uint8_img, assertWarns,
+                              is_parameter_instance)
 from imgaug.augmentables.batches import _BatchInAugmentation
 
 
@@ -36,15 +37,15 @@ class TestGammaContrast(unittest.TestCase):
 
     def test___init___tuple_to_uniform(self):
         aug = iaa.GammaContrast((1, 2))
-        assert isinstance(aug.params1d[0], iap.Uniform)
-        assert isinstance(aug.params1d[0].a, iap.Deterministic)
-        assert isinstance(aug.params1d[0].b, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0], iap.Uniform)
+        assert is_parameter_instance(aug.params1d[0].a, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0].b, iap.Deterministic)
         assert aug.params1d[0].a.value == 1
         assert aug.params1d[0].b.value == 2
 
     def test___init___list_to_choice(self):
         aug = iaa.GammaContrast([1, 2])
-        assert isinstance(aug.params1d[0], iap.Choice)
+        assert is_parameter_instance(aug.params1d[0], iap.Choice)
         assert np.all([val in aug.params1d[0].a for val in [1, 2]])
 
     def test_images_basic_functionality(self):
@@ -272,14 +273,14 @@ class TestSigmoidContrast(unittest.TestCase):
         # note that gain and cutoff are saved in inverted order in
         # _ContrastFuncWrapper to match the order of skimage's function
         aug = iaa.SigmoidContrast(gain=(1, 2), cutoff=(0.25, 0.75))
-        assert isinstance(aug.params1d[0], iap.Uniform)
-        assert isinstance(aug.params1d[0].a, iap.Deterministic)
-        assert isinstance(aug.params1d[0].b, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0], iap.Uniform)
+        assert is_parameter_instance(aug.params1d[0].a, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0].b, iap.Deterministic)
         assert aug.params1d[0].a.value == 1
         assert aug.params1d[0].b.value == 2
-        assert isinstance(aug.params1d[1], iap.Uniform)
-        assert isinstance(aug.params1d[1].a, iap.Deterministic)
-        assert isinstance(aug.params1d[1].b, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[1], iap.Uniform)
+        assert is_parameter_instance(aug.params1d[1].a, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[1].b, iap.Deterministic)
         assert np.allclose(aug.params1d[1].a.value, 0.25)
         assert np.allclose(aug.params1d[1].b.value, 0.75)
 
@@ -288,9 +289,9 @@ class TestSigmoidContrast(unittest.TestCase):
         # note that gain and cutoff are saved in inverted order in
         # _ContrastFuncWrapper to match the order of skimage's function
         aug = iaa.SigmoidContrast(gain=[1, 2], cutoff=[0.25, 0.75])
-        assert isinstance(aug.params1d[0], iap.Choice)
+        assert is_parameter_instance(aug.params1d[0], iap.Choice)
         assert np.all([val in aug.params1d[0].a for val in [1, 2]])
-        assert isinstance(aug.params1d[1], iap.Choice)
+        assert is_parameter_instance(aug.params1d[1], iap.Choice)
         assert np.all([
             np.allclose(val, val_choice)
             for val, val_choice
@@ -531,15 +532,15 @@ class TestLogContrast(unittest.TestCase):
 
     def test___init___tuple_to_uniform(self):
         aug = iaa.LogContrast((1, 2))
-        assert isinstance(aug.params1d[0], iap.Uniform)
-        assert isinstance(aug.params1d[0].a, iap.Deterministic)
-        assert isinstance(aug.params1d[0].b, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0], iap.Uniform)
+        assert is_parameter_instance(aug.params1d[0].a, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0].b, iap.Deterministic)
         assert aug.params1d[0].a.value == 1
         assert aug.params1d[0].b.value == 2
 
     def test___init___list_to_choice(self):
         aug = iaa.LogContrast([1, 2])
-        assert isinstance(aug.params1d[0], iap.Choice)
+        assert is_parameter_instance(aug.params1d[0], iap.Choice)
         assert np.all([val in aug.params1d[0].a for val in [1, 2]])
 
     def test_per_channel_is_float(self):
@@ -724,15 +725,15 @@ class TestLinearContrast(unittest.TestCase):
 
     def test___init___tuple_to_uniform(self):
         aug = iaa.LinearContrast((1, 2))
-        assert isinstance(aug.params1d[0], iap.Uniform)
-        assert isinstance(aug.params1d[0].a, iap.Deterministic)
-        assert isinstance(aug.params1d[0].b, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0], iap.Uniform)
+        assert is_parameter_instance(aug.params1d[0].a, iap.Deterministic)
+        assert is_parameter_instance(aug.params1d[0].b, iap.Deterministic)
         assert aug.params1d[0].a.value == 1
         assert aug.params1d[0].b.value == 2
 
     def test___init___list_to_choice(self):
         aug = iaa.LinearContrast([1, 2])
-        assert isinstance(aug.params1d[0], iap.Choice)
+        assert is_parameter_instance(aug.params1d[0], iap.Choice)
         assert np.all([val in aug.params1d[0].a for val in [1, 2]])
 
     def test_float_as_per_channel(self):
@@ -910,13 +911,14 @@ class TestAllChannelsCLAHE(unittest.TestCase):
             tile_grid_size_px=11,
             tile_grid_size_px_min=4,
             per_channel=True)
-        assert isinstance(aug.clip_limit, iap.Deterministic)
+        assert is_parameter_instance(aug.clip_limit, iap.Deterministic)
         assert aug.clip_limit.value == 10
-        assert isinstance(aug.tile_grid_size_px[0], iap.Deterministic)
+        assert is_parameter_instance(aug.tile_grid_size_px[0],
+                                     iap.Deterministic)
         assert aug.tile_grid_size_px[0].value == 11
         assert aug.tile_grid_size_px[1] is None
         assert aug.tile_grid_size_px_min == 4
-        assert isinstance(aug.per_channel, iap.Deterministic)
+        assert is_parameter_instance(aug.per_channel, iap.Deterministic)
         assert np.isclose(aug.per_channel.value, 1.0)
 
         aug = iaa.AllChannelsCLAHE(
@@ -924,35 +926,36 @@ class TestAllChannelsCLAHE(unittest.TestCase):
             tile_grid_size_px=(11, 17),
             tile_grid_size_px_min=4,
             per_channel=0.5)
-        assert isinstance(aug.clip_limit, iap.Uniform)
+        assert is_parameter_instance(aug.clip_limit, iap.Uniform)
         assert aug.clip_limit.a.value == 10
         assert aug.clip_limit.b.value == 20
-        assert isinstance(aug.tile_grid_size_px[0], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.tile_grid_size_px[0],
+                                     iap.DiscreteUniform)
         assert aug.tile_grid_size_px[0].a.value == 11
         assert aug.tile_grid_size_px[0].b.value == 17
         assert aug.tile_grid_size_px[1] is None
         assert aug.tile_grid_size_px_min == 4
-        assert isinstance(aug.per_channel, iap.Binomial)
+        assert is_parameter_instance(aug.per_channel, iap.Binomial)
         assert np.isclose(aug.per_channel.p.value, 0.5)
 
         aug = iaa.AllChannelsCLAHE(
             clip_limit=[10, 20, 30],
             tile_grid_size_px=[11, 17, 21])
-        assert isinstance(aug.clip_limit, iap.Choice)
+        assert is_parameter_instance(aug.clip_limit, iap.Choice)
         assert aug.clip_limit.a[0] == 10
         assert aug.clip_limit.a[1] == 20
         assert aug.clip_limit.a[2] == 30
-        assert isinstance(aug.tile_grid_size_px[0], iap.Choice)
+        assert is_parameter_instance(aug.tile_grid_size_px[0], iap.Choice)
         assert aug.tile_grid_size_px[0].a[0] == 11
         assert aug.tile_grid_size_px[0].a[1] == 17
         assert aug.tile_grid_size_px[0].a[2] == 21
         assert aug.tile_grid_size_px[1] is None
 
         aug = iaa.AllChannelsCLAHE(tile_grid_size_px=((11, 17), [11, 13, 15]))
-        assert isinstance(aug.tile_grid_size_px[0], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.tile_grid_size_px[0], iap.DiscreteUniform)
         assert aug.tile_grid_size_px[0].a.value == 11
         assert aug.tile_grid_size_px[0].b.value == 17
-        assert isinstance(aug.tile_grid_size_px[1], iap.Choice)
+        assert is_parameter_instance(aug.tile_grid_size_px[1], iap.Choice)
         assert aug.tile_grid_size_px[1].a[0] == 11
         assert aug.tile_grid_size_px[1].a[1] == 13
         assert aug.tile_grid_size_px[1].a[2] == 15
@@ -1250,7 +1253,7 @@ class TestAllChannelsCLAHE(unittest.TestCase):
             per_channel=True)
         params = aug.get_parameters()
         assert np.all([
-            isinstance(params[i], iap.Deterministic)
+            is_parameter_instance(params[i], iap.Deterministic)
             for i
             in [0, 3]])
         assert params[0].value == 1

--- a/test/augmenters/test_edges.py
+++ b/test/augmenters/test_edges.py
@@ -23,7 +23,8 @@ import cv2
 from imgaug import augmenters as iaa
 from imgaug import parameters as iap
 from imgaug import random as iarandom
-from imgaug.testutils import reseed, runtest_pickleable_uint8_img
+from imgaug.testutils import (reseed, runtest_pickleable_uint8_img,
+                              is_parameter_instance, remove_prefetching)
 
 
 class TestRandomColorsBinaryImageColorizer(unittest.TestCase):
@@ -32,8 +33,8 @@ class TestRandomColorsBinaryImageColorizer(unittest.TestCase):
 
     def test___init___default_settings(self):
         colorizer = iaa.RandomColorsBinaryImageColorizer()
-        assert isinstance(colorizer.color_true, iap.DiscreteUniform)
-        assert isinstance(colorizer.color_false, iap.DiscreteUniform)
+        assert is_parameter_instance(colorizer.color_true, iap.DiscreteUniform)
+        assert is_parameter_instance(colorizer.color_false, iap.DiscreteUniform)
         assert colorizer.color_true.a.value == 0
         assert colorizer.color_true.b.value == 255
         assert colorizer.color_false.a.value == 0
@@ -42,16 +43,16 @@ class TestRandomColorsBinaryImageColorizer(unittest.TestCase):
     def test___init___deterministic_settinga(self):
         colorizer = iaa.RandomColorsBinaryImageColorizer(color_true=1,
                                                          color_false=2)
-        assert isinstance(colorizer.color_true, iap.Deterministic)
-        assert isinstance(colorizer.color_false, iap.Deterministic)
+        assert is_parameter_instance(colorizer.color_true, iap.Deterministic)
+        assert is_parameter_instance(colorizer.color_false, iap.Deterministic)
         assert colorizer.color_true.value == 1
         assert colorizer.color_false.value == 2
 
     def test___init___tuple_and_list(self):
         colorizer = iaa.RandomColorsBinaryImageColorizer(
             color_true=(0, 100), color_false=[200, 201, 202])
-        assert isinstance(colorizer.color_true, iap.DiscreteUniform)
-        assert isinstance(colorizer.color_false, iap.Choice)
+        assert is_parameter_instance(colorizer.color_true, iap.DiscreteUniform)
+        assert is_parameter_instance(colorizer.color_false, iap.Choice)
         assert colorizer.color_true.a.value == 0
         assert colorizer.color_true.b.value == 100
         assert colorizer.color_false.a[0] == 200
@@ -62,8 +63,8 @@ class TestRandomColorsBinaryImageColorizer(unittest.TestCase):
         colorizer = iaa.RandomColorsBinaryImageColorizer(
             color_true=iap.DiscreteUniform(0, 100),
             color_false=iap.Choice([200, 201, 202]))
-        assert isinstance(colorizer.color_true, iap.DiscreteUniform)
-        assert isinstance(colorizer.color_false, iap.Choice)
+        assert is_parameter_instance(colorizer.color_true, iap.DiscreteUniform)
+        assert is_parameter_instance(colorizer.color_false, iap.Choice)
         assert colorizer.color_true.a.value == 0
         assert colorizer.color_true.b.value == 100
         assert colorizer.color_false.a[0] == 200
@@ -175,23 +176,27 @@ class TestRandomColorsBinaryImageColorizer(unittest.TestCase):
 class TestCanny(unittest.TestCase):
     def test___init___default_settings(self):
         aug = iaa.Canny()
-        assert isinstance(aug.alpha, iap.Uniform)
+        assert is_parameter_instance(aug.alpha, iap.Uniform)
         assert isinstance(aug.hysteresis_thresholds, tuple)
-        assert isinstance(aug.sobel_kernel_size, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.sobel_kernel_size, iap.DiscreteUniform)
         assert isinstance(aug.colorizer, iaa.RandomColorsBinaryImageColorizer)
         assert np.isclose(aug.alpha.a.value, 0.0)
         assert np.isclose(aug.alpha.b.value, 1.0)
         assert len(aug.hysteresis_thresholds) == 2
-        assert isinstance(aug.hysteresis_thresholds[0], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.hysteresis_thresholds[0],
+                                     iap.DiscreteUniform)
         assert np.isclose(aug.hysteresis_thresholds[0].a.value, 100-40)
         assert np.isclose(aug.hysteresis_thresholds[0].b.value, 100+40)
-        assert isinstance(aug.hysteresis_thresholds[1], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.hysteresis_thresholds[1],
+                                     iap.DiscreteUniform)
         assert np.isclose(aug.hysteresis_thresholds[1].a.value, 200-40)
         assert np.isclose(aug.hysteresis_thresholds[1].b.value, 200+40)
         assert aug.sobel_kernel_size.a.value == 3
         assert aug.sobel_kernel_size.b.value == 7
-        assert isinstance(aug.colorizer.color_true, iap.DiscreteUniform)
-        assert isinstance(aug.colorizer.color_false, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.colorizer.color_true,
+                                     iap.DiscreteUniform)
+        assert is_parameter_instance(aug.colorizer.color_false,
+                                     iap.DiscreteUniform)
         assert aug.colorizer.color_true.a.value == 0
         assert aug.colorizer.color_true.b.value == 255
         assert aug.colorizer.color_false.a.value == 0
@@ -205,21 +210,24 @@ class TestCanny(unittest.TestCase):
             colorizer=iaa.RandomColorsBinaryImageColorizer(
                 color_true=10, color_false=20)
         )
-        assert isinstance(aug.alpha, iap.Deterministic)
+        assert is_parameter_instance(aug.alpha, iap.Deterministic)
         assert isinstance(aug.hysteresis_thresholds, tuple)
-        assert isinstance(aug.sobel_kernel_size, iap.Choice)
+        assert is_parameter_instance(aug.sobel_kernel_size, iap.Choice)
         assert isinstance(aug.colorizer, iaa.RandomColorsBinaryImageColorizer)
         assert np.isclose(aug.alpha.value, 0.2)
         assert len(aug.hysteresis_thresholds) == 2
-        assert isinstance(aug.hysteresis_thresholds[0], iap.Choice)
+        assert is_parameter_instance(aug.hysteresis_thresholds[0], iap.Choice)
         assert aug.hysteresis_thresholds[0].a == [0, 1, 2]
-        assert isinstance(aug.hysteresis_thresholds[1], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.hysteresis_thresholds[1],
+                                     iap.DiscreteUniform)
         assert np.isclose(aug.hysteresis_thresholds[1].a.value, 1)
         assert np.isclose(aug.hysteresis_thresholds[1].b.value, 10)
-        assert isinstance(aug.sobel_kernel_size, iap.Choice)
+        assert is_parameter_instance(aug.sobel_kernel_size, iap.Choice)
         assert aug.sobel_kernel_size.a == [3, 5]
-        assert isinstance(aug.colorizer.color_true, iap.Deterministic)
-        assert isinstance(aug.colorizer.color_false, iap.Deterministic)
+        assert is_parameter_instance(aug.colorizer.color_true,
+                                     iap.Deterministic)
+        assert is_parameter_instance(aug.colorizer.color_false,
+                                     iap.Deterministic)
         assert aug.colorizer.color_true.value == 10
         assert aug.colorizer.color_false.value == 20
 
@@ -231,16 +239,18 @@ class TestCanny(unittest.TestCase):
             colorizer=iaa.RandomColorsBinaryImageColorizer(
                 color_true=10, color_false=20)
         )
-        assert isinstance(aug.alpha, iap.Deterministic)
-        assert isinstance(aug.hysteresis_thresholds, iap.Choice)
-        assert isinstance(aug.sobel_kernel_size, iap.Choice)
+        assert is_parameter_instance(aug.alpha, iap.Deterministic)
+        assert is_parameter_instance(aug.hysteresis_thresholds, iap.Choice)
+        assert is_parameter_instance(aug.sobel_kernel_size, iap.Choice)
         assert isinstance(aug.colorizer, iaa.RandomColorsBinaryImageColorizer)
         assert np.isclose(aug.alpha.value, 0.2)
         assert aug.hysteresis_thresholds.a == [0, 1, 2]
-        assert isinstance(aug.sobel_kernel_size, iap.Choice)
+        assert is_parameter_instance(aug.sobel_kernel_size, iap.Choice)
         assert aug.sobel_kernel_size.a == [3, 5]
-        assert isinstance(aug.colorizer.color_true, iap.Deterministic)
-        assert isinstance(aug.colorizer.color_false, iap.Deterministic)
+        assert is_parameter_instance(aug.colorizer.color_true,
+                                     iap.Deterministic)
+        assert is_parameter_instance(aug.colorizer.color_false,
+                                     iap.Deterministic)
         assert aug.colorizer.color_true.value == 10
         assert aug.colorizer.color_false.value == 20
 
@@ -253,6 +263,10 @@ class TestCanny(unittest.TestCase):
             hysteresis_thresholds=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             sobel_kernel_size=[3, 5, 7],
             random_state=iarandom.RNG(seed))
+        aug.alpha = remove_prefetching(aug.alpha)
+        aug.hysteresis_thresholds = remove_prefetching(
+            aug.hysteresis_thresholds)
+        aug.sobel_kernel_size = remove_prefetching(aug.sobel_kernel_size)
 
         example_image = np.zeros((5, 5, 3), dtype=np.uint8)
         samples = aug._draw_samples([example_image] * nb_images,
@@ -290,6 +304,12 @@ class TestCanny(unittest.TestCase):
                                    iap.DiscreteUniform(5, 100)),
             sobel_kernel_size=[3, 5, 7],
             random_state=iarandom.RNG(seed))
+        aug.alpha = remove_prefetching(aug.alpha)
+        aug.hysteresis_thresholds = (
+            remove_prefetching(aug.hysteresis_thresholds[0]),
+            remove_prefetching(aug.hysteresis_thresholds[1])
+        )
+        aug.sobel_kernel_size = remove_prefetching(aug.sobel_kernel_size)
 
         example_image = np.zeros((5, 5, 3), dtype=np.uint8)
         samples = aug._draw_samples([example_image] * nb_images,
@@ -630,9 +650,9 @@ class TestCanny(unittest.TestCase):
             colorizer=colorizer
         )
         params = aug.get_parameters()
-        assert params[0] is alpha
-        assert params[1] is hysteresis_thresholds
-        assert params[2] is sobel_kernel_size
+        assert params[0] is aug.alpha
+        assert params[1] is aug.hysteresis_thresholds
+        assert params[2] is aug.sobel_kernel_size
         assert params[3] is colorizer
 
     def test___str___single_value_hysteresis(self):
@@ -651,7 +671,9 @@ class TestCanny(unittest.TestCase):
         expected = ("Canny(alpha=%s, hysteresis_thresholds=%s, "
                     "sobel_kernel_size=%s, colorizer=%s, name=UnnamedCanny, "
                     "deterministic=False)") % (
-                        alpha, hysteresis_thresholds, sobel_kernel_size,
+                        str(aug.alpha),
+                        str(aug.hysteresis_thresholds),
+                        str(aug.sobel_kernel_size),
                         colorizer)
         assert observed == expected
 
@@ -674,9 +696,11 @@ class TestCanny(unittest.TestCase):
         expected = ("Canny(alpha=%s, hysteresis_thresholds=(%s, %s), "
                     "sobel_kernel_size=%s, colorizer=%s, name=UnnamedCanny, "
                     "deterministic=False)") % (
-                        alpha,
-                        hysteresis_thresholds[0], hysteresis_thresholds[1],
-                        sobel_kernel_size, colorizer)
+                        str(aug.alpha),
+                        str(aug.hysteresis_thresholds[0]),
+                        str(aug.hysteresis_thresholds[1]),
+                        str(aug.sobel_kernel_size),
+                        colorizer)
         assert observed == expected
 
     def test_pickleable(self):

--- a/test/augmenters/test_flip.py
+++ b/test/augmenters/test_flip.py
@@ -22,7 +22,8 @@ from imgaug import augmenters as iaa
 from imgaug import parameters as iap
 from imgaug import dtypes as iadt
 from imgaug.testutils import (reseed, assert_cbaois_equal,
-                              runtest_pickleable_uint8_img)
+                              runtest_pickleable_uint8_img,
+                              is_parameter_instance)
 from imgaug.augmentables.heatmaps import HeatmapsOnImage
 from imgaug.augmentables.segmaps import SegmentationMapsOnImage
 import imgaug.augmenters.flip as fliplib
@@ -439,8 +440,8 @@ class _TestFliplrAndFlipudBase(object):
     def test_get_parameters(self):
         aug = self.create_aug(p=0.5)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Binomial)
-        assert isinstance(params[0].p, iap.Deterministic)
+        assert is_parameter_instance(params[0], iap.Binomial)
+        assert is_parameter_instance(params[0].p, iap.Deterministic)
         assert 0.5 - 1e-4 < params[0].p.value < 0.5 + 1e-4
 
     def test_other_dtypes_bool(self):

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -26,7 +26,7 @@ from imgaug import parameters as iap
 from imgaug import dtypes as iadt
 from imgaug.testutils import (
     array_equal_lists, keypoints_equal, reseed, assert_cbaois_equal,
-    runtest_pickleable_uint8_img, assertWarns)
+    runtest_pickleable_uint8_img, assertWarns, is_parameter_instance)
 from imgaug.augmentables.heatmaps import HeatmapsOnImage
 from imgaug.augmentables.segmaps import SegmentationMapsOnImage
 import imgaug.augmenters.geometric as geometriclib
@@ -52,10 +52,10 @@ class TestAffine(unittest.TestCase):
 
         params = aug.get_parameters()
 
-        assert isinstance(params[0], iap.Deterministic)  # scale
+        assert is_parameter_instance(params[0], iap.Deterministic)  # scale
         assert isinstance(params[1], tuple)  # translate
-        assert isinstance(params[2], iap.Deterministic)  # rotate
-        assert isinstance(params[3], iap.Deterministic)  # shear
+        assert is_parameter_instance(params[2], iap.Deterministic)  # rotate
+        assert is_parameter_instance(params[3], iap.Deterministic)  # shear
         assert params[0].value == 1  # scale
         assert params[1][0].value == 2  # translate
         assert params[2].value == 3  # rotate
@@ -71,9 +71,9 @@ class TestAffine___init__(unittest.TestCase):
     def test___init___scale_is_stochastic_parameter(self):
         aug = iaa.Affine(scale=iap.Uniform(0.7, 0.9))
 
-        assert isinstance(aug.scale, iap.Uniform)
-        assert isinstance(aug.scale.a, iap.Deterministic)
-        assert isinstance(aug.scale.b, iap.Deterministic)
+        assert is_parameter_instance(aug.scale, iap.Uniform)
+        assert is_parameter_instance(aug.scale.a, iap.Deterministic)
+        assert is_parameter_instance(aug.scale.b, iap.Deterministic)
         assert 0.7 - 1e-8 < aug.scale.a.value < 0.7 + 1e-8
         assert 0.9 - 1e-8 < aug.scale.b.value < 0.9 + 1e-8
 
@@ -81,9 +81,9 @@ class TestAffine___init__(unittest.TestCase):
         aug = iaa.Affine(translate_percent=iap.Uniform(0.7, 0.9))
 
         assert isinstance(aug.translate, tuple)
-        assert isinstance(aug.translate[0], iap.Uniform)
-        assert isinstance(aug.translate[0].a, iap.Deterministic)
-        assert isinstance(aug.translate[0].b, iap.Deterministic)
+        assert is_parameter_instance(aug.translate[0], iap.Uniform)
+        assert is_parameter_instance(aug.translate[0].a, iap.Deterministic)
+        assert is_parameter_instance(aug.translate[0].b, iap.Deterministic)
         assert 0.7 - 1e-8 < aug.translate[0].a.value < 0.7 + 1e-8
         assert 0.9 - 1e-8 < aug.translate[0].b.value < 0.9 + 1e-8
         assert aug.translate[1] is None
@@ -93,9 +93,9 @@ class TestAffine___init__(unittest.TestCase):
         aug = iaa.Affine(translate_px=iap.DiscreteUniform(1, 10))
 
         assert isinstance(aug.translate, tuple)
-        assert isinstance(aug.translate[0], iap.DiscreteUniform)
-        assert isinstance(aug.translate[0].a, iap.Deterministic)
-        assert isinstance(aug.translate[0].b, iap.Deterministic)
+        assert is_parameter_instance(aug.translate[0], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.translate[0].a, iap.Deterministic)
+        assert is_parameter_instance(aug.translate[0].b, iap.Deterministic)
         assert aug.translate[0].a.value == 1
         assert aug.translate[0].b.value == 10
         assert aug.translate[1] is None
@@ -105,29 +105,29 @@ class TestAffine___init__(unittest.TestCase):
         aug = iaa.Affine(scale=1.0, translate_px=0, rotate=iap.Uniform(10, 20),
                          shear=0)
 
-        assert isinstance(aug.rotate, iap.Uniform)
-        assert isinstance(aug.rotate.a, iap.Deterministic)
+        assert is_parameter_instance(aug.rotate, iap.Uniform)
+        assert is_parameter_instance(aug.rotate.a, iap.Deterministic)
         assert aug.rotate.a.value == 10
-        assert isinstance(aug.rotate.b, iap.Deterministic)
+        assert is_parameter_instance(aug.rotate.b, iap.Deterministic)
         assert aug.rotate.b.value == 20
 
     def test___init___shear_is_stochastic_parameter(self):
         aug = iaa.Affine(scale=1.0, translate_px=0, rotate=0,
                          shear=iap.Uniform(10, 20))
 
-        assert isinstance(aug.shear, iap.Uniform)
-        assert isinstance(aug.shear.a, iap.Deterministic)
+        assert is_parameter_instance(aug.shear, iap.Uniform)
+        assert is_parameter_instance(aug.shear.a, iap.Deterministic)
         assert aug.shear.a.value == 10
-        assert isinstance(aug.shear.b, iap.Deterministic)
+        assert is_parameter_instance(aug.shear.b, iap.Deterministic)
         assert aug.shear.b.value == 20
 
     def test___init___cval_is_all(self):
         aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
                          cval=ia.ALL)
 
-        assert isinstance(aug.cval, iap.Uniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.Uniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 0
         assert aug.cval.b.value == 255
 
@@ -135,27 +135,27 @@ class TestAffine___init__(unittest.TestCase):
         aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
                          cval=iap.DiscreteUniform(1, 5))
 
-        assert isinstance(aug.cval, iap.DiscreteUniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 1
         assert aug.cval.b.value == 5
 
     def test___init___mode_is_all(self):
         aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
                          cval=0, mode=ia.ALL)
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
 
     def test___init___mode_is_string(self):
         aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
                          cval=0, mode="edge")
-        assert isinstance(aug.mode, iap.Deterministic)
+        assert is_parameter_instance(aug.mode, iap.Deterministic)
         assert aug.mode.value == "edge"
 
     def test___init___mode_is_list(self):
         aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
                          cval=0, mode=["constant", "edge"])
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert (
             len(aug.mode.a) == 2
             and "constant" in aug.mode.a
@@ -164,7 +164,7 @@ class TestAffine___init__(unittest.TestCase):
     def test___init___mode_is_stochastic_parameter(self):
         aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
                          cval=0, mode=iap.Choice(["constant", "edge"]))
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert (
             len(aug.mode.a) == 2
             and "constant" in aug.mode.a
@@ -3603,9 +3603,9 @@ def test_AffineCv2():
         assert nb_changed_aug_det == 0
 
         aug = iaa.AffineCv2(scale=iap.Uniform(0.7, 0.9))
-        assert isinstance(aug.scale, iap.Uniform)
-        assert isinstance(aug.scale.a, iap.Deterministic)
-        assert isinstance(aug.scale.b, iap.Deterministic)
+        assert is_parameter_instance(aug.scale, iap.Uniform)
+        assert is_parameter_instance(aug.scale.a, iap.Deterministic)
+        assert is_parameter_instance(aug.scale.b, iap.Deterministic)
         assert 0.7 - 1e-8 < aug.scale.a.value < 0.7 + 1e-8
         assert 0.9 - 1e-8 < aug.scale.b.value < 0.9 + 1e-8
 
@@ -3826,16 +3826,16 @@ def test_AffineCv2():
         assert (centers_aug < int(nb_iterations * (1/9 * 1.4))).all()
 
         aug = iaa.AffineCv2(translate_percent=iap.Uniform(0.7, 0.9))
-        assert isinstance(aug.translate, iap.Uniform)
-        assert isinstance(aug.translate.a, iap.Deterministic)
-        assert isinstance(aug.translate.b, iap.Deterministic)
+        assert is_parameter_instance(aug.translate, iap.Uniform)
+        assert is_parameter_instance(aug.translate.a, iap.Deterministic)
+        assert is_parameter_instance(aug.translate.b, iap.Deterministic)
         assert 0.7 - 1e-8 < aug.translate.a.value < 0.7 + 1e-8
         assert 0.9 - 1e-8 < aug.translate.b.value < 0.9 + 1e-8
 
         aug = iaa.AffineCv2(translate_px=iap.DiscreteUniform(1, 10))
-        assert isinstance(aug.translate, iap.DiscreteUniform)
-        assert isinstance(aug.translate.a, iap.Deterministic)
-        assert isinstance(aug.translate.b, iap.Deterministic)
+        assert is_parameter_instance(aug.translate, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.translate.a, iap.Deterministic)
+        assert is_parameter_instance(aug.translate.b, iap.Deterministic)
         assert aug.translate.a.value == 1
         assert aug.translate.b.value == 10
 
@@ -3968,10 +3968,10 @@ def test_AffineCv2():
         # rotate by StochasticParameter
         aug = iaa.AffineCv2(scale=1.0, translate_px=0,
                             rotate=iap.Uniform(10, 20), shear=0)
-        assert isinstance(aug.rotate, iap.Uniform)
-        assert isinstance(aug.rotate.a, iap.Deterministic)
+        assert is_parameter_instance(aug.rotate, iap.Uniform)
+        assert is_parameter_instance(aug.rotate.a, iap.Deterministic)
         assert aug.rotate.a.value == 10
-        assert isinstance(aug.rotate.b, iap.Deterministic)
+        assert is_parameter_instance(aug.rotate.b, iap.Deterministic)
         assert aug.rotate.b.value == 20
 
         # random rotation 0-364 degrees
@@ -4027,10 +4027,10 @@ def test_AffineCv2():
         # shear by StochasticParameter
         aug = iaa.AffineCv2(scale=1.0, translate_px=0, rotate=0,
                             shear=iap.Uniform(10, 20))
-        assert isinstance(aug.shear, iap.Uniform)
-        assert isinstance(aug.shear.a, iap.Deterministic)
+        assert is_parameter_instance(aug.shear, iap.Uniform)
+        assert is_parameter_instance(aug.shear.a, iap.Deterministic)
         assert aug.shear.a.value == 10
-        assert isinstance(aug.shear.b, iap.Deterministic)
+        assert is_parameter_instance(aug.shear.b, iap.Deterministic)
         assert aug.shear.b.value == 20
 
         # ---------------------
@@ -4096,17 +4096,17 @@ def test_AffineCv2():
 
         aug = iaa.AffineCv2(scale=1.0, translate_px=100, rotate=0, shear=0,
                             cval=ia.ALL)
-        assert isinstance(aug.cval, iap.DiscreteUniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 0
         assert aug.cval.b.value == 255
 
         aug = iaa.AffineCv2(scale=1.0, translate_px=100, rotate=0, shear=0,
                             cval=iap.DiscreteUniform(1, 5))
-        assert isinstance(aug.cval, iap.DiscreteUniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 1
         assert aug.cval.b.value == 5
 
@@ -4115,14 +4115,14 @@ def test_AffineCv2():
         # ------------
         aug = iaa.AffineCv2(scale=1.0, translate_px=100, rotate=0, shear=0,
                             cval=0, mode=ia.ALL)
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         aug = iaa.AffineCv2(scale=1.0, translate_px=100, rotate=0, shear=0,
                             cval=0, mode="replicate")
-        assert isinstance(aug.mode, iap.Deterministic)
+        assert is_parameter_instance(aug.mode, iap.Deterministic)
         assert aug.mode.value == "replicate"
         aug = iaa.AffineCv2(scale=1.0, translate_px=100, rotate=0, shear=0,
                             cval=0, mode=["replicate", "reflect"])
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert (
             len(aug.mode.a) == 2
             and "replicate" in aug.mode.a
@@ -4130,7 +4130,7 @@ def test_AffineCv2():
         aug = iaa.AffineCv2(scale=1.0, translate_px=100, rotate=0, shear=0,
                             cval=0,
                             mode=iap.Choice(["replicate", "reflect"]))
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert (
             len(aug.mode.a) == 2
             and "replicate" in aug.mode.a
@@ -4221,10 +4221,10 @@ def test_AffineCv2():
         aug = iaa.AffineCv2(scale=1, translate_px=2, rotate=3, shear=4,
                             order=1, cval=0, mode="constant")
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)  # scale
-        assert isinstance(params[1], iap.Deterministic)  # translate
-        assert isinstance(params[2], iap.Deterministic)  # rotate
-        assert isinstance(params[3], iap.Deterministic)  # shear
+        assert is_parameter_instance(params[0], iap.Deterministic)  # scale
+        assert is_parameter_instance(params[1], iap.Deterministic)  # translate
+        assert is_parameter_instance(params[2], iap.Deterministic)  # rotate
+        assert is_parameter_instance(params[3], iap.Deterministic)  # shear
         assert params[0].value == 1  # scale
         assert params[1].value == 2  # translate
         assert params[2].value == 3  # rotate
@@ -4265,16 +4265,16 @@ class TestPiecewiseAffine(unittest.TestCase):
     def test___init___scale_is_list(self):
         # scale as list
         aug = iaa.PiecewiseAffine(scale=[0.01, 0.10], nb_rows=12, nb_cols=4)
-        assert isinstance(aug.scale, iap.Choice)
+        assert is_parameter_instance(aug.scale, iap.Choice)
         assert 0.01 - 1e-8 < aug.scale.a[0] < 0.01 + 1e-8
         assert 0.10 - 1e-8 < aug.scale.a[1] < 0.10 + 1e-8
 
     def test___init___scale_is_tuple(self):
         # scale as tuple
         aug = iaa.PiecewiseAffine(scale=(0.01, 0.10), nb_rows=12, nb_cols=4)
-        assert isinstance(aug.jitter.scale, iap.Uniform)
-        assert isinstance(aug.jitter.scale.a, iap.Deterministic)
-        assert isinstance(aug.jitter.scale.b, iap.Deterministic)
+        assert is_parameter_instance(aug.jitter.scale, iap.Uniform)
+        assert is_parameter_instance(aug.jitter.scale.a, iap.Deterministic)
+        assert is_parameter_instance(aug.jitter.scale.b, iap.Deterministic)
         assert 0.01 - 1e-8 < aug.jitter.scale.a.value < 0.01 + 1e-8
         assert 0.10 - 1e-8 < aug.jitter.scale.b.value < 0.10 + 1e-8
 
@@ -4282,9 +4282,9 @@ class TestPiecewiseAffine(unittest.TestCase):
         # scale as StochasticParameter
         aug = iaa.PiecewiseAffine(scale=iap.Uniform(0.01, 0.10), nb_rows=12,
                                   nb_cols=4)
-        assert isinstance(aug.jitter.scale, iap.Uniform)
-        assert isinstance(aug.jitter.scale.a, iap.Deterministic)
-        assert isinstance(aug.jitter.scale.b, iap.Deterministic)
+        assert is_parameter_instance(aug.jitter.scale, iap.Uniform)
+        assert is_parameter_instance(aug.jitter.scale.a, iap.Deterministic)
+        assert is_parameter_instance(aug.jitter.scale.b, iap.Deterministic)
         assert 0.01 - 1e-8 < aug.jitter.scale.a.value < 0.01 + 1e-8
         assert 0.10 - 1e-8 < aug.jitter.scale.b.value < 0.10 + 1e-8
 
@@ -4301,16 +4301,16 @@ class TestPiecewiseAffine(unittest.TestCase):
     def test___init___nb_rows_is_list(self):
         # rows as list
         aug = iaa.PiecewiseAffine(scale=0.05, nb_rows=[4, 20], nb_cols=4)
-        assert isinstance(aug.nb_rows, iap.Choice)
+        assert is_parameter_instance(aug.nb_rows, iap.Choice)
         assert aug.nb_rows.a[0] == 4
         assert aug.nb_rows.a[1] == 20
 
     def test___init___nb_rows_is_tuple(self):
         # rows as tuple
         aug = iaa.PiecewiseAffine(scale=0.05, nb_rows=(4, 20), nb_cols=4)
-        assert isinstance(aug.nb_rows, iap.DiscreteUniform)
-        assert isinstance(aug.nb_rows.a, iap.Deterministic)
-        assert isinstance(aug.nb_rows.b, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_rows, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.nb_rows.a, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_rows.b, iap.Deterministic)
         assert aug.nb_rows.a.value == 4
         assert aug.nb_rows.b.value == 20
 
@@ -4318,9 +4318,9 @@ class TestPiecewiseAffine(unittest.TestCase):
         # rows as StochasticParameter
         aug = iaa.PiecewiseAffine(scale=0.05, nb_rows=iap.DiscreteUniform(4, 20),
                                   nb_cols=4)
-        assert isinstance(aug.nb_rows, iap.DiscreteUniform)
-        assert isinstance(aug.nb_rows.a, iap.Deterministic)
-        assert isinstance(aug.nb_rows.b, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_rows, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.nb_rows.a, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_rows.b, iap.Deterministic)
         assert aug.nb_rows.a.value == 4
         assert aug.nb_rows.b.value == 20
 
@@ -4336,16 +4336,16 @@ class TestPiecewiseAffine(unittest.TestCase):
 
     def test___init___nb_cols_is_list(self):
         aug = iaa.PiecewiseAffine(scale=0.05, nb_rows=4, nb_cols=[4, 20])
-        assert isinstance(aug.nb_cols, iap.Choice)
+        assert is_parameter_instance(aug.nb_cols, iap.Choice)
         assert aug.nb_cols.a[0] == 4
         assert aug.nb_cols.a[1] == 20
 
     def test___init___nb_cols_is_tuple(self):
         # cols as tuple
         aug = iaa.PiecewiseAffine(scale=0.05, nb_rows=4, nb_cols=(4, 20))
-        assert isinstance(aug.nb_cols, iap.DiscreteUniform)
-        assert isinstance(aug.nb_cols.a, iap.Deterministic)
-        assert isinstance(aug.nb_cols.b, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_cols, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.nb_cols.a, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_cols.b, iap.Deterministic)
         assert aug.nb_cols.a.value == 4
         assert aug.nb_cols.b.value == 20
 
@@ -4353,9 +4353,9 @@ class TestPiecewiseAffine(unittest.TestCase):
         # cols as StochasticParameter
         aug = iaa.PiecewiseAffine(scale=0.05, nb_rows=4,
                                   nb_cols=iap.DiscreteUniform(4, 20))
-        assert isinstance(aug.nb_cols, iap.DiscreteUniform)
-        assert isinstance(aug.nb_cols.a, iap.Deterministic)
-        assert isinstance(aug.nb_cols.b, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_cols, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.nb_cols.a, iap.Deterministic)
+        assert is_parameter_instance(aug.nb_cols.b, iap.Deterministic)
         assert aug.nb_cols.a.value == 4
         assert aug.nb_cols.b.value == 20
 
@@ -4372,28 +4372,28 @@ class TestPiecewiseAffine(unittest.TestCase):
     def test___init___order_is_int(self):
         # single int for order
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8, order=0)
-        assert isinstance(aug.order, iap.Deterministic)
+        assert is_parameter_instance(aug.order, iap.Deterministic)
         assert aug.order.value == 0
 
     def test___init___order_is_list(self):
         # list for order
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   order=[0, 1, 3])
-        assert isinstance(aug.order, iap.Choice)
+        assert is_parameter_instance(aug.order, iap.Choice)
         assert all([v in aug.order.a for v in [0, 1, 3]])
 
     def test___init___order_is_stochastic_parameter(self):
         # StochasticParameter for order
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   order=iap.Choice([0, 1, 3]))
-        assert isinstance(aug.order, iap.Choice)
+        assert is_parameter_instance(aug.order, iap.Choice)
         assert all([v in aug.order.a for v in [0, 1, 3]])
 
     def test___init___order_is_all(self):
         # ALL for order
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   order=ia.ALL)
-        assert isinstance(aug.order, iap.Choice)
+        assert is_parameter_instance(aug.order, iap.Choice)
         assert all([v in aug.order.a for v in [0, 1, 3, 4, 5]])
 
     def test___init___bad_datatype_for_order_leads_to_failure(self):
@@ -4411,7 +4411,7 @@ class TestPiecewiseAffine(unittest.TestCase):
         # cval as list
         aug = iaa.PiecewiseAffine(scale=0.7, nb_rows=5, nb_cols=5,
                                   mode="constant", cval=[0, 10])
-        assert isinstance(aug.cval, iap.Choice)
+        assert is_parameter_instance(aug.cval, iap.Choice)
         assert aug.cval.a[0] == 0
         assert aug.cval.a[1] == 10
 
@@ -4419,9 +4419,9 @@ class TestPiecewiseAffine(unittest.TestCase):
         # cval as tuple
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   mode="constant", cval=(0, 10))
-        assert isinstance(aug.cval, iap.Uniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.Uniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 0
         assert aug.cval.b.value == 10
 
@@ -4430,9 +4430,9 @@ class TestPiecewiseAffine(unittest.TestCase):
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   mode="constant",
                                   cval=iap.DiscreteUniform(0, 10))
-        assert isinstance(aug.cval, iap.DiscreteUniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.DiscreteUniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 0
         assert aug.cval.b.value == 10
 
@@ -4440,9 +4440,9 @@ class TestPiecewiseAffine(unittest.TestCase):
         # ALL as cval
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   mode="constant", cval=ia.ALL)
-        assert isinstance(aug.cval, iap.Uniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.Uniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 0
         assert aug.cval.b.value == 255
 
@@ -4460,14 +4460,14 @@ class TestPiecewiseAffine(unittest.TestCase):
         # single string for mode
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   mode="nearest")
-        assert isinstance(aug.mode, iap.Deterministic)
+        assert is_parameter_instance(aug.mode, iap.Deterministic)
         assert aug.mode.value == "nearest"
 
     def test___init___mode_is_list(self):
         # list for mode
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8,
                                   mode=["nearest", "edge", "symmetric"])
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert all([
             v in aug.mode.a for v in ["nearest", "edge", "symmetric"]
         ])
@@ -4477,7 +4477,7 @@ class TestPiecewiseAffine(unittest.TestCase):
         aug = iaa.PiecewiseAffine(
             scale=0.1, nb_rows=8, nb_cols=8,
             mode=iap.Choice(["nearest", "edge", "symmetric"]))
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert all([
             v in aug.mode.a for v in ["nearest", "edge", "symmetric"]
         ])
@@ -4485,7 +4485,7 @@ class TestPiecewiseAffine(unittest.TestCase):
     def test___init___mode_is_all(self):
         # ALL for mode
         aug = iaa.PiecewiseAffine(scale=0.1, nb_rows=8, nb_cols=8, mode=ia.ALL)
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert all([
             v in aug.mode.a
             for v
@@ -4863,17 +4863,19 @@ class TestPiecewiseAffine(unittest.TestCase):
 
     def test_scale_alignment_between_images_and_keypoints(self):
         # strong scale, measure alignment between images and keypoints
-        aug = iaa.PiecewiseAffine(scale=0.10, nb_rows=12, nb_cols=4)
+        # fairly large scale here, as otherwise keypoints can end up
+        # outside of the image plane
+        aug = iaa.PiecewiseAffine(scale=0.05, nb_rows=12, nb_cols=4)
         aug_det = aug.to_deterministic()
-        kps = [ia.Keypoint(x=5, y=15), ia.Keypoint(x=17, y=12)]
-        kpsoi = ia.KeypointsOnImage(kps, shape=(24, 30, 3))
-        img_kps = np.zeros((24, 30, 3), dtype=np.uint8)
+        kps = [ia.Keypoint(x=160, y=110), ia.Keypoint(x=140, y=90)]
+        kpsoi = ia.KeypointsOnImage(kps, shape=(200, 300, 3))
+        img_kps = np.zeros((200, 300, 3), dtype=np.uint8)
         img_kps = kpsoi.draw_on_image(img_kps, color=[255, 255, 255])
 
         img_kps_aug = aug_det.augment_image(img_kps)
         kpsoi_aug = aug_det.augment_keypoints([kpsoi])[0]
 
-        assert kpsoi_aug.shape == (24, 30, 3)
+        assert kpsoi_aug.shape == (200, 300, 3)
         bb1 = ia.BoundingBox(
             x1=kpsoi_aug.keypoints[0].x-1, y1=kpsoi_aug.keypoints[0].y-1,
             x2=kpsoi_aug.keypoints[0].x+1, y2=kpsoi_aug.keypoints[0].y+1)
@@ -5313,12 +5315,12 @@ class TestPiecewiseAffine(unittest.TestCase):
                                   cval=2, mode="constant",
                                   absolute_scale=False)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
-        assert isinstance(params[2], iap.Deterministic)
-        assert isinstance(params[3], iap.Deterministic)
-        assert isinstance(params[4], iap.Deterministic)
-        assert isinstance(params[5], iap.Deterministic)
+        assert params[0] is aug.jitter.scale
+        assert params[1] is aug.nb_rows
+        assert params[2] is aug.nb_cols
+        assert params[3] is aug.order
+        assert params[4] is aug.cval
+        assert params[5] is aug.mode
         assert params[6] is False
         assert 0.1 - 1e-8 < params[0].value < 0.1 + 1e-8
         assert params[1].value == 8
@@ -5443,16 +5445,16 @@ class TestPerspectiveTransform(unittest.TestCase):
     def test___init___scale_is_tuple(self):
         # tuple for scale
         aug = iaa.PerspectiveTransform(scale=(0.1, 0.2))
-        assert isinstance(aug.jitter.scale, iap.Uniform)
-        assert isinstance(aug.jitter.scale.a, iap.Deterministic)
-        assert isinstance(aug.jitter.scale.b, iap.Deterministic)
+        assert is_parameter_instance(aug.jitter.scale, iap.Uniform)
+        assert is_parameter_instance(aug.jitter.scale.a, iap.Deterministic)
+        assert is_parameter_instance(aug.jitter.scale.b, iap.Deterministic)
         assert 0.1 - 1e-8 < aug.jitter.scale.a.value < 0.1 + 1e-8
         assert 0.2 - 1e-8 < aug.jitter.scale.b.value < 0.2 + 1e-8
 
     def test___init___scale_is_list(self):
         # list for scale
         aug = iaa.PerspectiveTransform(scale=[0.1, 0.2, 0.3])
-        assert isinstance(aug.jitter.scale, iap.Choice)
+        assert is_parameter_instance(aug.jitter.scale, iap.Choice)
         assert len(aug.jitter.scale.a) == 3
         assert 0.1 - 1e-8 < aug.jitter.scale.a[0] < 0.1 + 1e-8
         assert 0.2 - 1e-8 < aug.jitter.scale.a[1] < 0.2 + 1e-8
@@ -5461,7 +5463,7 @@ class TestPerspectiveTransform(unittest.TestCase):
     def test___init___scale_is_stochastic_parameter(self):
         # StochasticParameter for scale
         aug = iaa.PerspectiveTransform(scale=iap.Choice([0.1, 0.2, 0.3]))
-        assert isinstance(aug.jitter.scale, iap.Choice)
+        assert is_parameter_instance(aug.jitter.scale, iap.Choice)
         assert len(aug.jitter.scale.a) == 3
         assert 0.1 - 1e-8 < aug.jitter.scale.a[0] < 0.1 + 1e-8
         assert 0.2 - 1e-8 < aug.jitter.scale.a[1] < 0.2 + 1e-8
@@ -5479,16 +5481,16 @@ class TestPerspectiveTransform(unittest.TestCase):
 
     def test___init___mode_is_all(self):
         aug = iaa.PerspectiveTransform(cval=0, mode=ia.ALL)
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
 
     def test___init___mode_is_string(self):
         aug = iaa.PerspectiveTransform(cval=0, mode="replicate")
-        assert isinstance(aug.mode, iap.Deterministic)
+        assert is_parameter_instance(aug.mode, iap.Deterministic)
         assert aug.mode.value == "replicate"
 
     def test___init___mode_is_list(self):
         aug = iaa.PerspectiveTransform(cval=0, mode=["replicate", "constant"])
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert (
             len(aug.mode.a) == 2
             and "replicate" in aug.mode.a
@@ -5497,7 +5499,7 @@ class TestPerspectiveTransform(unittest.TestCase):
     def test___init___mode_is_stochastic_parameter(self):
         aug = iaa.PerspectiveTransform(
             cval=0, mode=iap.Choice(["replicate", "constant"]))
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert (
             len(aug.mode.a) == 2
             and "replicate" in aug.mode.a
@@ -6523,8 +6525,8 @@ class TestPerspectiveTransform(unittest.TestCase):
     def test_get_parameters(self):
         aug = iaa.PerspectiveTransform(scale=0.1, keep_size=False)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Normal)
-        assert isinstance(params[0].scale, iap.Deterministic)
+        assert is_parameter_instance(params[0], iap.Normal)
+        assert is_parameter_instance(params[0].scale, iap.Deterministic)
         assert 0.1 - 1e-8 < params[0].scale.value < 0.1 + 1e-8
         assert params[1] is False
         assert params[2].value == 0
@@ -6700,18 +6702,18 @@ class TestElasticTransformation(unittest.TestCase):
     def test___init___alpha_is_tuple(self):
         # test alpha being tuple
         aug = iaa.ElasticTransformation(alpha=(1.0, 2.0), sigma=0.25)
-        assert isinstance(aug.alpha, iap.Uniform)
-        assert isinstance(aug.alpha.a, iap.Deterministic)
-        assert isinstance(aug.alpha.b, iap.Deterministic)
+        assert is_parameter_instance(aug.alpha, iap.Uniform)
+        assert is_parameter_instance(aug.alpha.a, iap.Deterministic)
+        assert is_parameter_instance(aug.alpha.b, iap.Deterministic)
         assert 1.0 - 1e-8 < aug.alpha.a.value < 1.0 + 1e-8
         assert 2.0 - 1e-8 < aug.alpha.b.value < 2.0 + 1e-8
 
     def test___init___sigma_is_tuple(self):
         # test sigma being tuple
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=(1.0, 2.0))
-        assert isinstance(aug.sigma, iap.Uniform)
-        assert isinstance(aug.sigma.a, iap.Deterministic)
-        assert isinstance(aug.sigma.b, iap.Deterministic)
+        assert is_parameter_instance(aug.sigma, iap.Uniform)
+        assert is_parameter_instance(aug.sigma.a, iap.Deterministic)
+        assert is_parameter_instance(aug.sigma.b, iap.Deterministic)
         assert 1.0 - 1e-8 < aug.sigma.a.value < 1.0 + 1e-8
         assert 2.0 - 1e-8 < aug.sigma.b.value < 2.0 + 1e-8
 
@@ -6727,23 +6729,23 @@ class TestElasticTransformation(unittest.TestCase):
 
     def test___init___order_is_all(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, order=ia.ALL)
-        assert isinstance(aug.order, iap.Choice)
+        assert is_parameter_instance(aug.order, iap.Choice)
         assert all([order in aug.order.a for order in [0, 1, 2, 3, 4, 5]])
 
     def test___init___order_is_int(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, order=1)
-        assert isinstance(aug.order, iap.Deterministic)
+        assert is_parameter_instance(aug.order, iap.Deterministic)
         assert aug.order.value == 1
 
     def test___init___order_is_list(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, order=[0, 1, 2])
-        assert isinstance(aug.order, iap.Choice)
+        assert is_parameter_instance(aug.order, iap.Choice)
         assert all([order in aug.order.a for order in [0, 1, 2]])
 
     def test___init___order_is_stochastic_parameter(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0,
                                         order=iap.Choice([0, 1, 2, 3]))
-        assert isinstance(aug.order, iap.Choice)
+        assert is_parameter_instance(aug.order, iap.Choice)
         assert all([order in aug.order.a for order in [0, 1, 2, 3]])
 
     def test___init___bad_datatype_for_order_leads_to_failure(self):
@@ -6757,34 +6759,34 @@ class TestElasticTransformation(unittest.TestCase):
 
     def test___init___cval_is_all(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, cval=ia.ALL)
-        assert isinstance(aug.cval, iap.Uniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.Uniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 0
         assert aug.cval.b.value == 255
 
     def test___init___cval_is_int(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, cval=128)
-        assert isinstance(aug.cval, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.Deterministic)
         assert aug.cval.value == 128
 
     def test___init___cval_is_list(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0,
                                         cval=[16, 32, 64])
-        assert isinstance(aug.cval, iap.Choice)
+        assert is_parameter_instance(aug.cval, iap.Choice)
         assert all([cval in aug.cval.a for cval in [16, 32, 64]])
 
     def test___init___cval_is_stochastic_parameter(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0,
                                         cval=iap.Choice([16, 32, 64]))
-        assert isinstance(aug.cval, iap.Choice)
+        assert is_parameter_instance(aug.cval, iap.Choice)
         assert all([cval in aug.cval.a for cval in [16, 32, 64]])
 
     def test___init___cval_is_tuple(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, cval=(128, 255))
-        assert isinstance(aug.cval, iap.Uniform)
-        assert isinstance(aug.cval.a, iap.Deterministic)
-        assert isinstance(aug.cval.b, iap.Deterministic)
+        assert is_parameter_instance(aug.cval, iap.Uniform)
+        assert is_parameter_instance(aug.cval.a, iap.Deterministic)
+        assert is_parameter_instance(aug.cval.b, iap.Deterministic)
         assert aug.cval.a.value == 128
         assert aug.cval.b.value == 255
 
@@ -6799,7 +6801,7 @@ class TestElasticTransformation(unittest.TestCase):
 
     def test___init___mode_is_all(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, mode=ia.ALL)
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert all([
             mode in aug.mode.a
             for mode
@@ -6807,19 +6809,19 @@ class TestElasticTransformation(unittest.TestCase):
 
     def test___init___mode_is_string(self):
         aug = iaa.ElasticTransformation(alpha=0.25, sigma=1.0, mode="nearest")
-        assert isinstance(aug.mode, iap.Deterministic)
+        assert is_parameter_instance(aug.mode, iap.Deterministic)
         assert aug.mode.value == "nearest"
 
     def test___init___mode_is_list(self):
         aug = iaa.ElasticTransformation(
             alpha=0.25, sigma=1.0, mode=["constant", "nearest"])
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert all([mode in aug.mode.a for mode in ["constant", "nearest"]])
 
     def test___init___mode_is_stochastic_parameter(self):
         aug = iaa.ElasticTransformation(
             alpha=0.25, sigma=1.0, mode=iap.Choice(["constant", "nearest"]))
-        assert isinstance(aug.mode, iap.Choice)
+        assert is_parameter_instance(aug.mode, iap.Choice)
         assert all([mode in aug.mode.a for mode in ["constant", "nearest"]])
 
     def test___init___bad_datatype_for_mode_leads_to_failure(self):
@@ -7654,11 +7656,11 @@ class TestElasticTransformation(unittest.TestCase):
         aug = iaa.ElasticTransformation(
             alpha=0.25, sigma=1.0, order=2, cval=10, mode="constant")
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
-        assert isinstance(params[2], iap.Deterministic)
-        assert isinstance(params[3], iap.Deterministic)
-        assert isinstance(params[4], iap.Deterministic)
+        assert params[0] is aug.alpha
+        assert params[1] is aug.sigma
+        assert params[2] is aug.order
+        assert params[3] is aug.cval
+        assert params[4] is aug.mode
         assert 0.25 - 1e-8 < params[0].value < 0.25 + 1e-8
         assert 1.0 - 1e-8 < params[1].value < 1.0 + 1e-8
         assert params[2].value == 2
@@ -8064,14 +8066,14 @@ class TestRot90(unittest.TestCase):
 
     def test___init___k_is_list(self):
         aug = iaa.Rot90([1, 3])
-        assert isinstance(aug.k, iap.Choice)
+        assert is_parameter_instance(aug.k, iap.Choice)
         assert len(aug.k.a) == 2
         assert aug.k.a[0] == 1
         assert aug.k.a[1] == 3
 
     def test___init___k_is_all(self):
         aug = iaa.Rot90(ia.ALL)
-        assert isinstance(aug.k, iap.Choice)
+        assert is_parameter_instance(aug.k, iap.Choice)
         assert len(aug.k.a) == 4
         assert aug.k.a == [0, 1, 2, 3]
 

--- a/test/augmenters/test_imgcorruptlike.py
+++ b/test/augmenters/test_imgcorruptlike.py
@@ -256,28 +256,29 @@ class TestAugmenters(unittest.TestCase):
             np.arange(32*32*3), 256
         ).reshape((32, 32, 3)).astype(np.uint8)
 
-        rng = iarandom.RNG(1)
-        # Replay sampling of severities.
-        # Even for deterministic values this is required as currently
-        # there is an advance() at the end of each draw_samples().
-        _ = iap.Deterministic(1).draw_samples((1,), rng)
+        with iap.no_prefetching():
+            rng = iarandom.RNG(1)
+            # Replay sampling of severities.
+            # Even for deterministic values this is required as currently
+            # there is an advance() at the end of each draw_samples().
+            _ = iap.Deterministic(1).draw_samples((1,), rng)
 
-        # As for the functions above, we can't just change the seed value
-        # to get different augmentations as many functions are dependend
-        # only on the severity. So we change only for some functions only
-        # the seed and for the others severity+seed.
-        image_aug1 = aug_cls(severity=severity, seed=1)(image=image)
-        image_aug2 = aug_cls(severity=severity, seed=1)(image=image)
-        if dependent_on_seed:
-            image_aug3 = aug_cls(severity=severity, seed=2)(
-                image=image)
-        else:
-            image_aug3 = aug_cls(severity=severity-1, seed=2)(
-                image=image)
-        image_aug_exp = func_expected(
-            image,
-            severity=severity,
-            seed=rng.generate_seed_())
+            # As for the functions above, we can't just change the seed value
+            # to get different augmentations as many functions are dependend
+            # only on the severity. So we change only for some functions only
+            # the seed and for the others severity+seed.
+            image_aug1 = aug_cls(severity=severity, seed=1)(image=image)
+            image_aug2 = aug_cls(severity=severity, seed=1)(image=image)
+            if dependent_on_seed:
+                image_aug3 = aug_cls(severity=severity, seed=2)(
+                    image=image)
+            else:
+                image_aug3 = aug_cls(severity=severity-1, seed=2)(
+                    image=image)
+            image_aug_exp = func_expected(
+                image,
+                severity=severity,
+                seed=rng.generate_seed_())
 
         assert aug_cls(severity=severity).func is func_expected
         assert np.array_equal(image_aug1, image_aug_exp)

--- a/test/augmenters/test_meta.py
+++ b/test/augmenters/test_meta.py
@@ -37,7 +37,7 @@ from imgaug.testutils import (create_random_images, create_random_keypoints,
                               array_equal_lists, keypoints_equal, reseed,
                               assert_cbaois_equal,
                               runtest_pickleable_uint8_img,
-                              TemporaryDirectory)
+                              TemporaryDirectory, is_parameter_instance)
 from imgaug.augmentables.heatmaps import HeatmapsOnImage
 from imgaug.augmentables.segmaps import SegmentationMapsOnImage
 from imgaug.augmentables.lines import LineString, LineStringsOnImage
@@ -7609,8 +7609,8 @@ class TestSometimes(unittest.TestCase):
     def test_get_parameters(self):
         aug = iaa.Sometimes(0.75)
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Binomial)
-        assert isinstance(params[0].p, iap.Deterministic)
+        assert is_parameter_instance(params[0], iap.Binomial)
+        assert is_parameter_instance(params[0].p, iap.Deterministic)
         assert 0.75 - 1e-8 < params[0].p.value < 0.75 + 1e-8
 
     def test___str___and___repr__(self):
@@ -7622,7 +7622,6 @@ class TestSometimes(unittest.TestCase):
             else_list=else_list,
             name="SometimesTest")
 
-        expected_p = "Binomial(Deterministic(float 0.50000000))"
         expected_then_list = (
             "Sequential("
             "name=SometimesTest-then, "
@@ -7641,7 +7640,7 @@ class TestSometimes(unittest.TestCase):
             "Sometimes("
             "p=%s, name=%s, then_list=%s, else_list=%s, deterministic=%s"
             ")" % (
-                expected_p,
+                str(aug.p),
                 "SometimesTest",
                 expected_then_list,
                 expected_else_list,
@@ -7660,7 +7659,6 @@ class TestSometimes(unittest.TestCase):
             else_list=None,
             name="SometimesTest")
 
-        expected_p = "Binomial(Deterministic(float 0.50000000))"
         expected = (
             "Sometimes("
             "p=%s, "
@@ -7669,7 +7667,7 @@ class TestSometimes(unittest.TestCase):
             "else_list=%s, "
             "deterministic=%s"
             ")" % (
-                expected_p,
+                str(aug.p),
                 "SometimesTest",
                 "None",
                 "None",
@@ -8465,8 +8463,8 @@ class TestChannelShuffle(unittest.TestCase):
 
     def test___init__(self):
         aug = iaa.ChannelShuffle(p=0.9, channels=[0, 2])
-        assert isinstance(aug.p, iap.Binomial)
-        assert isinstance(aug.p.p, iap.Deterministic)
+        assert is_parameter_instance(aug.p, iap.Binomial)
+        assert is_parameter_instance(aug.p.p, iap.Deterministic)
         assert np.allclose(aug.p.p.value, 0.9)
         assert aug.channels == [0, 2]
 

--- a/test/augmenters/test_pooling.py
+++ b/test/augmenters/test_pooling.py
@@ -21,8 +21,10 @@ import imgaug.random as iarandom
 import imgaug.augmenters.pooling as iapooling
 from imgaug import augmenters as iaa
 from imgaug import parameters as iap
-from imgaug.testutils import (reseed, assert_cbaois_equal,
-                              runtest_pickleable_uint8_img)
+from imgaug.testutils import (reseed,
+                              assert_cbaois_equal,
+                              runtest_pickleable_uint8_img,
+                              is_parameter_instance)
 
 
 class Test_compute_shape_after_pooling(unittest.TestCase):
@@ -601,7 +603,7 @@ class _TestPoolingAugmentersBase(object):
         params = aug.get_parameters()
         assert len(params) == 2
         assert len(params[0]) == 2
-        assert isinstance(params[0][0], iap.Deterministic)
+        assert is_parameter_instance(params[0][0], iap.Deterministic)
         assert params[0][0].value == 2
         assert params[0][1] is None
 
@@ -622,7 +624,7 @@ class TestAveragePooling(unittest.TestCase, _TestPoolingAugmentersBase):
     def test___init___default_settings(self):
         aug = iaa.AveragePooling(2)
         assert len(aug.kernel_size) == 2
-        assert isinstance(aug.kernel_size[0], iap.Deterministic)
+        assert is_parameter_instance(aug.kernel_size[0], iap.Deterministic)
         assert aug.kernel_size[0].value == 2
         assert aug.kernel_size[1] is None
         assert aug.keep_size is True
@@ -630,8 +632,8 @@ class TestAveragePooling(unittest.TestCase, _TestPoolingAugmentersBase):
     def test___init___custom_settings(self):
         aug = iaa.AveragePooling(((2, 4), (5, 6)), keep_size=False)
         assert len(aug.kernel_size) == 2
-        assert isinstance(aug.kernel_size[0], iap.DiscreteUniform)
-        assert isinstance(aug.kernel_size[1], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.kernel_size[0], iap.DiscreteUniform)
+        assert is_parameter_instance(aug.kernel_size[1], iap.DiscreteUniform)
         assert aug.kernel_size[0].a.value == 2
         assert aug.kernel_size[0].b.value == 4
         assert aug.kernel_size[1].a.value == 5

--- a/test/augmenters/test_segmentation.py
+++ b/test/augmenters/test_segmentation.py
@@ -22,7 +22,10 @@ from imgaug import parameters as iap
 from imgaug import dtypes as iadt
 from imgaug import random as iarandom
 from imgaug.testutils import (
-    reseed, runtest_pickleable_uint8_img, temporary_constants
+    reseed,
+    runtest_pickleable_uint8_img,
+    temporary_constants,
+    is_parameter_instance
 )
 
 
@@ -227,9 +230,9 @@ class TestSuperpixels(unittest.TestCase):
         aug = iaa.Superpixels(
             p_replace=0.5, n_segments=2, max_size=100, interpolation="nearest")
         params = aug.get_parameters()
-        assert isinstance(params[0], iap.Binomial)
-        assert isinstance(params[0].p, iap.Deterministic)
-        assert isinstance(params[1], iap.Deterministic)
+        assert params[0] is aug.p_replace
+        assert is_parameter_instance(params[0].p, iap.Deterministic)
+        assert params[1] is aug.n_segments
         assert 0.5 - 1e-4 < params[0].p.value < 0.5 + 1e-4
         assert params[1].value == 2
         assert params[2] == 100
@@ -534,7 +537,7 @@ class TestVoronoi(unittest.TestCase):
         sampler = iaa.RegularGridPointsSampler(1, 1)
         aug = iaa.Voronoi(sampler)
         assert aug.points_sampler is sampler
-        assert isinstance(aug.p_replace, iap.Deterministic)
+        assert is_parameter_instance(aug.p_replace, iap.Deterministic)
         assert aug.p_replace.value == 1
         assert aug.max_size == 128
         assert aug.interpolation == "linear"
@@ -544,7 +547,7 @@ class TestVoronoi(unittest.TestCase):
         aug = iaa.Voronoi(sampler, p_replace=0.5, max_size=None,
                           interpolation="cubic")
         assert aug.points_sampler is sampler
-        assert isinstance(aug.p_replace, iap.Binomial)
+        assert is_parameter_instance(aug.p_replace, iap.Binomial)
         assert np.isclose(aug.p_replace.p.value, 0.5)
         assert aug.max_size is None
         assert aug.interpolation == "cubic"
@@ -800,7 +803,7 @@ class TestVoronoi(unittest.TestCase):
                           interpolation="cubic")
         params = aug.get_parameters()
         assert params[0] is sampler
-        assert isinstance(params[1], iap.Binomial)
+        assert is_parameter_instance(params[1], iap.Binomial)
         assert np.isclose(params[1].p.value, 0.5)
         assert params[2] is None
         assert params[3] == "cubic"
@@ -919,8 +922,10 @@ class TestRegularGridVoronoi(unittest.TestCase):
             name=None
         )
         assert aug.points_sampler.other_points_sampler.n_rows.value == 10
-        assert isinstance(aug.points_sampler.other_points_sampler.n_cols,
-                          iap.DiscreteUniform)
+        assert is_parameter_instance(
+            aug.points_sampler.other_points_sampler.n_cols,
+            iap.DiscreteUniform
+        )
         assert aug.points_sampler.other_points_sampler.n_cols.a.value == 10
         assert aug.points_sampler.other_points_sampler.n_cols.b.value == 30
         assert np.isclose(aug.p_replace.p.value, 0.5)
@@ -983,7 +988,8 @@ class TestRelativeRegularGridVoronoi(unittest.TestCase):
 
         ps = aug.points_sampler
         assert np.isclose(ps.other_points_sampler.n_rows_frac.value, 0.1)
-        assert isinstance(ps.other_points_sampler.n_cols_frac, iap.Uniform)
+        assert is_parameter_instance(ps.other_points_sampler.n_cols_frac,
+                                     iap.Uniform)
         assert np.isclose(ps.other_points_sampler.n_cols_frac.a.value, 0.1)
         assert np.isclose(ps.other_points_sampler.n_cols_frac.b.value, 0.3)
         assert np.isclose(aug.p_replace.p.value, 0.5)
@@ -1005,7 +1011,7 @@ class TestRegularGridPointsSampler(unittest.TestCase):
 
     def test___init___(self):
         sampler = iaa.RegularGridPointsSampler((1, 10), 20)
-        assert isinstance(sampler.n_rows, iap.DiscreteUniform)
+        assert is_parameter_instance(sampler.n_rows, iap.DiscreteUniform)
         assert sampler.n_rows.a.value == 1
         assert sampler.n_rows.b.value == 10
         assert sampler.n_cols.value == 20
@@ -1141,9 +1147,12 @@ class TestRegularGridPointsSampler(unittest.TestCase):
         sampler = iaa.RegularGridPointsSampler(10, (10, 30))
         expected = (
             "RegularGridPointsSampler("
-            "Deterministic(int 10), "
-            "DiscreteUniform(Deterministic(int 10), Deterministic(int 30))"
-            ")"
+            "%s, "
+            "%s"
+            ")" % (
+                str(sampler.n_rows),
+                str(sampler.n_cols)
+            )
         )
         assert sampler.__str__() == sampler.__repr__() == expected
 
@@ -1154,7 +1163,7 @@ class TestRelativeRegularGridPointsSampler(unittest.TestCase):
 
     def test___init___(self):
         sampler = iaa.RelativeRegularGridPointsSampler((0.1, 0.2), 0.1)
-        assert isinstance(sampler.n_rows_frac, iap.Uniform)
+        assert is_parameter_instance(sampler.n_rows_frac, iap.Uniform)
         assert np.isclose(sampler.n_rows_frac.a.value, 0.1)
         assert np.isclose(sampler.n_rows_frac.b.value, 0.2)
         assert np.isclose(sampler.n_cols_frac.value, 0.1)
@@ -1269,12 +1278,12 @@ class TestRelativeRegularGridPointsSampler(unittest.TestCase):
         sampler = iaa.RelativeRegularGridPointsSampler(0.01, (0.01, 0.05))
         expected = (
             "RelativeRegularGridPointsSampler("
-            "Deterministic(float 0.01000000), "
-            "Uniform("
-            "Deterministic(float 0.01000000), "
-            "Deterministic(float 0.05000000)"
-            ")"
-            ")"
+            "%s, "
+            "%s"
+            ")" % (
+                str(sampler.n_rows_frac),
+                str(sampler.n_cols_frac)
+            )
         )
         assert sampler.__str__() == sampler.__repr__() == expected
 
@@ -1376,11 +1385,15 @@ class TestDropoutPointsSampler(unittest.TestCase):
         expected = (
             "DropoutPointsSampler("
             "RegularGridPointsSampler("
-            "Deterministic(int 10), "
-            "Deterministic(int 20)"
+            "%s, "
+            "%s"
             "), "
-            "Binomial(Deterministic(float 0.80000000))"
-            ")"
+            "%s"
+            ")" % (
+                str(sampler.other_points_sampler.n_rows),
+                str(sampler.other_points_sampler.n_cols),
+                str(sampler.p_drop)
+            )
         )
         assert sampler.__str__() == sampler.__repr__() == expected
 
@@ -1391,7 +1404,7 @@ class TestUniformPointsSampler(unittest.TestCase):
 
     def test___init__(self):
         sampler = iaa.UniformPointsSampler(100)
-        assert isinstance(sampler.n_points, iap.Deterministic)
+        assert is_parameter_instance(sampler.n_points, iap.Deterministic)
         assert sampler.n_points.value == 100
 
     def test_sampled_points_not_identical(self):
@@ -1566,7 +1579,9 @@ class TestUniformPointsSampler(unittest.TestCase):
 
     def test_conversion_to_string(self):
         sampler = iaa.UniformPointsSampler(10)
-        expected = "UniformPointsSampler(Deterministic(int 10))"
+        expected = "UniformPointsSampler(%s)" % (
+            str(sampler.n_points)
+        )
         assert sampler.__str__() == sampler.__repr__() == expected
 
 
@@ -1655,10 +1670,13 @@ class TestSubsamplingPointsSampler(unittest.TestCase):
         expected = (
             "SubsamplingPointsSampler("
             "RegularGridPointsSampler("
-            "Deterministic(int 10), "
-            "Deterministic(int 20)"
+            "%s, "
+            "%s"
             "), "
             "10"
-            ")"
+            ")" % (
+                str(sampler.other_points_sampler.n_rows),
+                str(sampler.other_points_sampler.n_cols)
+            )
         )
         assert sampler.__str__() == sampler.__repr__() == expected

--- a/test/augmenters/test_weather.py
+++ b/test/augmenters/test_weather.py
@@ -18,7 +18,8 @@ import cv2
 import imgaug as ia
 from imgaug import augmenters as iaa
 from imgaug import parameters as iap
-from imgaug.testutils import reseed, runtest_pickleable_uint8_img
+from imgaug.testutils import (reseed, runtest_pickleable_uint8_img,
+                              is_parameter_instance)
 
 
 class _TwoValueParam(iap.StochasticParameter):
@@ -42,12 +43,12 @@ class TestFastSnowyLandscape(unittest.TestCase):
         aug = iaa.FastSnowyLandscape(
             lightness_threshold=[100, 200],
             lightness_multiplier=[1.0, 4.0])
-        assert isinstance(aug.lightness_threshold, iap.Choice)
+        assert is_parameter_instance(aug.lightness_threshold, iap.Choice)
         assert len(aug.lightness_threshold.a) == 2
         assert aug.lightness_threshold.a[0] == 100
         assert aug.lightness_threshold.a[1] == 200
 
-        assert isinstance(aug.lightness_multiplier, iap.Choice)
+        assert is_parameter_instance(aug.lightness_multiplier, iap.Choice)
         assert len(aug.lightness_multiplier.a) == 2
         assert np.allclose(aug.lightness_multiplier.a[0], 1.0)
         assert np.allclose(aug.lightness_multiplier.a[1], 4.0)

--- a/test/augmenters/test_weather.py
+++ b/test/augmenters/test_weather.py
@@ -363,10 +363,10 @@ class TestSnowflakes(unittest.TestCase):
         # test density_uniformity
         imgs_aug_ununiform = iaa.Snowflakes(
             density=0.4,
-            density_uniformity=0.1).augment_images([img] * 5)
+            density_uniformity=0.1).augment_images([img] * 30)
         imgs_aug_uniform = iaa.Snowflakes(
             density=0.4,
-            density_uniformity=0.9).augment_images([img] * 5)
+            density_uniformity=0.9).augment_images([img] * 30)
 
         ununiform_uniformity = np.average([
             self._measure_uniformity(img_aug)
@@ -408,7 +408,7 @@ class TestSnowflakes(unittest.TestCase):
         runtest_pickleable_uint8_img(aug, iterations=3, shape=(20, 20, 3))
 
     @classmethod
-    def _measure_uniformity(cls, image, patch_size=5, n_patches=100):
+    def _measure_uniformity(cls, image, patch_size=5, n_patches=50):
         pshalf = (patch_size-1) // 2
         image_f32 = image.astype(np.float32)
         grad_x = image_f32[:, 1:] - image_f32[:, :-1]

--- a/test/test_multicore.py
+++ b/test/test_multicore.py
@@ -417,15 +417,17 @@ class TestPool(unittest.TestCase):
                 sum_to_vecs[vecsum].append(vec)
 
     def test_augmentations_with_seed_match(self):
+        nb_batches = 60
         augseq = iaa.AddElementwise((0, 255))
         image = np.zeros((10, 10, 1), dtype=np.uint8)
         batch = ia.Batch(images=np.uint8([image, image]))
-        batches = [batch.deepcopy() for _ in sm.xrange(60)]
+        batches = [batch.deepcopy() for _ in sm.xrange(nb_batches)]
 
         # seed=1
         with multicore.Pool(augseq, processes=2, maxtasksperchild=30,
                             seed=1) as pool:
             batches_aug1 = pool.map_batches(batches, chunksize=2)
+
         # seed=1
         with multicore.Pool(augseq, processes=2, seed=1) as pool:
             batches_aug2 = pool.map_batches(batches, chunksize=1)
@@ -433,9 +435,9 @@ class TestPool(unittest.TestCase):
         with multicore.Pool(augseq, processes=2, seed=2) as pool:
             batches_aug3 = pool.map_batches(batches, chunksize=1)
 
-        assert len(batches_aug1) == 60
-        assert len(batches_aug2) == 60
-        assert len(batches_aug3) == 60
+        assert len(batches_aug1) == nb_batches
+        assert len(batches_aug2) == nb_batches
+        assert len(batches_aug3) == nb_batches
 
         for b1, b2, b3 in zip(batches_aug1, batches_aug2, batches_aug3):
             # images were augmented

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -26,7 +26,7 @@ import scipy.special
 import imgaug as ia
 import imgaug.random as iarandom
 from imgaug import parameters as iap
-from imgaug.testutils import reseed
+from imgaug.testutils import reseed, is_parameter_instance
 
 
 def _eps(arr):
@@ -39,7 +39,8 @@ class Test_handle_continuous_param(unittest.TestCase):
     def test_value_range_is_none(self):
         result = iap.handle_continuous_param(
             1, "[test1]",
-            value_range=None, tuple_to_uniform=True, list_to_choice=True)
+            value_range=None, tuple_to_uniform=True, list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_range_is_tuple_of_nones(self):
@@ -47,13 +48,15 @@ class Test_handle_continuous_param(unittest.TestCase):
             1, "[test1b]",
             value_range=(None, None),
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_param_is_stochastic_parameter(self):
         result = iap.handle_continuous_param(
             iap.Deterministic(1), "[test2]",
-            value_range=None, tuple_to_uniform=True, list_to_choice=True)
+            value_range=None, tuple_to_uniform=True, list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_range_is_tuple_of_integers(self):
@@ -61,7 +64,8 @@ class Test_handle_continuous_param(unittest.TestCase):
             1, "[test3]",
             value_range=(0, 10),
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_param_is_outside_of_value_range(self):
@@ -79,7 +83,8 @@ class Test_handle_continuous_param(unittest.TestCase):
             1, "[test5]",
             value_range=(None, 12),
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_param_is_outside_of_value_range_and_no_lower_bound(self):
@@ -98,7 +103,8 @@ class Test_handle_continuous_param(unittest.TestCase):
             1, "[test7]",
             value_range=(-1, None),
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_param_is_outside_of_value_range_and_no_upper_bound(self):
@@ -127,7 +133,8 @@ class Test_handle_continuous_param(unittest.TestCase):
             (1, 2), "[test10]",
             value_range=None,
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Uniform))
 
     def test_tuple_as_value_and_tuples_allowed_and_inside_value_range(self):
@@ -136,7 +143,8 @@ class Test_handle_continuous_param(unittest.TestCase):
             (1, 2), "[test11]",
             value_range=(0, 10),
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Uniform))
 
     def test_tuple_value_and_allowed_and_partially_outside_value_range(self):
@@ -177,7 +185,8 @@ class Test_handle_continuous_param(unittest.TestCase):
             [1, 2, 3], "[test15]",
             value_range=None,
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Choice))
 
     def test_list_value_and_allowed_and_partially_outside_value_range(self):
@@ -210,7 +219,8 @@ class Test_handle_continuous_param(unittest.TestCase):
             1, "[test18]",
             value_range=_value_range,
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_bad_datatype_as_value_range(self):
@@ -240,28 +250,29 @@ class Test_handle_discrete_param(unittest.TestCase):
         # value without value range
         result = iap.handle_discrete_param(
             1, "[test1]", value_range=None, tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_range_is_tuple_of_nones(self):
         # value without value range as (None, None)
         result = iap.handle_discrete_param(
             1, "[test1b]", value_range=(None, None), tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_is_stochastic_parameter(self):
         # stochastic parameter
         result = iap.handle_discrete_param(
             iap.Deterministic(1), "[test2]", value_range=None,
-            tuple_to_uniform=True, list_to_choice=True, allow_floats=True)
+            tuple_to_uniform=True, list_to_choice=True, allow_floats=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_inside_value_range(self):
         # value within value range
         result = iap.handle_discrete_param(
             1, "[test3]", value_range=(0, 10), tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_outside_value_range(self):
@@ -269,14 +280,14 @@ class Test_handle_discrete_param(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             _ = iap.handle_discrete_param(
                 1, "[test4]", value_range=(2, 12), tuple_to_uniform=True,
-                list_to_choice=True, allow_floats=True)
+                list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue("[test4]" in str(context.exception))
 
     def test_value_inside_value_range_no_lower_bound(self):
         # value within value range (without lower bound)
         result = iap.handle_discrete_param(
             1, "[test5]", value_range=(None, 12), tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_outside_value_range_no_lower_bound(self):
@@ -284,14 +295,14 @@ class Test_handle_discrete_param(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             _ = iap.handle_discrete_param(
                 1, "[test6]", value_range=(None, 0), tuple_to_uniform=True,
-                list_to_choice=True, allow_floats=True)
+                list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue("[test6]" in str(context.exception))
 
     def test_value_inside_value_range_no_upper_bound(self):
         # value within value range (without upper bound)
         result = iap.handle_discrete_param(
             1, "[test7]", value_range=(-1, None), tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_value_outside_value_range_no_upper_bound(self):
@@ -314,14 +325,14 @@ class Test_handle_discrete_param(unittest.TestCase):
         # tuple as value and tuple allowed
         result = iap.handle_discrete_param(
             (1, 2), "[test10]", value_range=None, tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.DiscreteUniform))
 
     def test_value_tuple_and_allowed_and_inside_value_range(self):
         # tuple as value and tuple allowed and tuple within value range
         result = iap.handle_discrete_param(
             (1, 2), "[test11]", value_range=(0, 10), tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.DiscreteUniform))
 
     def test_value_tuple_and_allowed_and_inside_vr_allow_floats_false(self):
@@ -329,7 +340,8 @@ class Test_handle_discrete_param(unittest.TestCase):
         # allow_floats=False
         result = iap.handle_discrete_param(
             (1, 2), "[test11b]", value_range=(0, 10),
-            tuple_to_uniform=True, list_to_choice=True, allow_floats=False)
+            tuple_to_uniform=True, list_to_choice=True, allow_floats=False,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.DiscreteUniform))
 
     def test_value_tuple_and_allowed_and_partially_outside_value_range(self):
@@ -362,7 +374,7 @@ class Test_handle_discrete_param(unittest.TestCase):
         # list as value and list allowed
         result = iap.handle_discrete_param(
             [1, 2, 3], "[test15]", value_range=None, tuple_to_uniform=True,
-            list_to_choice=True, allow_floats=True)
+            list_to_choice=True, allow_floats=True, prefetch=False)
         self.assertTrue(isinstance(result, iap.Choice))
 
     def test_value_list_and_allowed_and_partially_outside_value_range(self):
@@ -390,7 +402,8 @@ class Test_handle_discrete_param(unittest.TestCase):
             1, "[test18]",
             value_range=_value_range,
             tuple_to_uniform=True,
-            list_to_choice=True)
+            list_to_choice=True,
+            prefetch=False)
         self.assertTrue(isinstance(result, iap.Deterministic))
 
     def test_bad_datatype_as_value_range(self):
@@ -410,12 +423,12 @@ class Test_handle_categorical_string_param(unittest.TestCase):
         param = iap.handle_categorical_string_param(
             ia.ALL, "foo", valid_values)
 
-        assert isinstance(param, iap.Choice)
+        assert is_parameter_instance(param, iap.Choice)
         assert param.a == valid_values
 
     def test_arg_is_str(self):
         param = iap.handle_categorical_string_param("class1", "foo")
-        assert isinstance(param, iap.Deterministic)
+        assert is_parameter_instance(param, iap.Deterministic)
         assert param.value == "class1"
 
     def test_arg_is_valid_str(self):
@@ -424,7 +437,7 @@ class Test_handle_categorical_string_param(unittest.TestCase):
         param = iap.handle_categorical_string_param(
             "class1", "foo", valid_values)
 
-        assert isinstance(param, iap.Deterministic)
+        assert is_parameter_instance(param, iap.Deterministic)
         assert param.value == "class1"
 
     def test_arg_is_invalid_str(self):
@@ -443,7 +456,7 @@ class Test_handle_categorical_string_param(unittest.TestCase):
         param = iap.handle_categorical_string_param(["class1", "class3"],
                                                     "foo")
 
-        assert isinstance(param, iap.Choice)
+        assert is_parameter_instance(param, iap.Choice)
         assert param.a == ["class1", "class3"]
 
     def test_arg_is_valid_list(self):
@@ -452,7 +465,7 @@ class Test_handle_categorical_string_param(unittest.TestCase):
         param = iap.handle_categorical_string_param(
             ["class1", "class3"], "foo", valid_values)
 
-        assert isinstance(param, iap.Choice)
+        assert is_parameter_instance(param, iap.Choice)
         assert param.a == ["class1", "class3"]
 
     def test_arg_is_list_with_invalid_types(self):
@@ -486,7 +499,7 @@ class Test_handle_categorical_string_param(unittest.TestCase):
         param = iap.Deterministic("class1")
 
         param_out = iap.handle_categorical_string_param(
-            param, "foo", ["class1"])
+            param, "foo", ["class1"], prefetch=False)
 
         assert param_out is param
 
@@ -503,21 +516,21 @@ class Test_handle_probability_param(unittest.TestCase):
     def test_bool_like_values(self):
         for val in [True, False, 0, 1, 0.0, 1.0]:
             with self.subTest(param=val):
-                p = iap.handle_probability_param(val, "[test1]")
+                p = iap.handle_probability_param(val, "[test1]", prefetch=False)
                 assert isinstance(p, iap.Deterministic)
                 assert p.value == int(val)
 
     def test_float_probabilities(self):
         for val in [0.0001, 0.001, 0.01, 0.1, 0.9, 0.99, 0.999, 0.9999]:
             with self.subTest(param=val):
-                p = iap.handle_probability_param(val, "[test2]")
-                assert isinstance(p, iap.Binomial)
-                assert isinstance(p.p, iap.Deterministic)
+                p = iap.handle_probability_param(val, "[test2]", prefetch=False)
+                assert is_parameter_instance(p, iap.Binomial)
+                assert is_parameter_instance(p.p, iap.Deterministic)
                 assert val-1e-8 < p.p.value < val+1e-8
 
     def test_probability_is_stochastic_parameter(self):
         det = iap.Deterministic(1)
-        p = iap.handle_probability_param(det, "[test3]")
+        p = iap.handle_probability_param(det, "[test3]", prefetch=False)
         assert p == det
 
     def test_probability_has_bad_datatype(self):
@@ -1000,24 +1013,188 @@ class TestStochasticParameterOperators(unittest.TestCase):
         self.assertTrue("Invalid datatypes" in str(context.exception))
 
 
+class TestAutoPrefetcher(unittest.TestCase):
+    def setUp(self):
+        reseed()
+
+    def test_does_not_prefetch_at_first_call(self):
+        other_param = mock.Mock()
+        other_param.draw_samples.return_value = np.zeros((100,), dtype=np.uint8)
+        param = iap.AutoPrefetcher(other_param, 10)
+        rng = iarandom.RNG(0)
+
+        _samples = param.draw_samples((1,), rng)
+
+        # rng is currently not identical in call args,
+        # because draw_samples() creates a new one with same state
+        assert other_param.draw_samples.call_count == 1
+        assert other_param.draw_samples.call_args_list[0][0][0] == (1,)
+        assert other_param.draw_samples.call_args_list[0][0][1].equals(rng)
+        assert param.samples is None
+        assert param.index == 0
+        assert param.last_rng_idx == rng._idx
+
+    def test_prefetches_at_second_call(self):
+        other_param = mock.Mock()
+        other_param.draw_samples.return_value = np.zeros((100,), dtype=np.uint8)
+        param = iap.AutoPrefetcher(other_param, 10)
+        rng = iarandom.RNG(0)
+
+        _samples = param.draw_samples((1,), rng)
+        _samples = param.draw_samples((1,), rng)
+
+        # rng is currently not identical in call args,
+        # because draw_samples() creates a new one with same state
+        assert other_param.draw_samples.call_count == 2
+        assert other_param.draw_samples.call_args_list[0][0][0] == (1,)
+        assert other_param.draw_samples.call_args_list[0][0][1].equals(rng)
+        assert other_param.draw_samples.call_args_list[1][0][0] == (10,)
+        assert other_param.draw_samples.call_args_list[1][0][1].equals(rng)
+        # (100,) because that's what the mock always returns
+        assert param.samples.shape == (100,)
+        assert param.index == 1
+        assert param.last_rng_idx == rng._idx
+
+    def test_nb_prefetch_is_evenly_divisible_by_requested_sizes(self):
+        other_param = iap.DeterministicList(np.arange(200))
+        param = iap.AutoPrefetcher(other_param, 100)
+        rng = iarandom.RNG(0)
+
+        samples1 = param.draw_samples((50,), rng)
+        samples2 = param.draw_samples((50,), rng)
+        samples3 = param.draw_samples((50,), rng)
+        samples4 = param.draw_samples((50,), rng)
+
+        # first call is not prefetched, second+ is, so first and second are
+        # here identical
+        assert np.array_equal(samples1, np.arange(50))
+        assert np.array_equal(samples2, np.arange(50))
+        assert np.array_equal(samples3, 50 + np.arange(50))
+        assert np.array_equal(samples4, np.arange(50))
+
+    def test_nb_prefetch_is_not_evenly_divisible_by_requested_sizes(self):
+        other_param = iap.DeterministicList(np.arange(200))
+        param = iap.AutoPrefetcher(other_param, 100)
+        rng = iarandom.RNG(0)
+
+        samples1 = param.draw_samples((40,), rng)
+        samples2 = param.draw_samples((40,), rng)
+        samples3 = param.draw_samples((40,), rng)
+        samples4 = param.draw_samples((40,), rng)
+
+        # first call is not prefetched, second+ is, so first and second are
+        # here identical
+        assert np.array_equal(samples1, np.arange(40))
+        assert np.array_equal(samples2, np.arange(40))
+        assert np.array_equal(samples3, 40 + np.arange(40))
+        assert np.array_equal(
+            samples4,
+            np.concatenate([
+                80 + np.arange(20),
+                np.arange(20)
+            ], axis=0)
+        )
+
+    def test_exactly_as_many_components_requested_as_nb_prefetch_allows(self):
+        other_param = iap.DeterministicList(np.arange(200))
+        param = iap.AutoPrefetcher(other_param, 40)
+        rng = iarandom.RNG(0)
+
+        samples1 = param.draw_samples((40,), rng)
+        samples2 = param.draw_samples((40,), rng)
+        samples3 = param.draw_samples((40,), rng)
+
+        assert np.array_equal(samples1, np.arange(40))
+        assert np.array_equal(samples2, np.arange(40))
+        assert np.array_equal(samples3, np.arange(40))
+
+    def test_more_components_requested_than_nb_prefetch_allows(self):
+        other_param = iap.DeterministicList(np.arange(200))
+        param = iap.AutoPrefetcher(other_param, 10)
+        rng = iarandom.RNG(0)
+
+        samples1 = param.draw_samples((40,), rng)
+        samples2 = param.draw_samples((40,), rng)
+        samples3 = param.draw_samples((40,), rng)
+
+        assert np.array_equal(samples1, np.arange(40))
+        assert np.array_equal(samples2, np.arange(40))
+        assert np.array_equal(samples3, np.arange(40))
+
+    def test_size_is_tuple(self):
+        other_param = iap.DeterministicList(np.arange(200))
+        param = iap.AutoPrefetcher(other_param, 50)
+        rng = iarandom.RNG(0)
+
+        samples1 = param.draw_samples((2, 3, 4), rng)  # 24 samples
+        samples2 = param.draw_samples((1, 5, 2), rng)  # 10 samples
+        samples3 = param.draw_samples((10, 2), rng)  # 20 samples
+
+        assert np.array_equal(samples1, np.arange(2*3*4).reshape((2, 3, 4)))
+        assert np.array_equal(samples2, np.arange(1*5*2).reshape((1, 5, 2)))
+        assert np.array_equal(samples3,
+                              (1*5*2) + np.arange(10*2).reshape((10, 2)))
+
+    def test_to_string_first_call(self):
+        other_param = iap.DeterministicList(np.arange(200))
+        param = iap.AutoPrefetcher(other_param, 10)
+        other_param_str = str(other_param)
+
+        expected = (
+            "AutoPrefetcher("
+            "nb_prefetch=10, "
+            "samples=None (dtype None), "
+            "index=0, "
+            "last_rng_idx=None, "
+            "other_param=%s"
+            ")" % (other_param_str,)
+        )
+        assert str(param) == repr(param) == expected
+
+    def test_to_string_second_call(self):
+        other_param = iap.DeterministicList(np.arange(200))
+        param = iap.AutoPrefetcher(other_param, 10)
+        other_param_str = str(other_param)
+
+        rng = iarandom.RNG(0)
+
+        _ = param.draw_samples((2,), rng)
+        _ = param.draw_samples((2,), rng)
+
+        expected = (
+            "AutoPrefetcher("
+            "nb_prefetch=10, "
+            "samples=(10,) (dtype int64), "
+            "index=2, "
+            "last_rng_idx=%d, "
+            "other_param=%s"
+            ")" % (rng._idx, other_param_str)
+        )
+        assert str(param) == repr(param) == expected
+
+
 class TestBinomial(unittest.TestCase):
     def setUp(self):
         reseed()
 
     def test___init___p_is_zero(self):
         param = iap.Binomial(0)
+        expected = "Binomial(%s)" % (str(param.p),)
+        assert "Deterministic(int 0)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Binomial(Deterministic(int 0))"
+            == expected
         )
 
     def test___init___p_is_one(self):
         param = iap.Binomial(1.0)
+        expected = "Binomial(%s)" % (str(param.p),)
+        assert "Deterministic(float 1.00000000)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Binomial(Deterministic(float 1.00000000))"
+            == expected
         )
 
     def test_p_is_zero(self):
@@ -1278,10 +1455,13 @@ class TestDiscreteUniform(unittest.TestCase):
 
     def test___init__(self):
         param = iap.DiscreteUniform(0, 2)
+        expected = "DiscreteUniform(%s, %s)" % (str(param.a), str(param.b))
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 2)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "DiscreteUniform(Deterministic(int 0), Deterministic(int 2))"
+            == expected
         )
 
     def test_bounds_are_ints(self):
@@ -1392,10 +1572,12 @@ class TestPoisson(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Poisson(1)
+        expected = "Poisson(%s)" % (str(param.lam),)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Poisson(Deterministic(int 1))"
+            == expected
         )
 
     def test_draw_sample(self):
@@ -1437,10 +1619,12 @@ class TestNormal(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Normal(0, 1)
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Normal(loc=Deterministic(int 0), scale=Deterministic(int 1))"
+            == "Normal(loc=%s, scale=%s)" % (str(param.loc), str(param.scale))
         )
 
     def test_draw_sample(self):
@@ -1519,12 +1703,21 @@ class TestTruncatedNormal(unittest.TestCase):
         param = iap.TruncatedNormal(0, 1)
         expected = (
             "TruncatedNormal("
-            "loc=Deterministic(int 0), "
-            "scale=Deterministic(int 1), "
-            "low=Deterministic(float -inf), "
-            "high=Deterministic(float inf)"
-            ")"
+            "loc=%s, "
+            "scale=%s, "
+            "low=%s, "
+            "high=%s"
+            ")" % (
+                str(param.loc),
+                str(param.scale),
+                str(param.low),
+                str(param.high)
+            )
         )
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
+        assert "Deterministic(float -inf)" in str(param)
+        assert "Deterministic(float inf)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
@@ -1535,12 +1728,21 @@ class TestTruncatedNormal(unittest.TestCase):
         param = iap.TruncatedNormal(0, 1, low=-100, high=50.0)
         expected = (
             "TruncatedNormal("
-            "loc=Deterministic(int 0), "
-            "scale=Deterministic(int 1), "
-            "low=Deterministic(int -100), "
-            "high=Deterministic(float 50.00000000)"
-            ")"
+            "loc=%s, "
+            "scale=%s, "
+            "low=%s, "
+            "high=%s"
+            ")" % (
+                str(param.loc),
+                str(param.scale),
+                str(param.low),
+                str(param.high)
+            )
         )
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
+        assert "Deterministic(int -100)" in str(param)
+        assert "Deterministic(float 50.00000000)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
@@ -1621,10 +1823,16 @@ class TestLaplace(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Laplace(0, 1)
+        expected = "Laplace(loc=%s, scale=%s)" % (
+            str(param.loc),
+            str(param.scale)
+        )
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Laplace(loc=Deterministic(int 0), scale=Deterministic(int 1))"
+            == expected
         )
 
     def test_draw_sample(self):
@@ -1714,11 +1922,12 @@ class TestChiSquare(unittest.TestCase):
 
     def test___init__(self):
         param = iap.ChiSquare(1)
-
+        expected = "ChiSquare(df=%s)" % (str(param.df),)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "ChiSquare(df=Deterministic(int 1))"
+            == expected
         )
 
     def test_draw_sample(self):
@@ -1802,11 +2011,12 @@ class TestWeibull(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Weibull(1)
-
+        expected = "Weibull(a=%s)" % (str(param.a),)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Weibull(a=Deterministic(int 1))"
+            == expected
         )
 
     def test_draw_sample(self):
@@ -1821,8 +2031,7 @@ class TestWeibull(unittest.TestCase):
         param = iap.Weibull(1)
 
         samples = param.draw_samples((100, 1000))
-        samples_direct = iarandom.RNG(1234).weibull(a=1,
-                                                             size=(100, 1000))
+        samples_direct = iarandom.RNG(1234).weibull(a=1, size=(100, 1000))
 
         assert samples.shape == (100, 1000)
         assert np.all(0 <= samples)
@@ -1919,10 +2128,13 @@ class TestUniform(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Uniform(0, 1.0)
+        expected = "Uniform(%s, %s)" % (str(param.a), str(param.b))
+        assert "Deterministic(int 0)" in str(param.a)
+        assert "Deterministic(float 1.00000000)" in str(param.b)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Uniform(Deterministic(int 0), Deterministic(float 1.00000000))"
+            == expected
         )
 
     def test_draw_sample(self):
@@ -2052,13 +2264,12 @@ class TestBeta(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Beta(0.5, 0.5)
+        expected = "Beta(%s, %s)" % (str(param.alpha), str(param.beta))
+        assert "Deterministic(float 0.50000000)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Beta("
-               "Deterministic(float 0.50000000), "
-               "Deterministic(float 0.50000000)"
-               ")"
+            == expected
         )
 
     def test_draw_sample(self):
@@ -2410,28 +2621,40 @@ class TestFromLowerResolution(unittest.TestCase):
         param = iap.FromLowerResolution(other_param=iap.Deterministic(0),
                                         size_percent=1, method="nearest")
 
+        expected = (
+            "FromLowerResolution(size_percent=%s, method=%s, other_param=%s)"
+        ) % (
+            str(param.size_percent),
+            str(param.method),
+            str(param.other_param)
+        )
+        assert "Deterministic(int 1)" in str(param)
+        assert "Deterministic(nearest)" in str(param)
+        assert "Deterministic(int 0)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "FromLowerResolution("
-               "size_percent=Deterministic(int 1), "
-               "method=Deterministic(nearest), "
-               "other_param=Deterministic(int 0)"
-               ")"
+            == expected
         )
 
     def test___init___size_px(self):
         param = iap.FromLowerResolution(other_param=iap.Deterministic(0),
                                         size_px=1, method="nearest")
 
+        expected = (
+            "FromLowerResolution(size_px=%s, method=%s, other_param=%s)"
+        ) % (
+            str(param.size_px),
+            str(param.method),
+            str(param.other_param)
+        )
+        assert "Deterministic(int 1)" in str(param)
+        assert "Deterministic(nearest)" in str(param)
+        assert "Deterministic(int 0)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "FromLowerResolution("
-               "size_px=Deterministic(int 1), "
-               "method=Deterministic(nearest), "
-               "other_param=Deterministic(int 0)"
-               ")"
+            == expected
         )
 
     def test_binomial_hwc(self):
@@ -2694,10 +2917,12 @@ class TestClip(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Clip(iap.Deterministic(0), -1, 1)
+        expected = "Clip(%s, -1.000000, 1.000000)" % (str(param.other_param),)
+        assert "Deterministic(int 0)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Clip(Deterministic(int 0), -1.000000, 1.000000)"
+            == expected
         )
 
     def test_value_within_bounds(self):
@@ -2796,36 +3021,36 @@ class TestClip(unittest.TestCase):
         param = iap.Clip(iap.Deterministic(0), None, 1)
 
         sample = param.draw_sample()
-
+        expected = "Clip(%s, None, 1.000000)" % (str(param.other_param),)
         assert sample == 0
         assert (
             param.__str__()
             == param.__repr__()
-            == "Clip(Deterministic(int 0), None, 1.000000)"
+            == expected
         )
 
     def test_upper_bound_is_none(self):
         param = iap.Clip(iap.Deterministic(0), 0, None)
 
         sample = param.draw_sample()
-
+        expected = "Clip(%s, 0.000000, None)" % (str(param.other_param),)
         assert sample == 0
         assert (
             param.__str__()
             == param.__repr__()
-            == "Clip(Deterministic(int 0), 0.000000, None)"
+            == expected
         )
 
     def test_both_bounds_are_none(self):
         param = iap.Clip(iap.Deterministic(0), None, None)
 
         sample = param.draw_sample()
-
+        expected = "Clip(%s, None, None)" % (str(param.other_param),)
         assert sample == 0
         assert (
             param.__str__()
             == param.__repr__()
-            == "Clip(Deterministic(int 0), None, None)"
+            == expected
         )
 
 
@@ -2835,11 +3060,12 @@ class TestDiscretize(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Discretize(iap.Deterministic(0))
-
+        expected = "Discretize(%s, round=True)" % (param.other_param,)
+        assert "Deterministic(int 0)" in str(param.other_param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Discretize(Deterministic(int 0), round=True)"
+            == expected
         )
 
     def test_applied_to_deterministic(self):
@@ -2915,10 +3141,16 @@ class TestMultiply(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Multiply(iap.Deterministic(0), 1, elementwise=False)
+        expected = "Multiply(%s, %s, False)" % (
+            str(param.other_param),
+            str(param.val)
+        )
+        assert "Deterministic(int 0)" in str(param.other_param)
+        assert "Deterministic(int 1)" in str(param.val)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Multiply(Deterministic(int 0), Deterministic(int 1), False)"
+            == expected
         )
 
     def test_multiply_example_integer_values(self):
@@ -3057,10 +3289,15 @@ class TestDivide(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Divide(iap.Deterministic(0), 1, elementwise=False)
+        expected = "Divide(%s, %s, False)" % (
+            str(param.other_param), str(param.val)
+        )
+        assert "Deterministic(int 0)" in str(param.other_param)
+        assert "Deterministic(int 1)" in str(param.val)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Divide(Deterministic(int 0), Deterministic(int 1), False)"
+            == expected
         )
 
     def test_divide_integers(self):
@@ -3245,10 +3482,16 @@ class TestAdd(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Add(iap.Deterministic(0), 1, elementwise=False)
+        expected = "Add(%s, %s, False)" % (
+            str(param.other_param),
+            str(param.val)
+        )
+        assert "Deterministic(int 0)" in str(param.other_param)
+        assert "Deterministic(int 1)" in str(param.val)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Add(Deterministic(int 0), Deterministic(int 1), False)"
+            == expected
         )
 
     def test_add_integers(self):
@@ -3384,10 +3627,16 @@ class TestSubtract(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Subtract(iap.Deterministic(0), 1, elementwise=False)
+        expected = "Subtract(%s, %s, False)" % (
+            str(param.other_param),
+            str(param.val)
+        )
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Subtract(Deterministic(int 0), Deterministic(int 1), False)"
+            == expected
         )
 
     def test_subtract_integers(self):
@@ -3527,10 +3776,16 @@ class TestPower(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Power(iap.Deterministic(0), 1, elementwise=False)
+        expected = "Power(%s, %s, False)" % (
+            str(param.other_param),
+            str(param.val)
+        )
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Power(Deterministic(int 0), Deterministic(int 1), False)"
+            == expected
         )
 
     def test_pairs(self):
@@ -3664,10 +3919,12 @@ class TestAbsolute(unittest.TestCase):
 
     def test___init__(self):
         param = iap.Absolute(iap.Deterministic(0))
+        expected = "Absolute(%s)" % (str(param.other_param),)
+        assert "Deterministic(int 0)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "Absolute(Deterministic(int 0))"
+            == expected
         )
 
     def test_fixed_values(self):
@@ -3714,10 +3971,12 @@ class TestRandomSign(unittest.TestCase):
 
     def test___init__(self):
         param = iap.RandomSign(iap.Deterministic(0), 0.5)
+        expected = "RandomSign(%s, 0.50)" % (str(param.other_param),)
+        assert "Deterministic(int 0)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "RandomSign(Deterministic(int 0), 0.50)"
+            == expected
         )
 
     def test_value_is_deterministic(self):
@@ -3783,10 +4042,12 @@ class TestForceSign(unittest.TestCase):
 
     def test___init__(self):
         param = iap.ForceSign(iap.Deterministic(0), True, "invert", 1)
+        expected = "ForceSign(%s, True, invert, 1)" % (str(param.other_param),)
+        assert "Deterministic(int 0)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == "ForceSign(Deterministic(int 0), True, invert, 1)"
+            == expected
         )
 
     def test_single_sample_positive(self):
@@ -3934,18 +4195,19 @@ class TestIterativeNoiseAggregator(unittest.TestCase):
         param = iap.IterativeNoiseAggregator(iap.Deterministic(0),
                                              iterations=(1, 3),
                                              aggregation_method="max")
+        expected = "IterativeNoiseAggregator(%s, %s, %s)" % (
+            str(param.other_param),
+            str(param.iterations),
+            str(param.aggregation_method)
+        )
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
+        assert "Deterministic(int 3)" in str(param)
+        assert "Deterministic(max)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == (
-                "IterativeNoiseAggregator("
-                "Deterministic(int 0), "
-                "DiscreteUniform(Deterministic(int 1), "
-                "Deterministic(int 3)"
-                "), "
-                "Deterministic(max)"
-                ")"
-            )
+            == expected
         )
 
     def test_value_is_deterministic_max_1_iter(self):
@@ -4138,21 +4400,20 @@ class TestSigmoid(unittest.TestCase):
             threshold=(-10, 10),
             activated=True,
             mul=1,
-            add=0)
+            add=0
+        )
+        expected = "Sigmoid(%s, %s, %s, 1, 0)" % (
+            str(param.other_param),
+            str(param.threshold),
+            str(param.activated)
+        )
+        assert "Deterministic(int 0)" in str(param)
+        assert "Deterministic(int -10)" in str(param)
+        assert "Deterministic(int 1)" in str(param)
         assert (
             param.__str__()
             == param.__repr__()
-            == (
-                "Sigmoid("
-                "Deterministic(int 0), "
-                "Uniform("
-                "Deterministic(int -10), "
-                "Deterministic(int 10)"
-                "), "
-                "Deterministic(int 1), "
-                "1, "
-                "0)"
-            )
+            == expected
         )
 
     def test_activated_is_true(self):


### PR DESCRIPTION
This patch adds automatic prefetching of random samples,
which performs a single large random sampling call instead
of many smaller ones. This seems to improve the
performance of most augmenters by 5% to 40% for longer
augmentation sessions (50+ consecutive batches of 128
examples each). A few augmenters seem to have gotten
slightly slower, though these might be measuring errors.

The prefetching is done by adding a new parameter,
`imgaug.parameters.AutoPrefetcher`, which prefetches
samples from a child parameter.

The change is expected to have for most augmenters a
slight negative performance impact if the augmenters
are used only once and not for multiple batches. For a
few augmenters there might be sizeable negative
peformance impact (due to prefetching falsely being
performed). The negative impact can be avoided in
these cases by wrapping the augmentation calls in
`with imgaug.parameters.no_prefetching(): ...`.

This patch also adds the property `prefetchable` to
`StochasticParameter`, which defaults to `False` and
determines whether the parameter's outputs may be
prefetched.

It further adds to
`handle_continuous_param()`, `handle_discrete_param()`.
`handle_categorical_string_param()`,
`handle_discrete_kernel_size_param()` and
`handle_probability_param()` in `imgaug.parameters` the
new argument `prefetch`. If set to `True` (the default),
these functions may now partially or fully wrap their
results in `AutoPrefetcher`.

Add functions:
* `imgaug.random.RNG.create_if_not_rng_()`
* `imgaug.parameters.toggle_prefetching()`
* `imgaug.testutils.is_parameter_instance()`
* `imgaug.testutils.remove_prefetching()`

Add properties:
* `imgaug.parameters.StochasticParameter.prefetchable`

Add classes:
* `imgaug.parameters.toggled_prefetching()` (context)
* `imgaug.parameters.no_prefetching()` (context)
* `imgaug.parameters.AutoPrefetcher`
