### PR TITLE
Fix change_color_temperatures_() broadcasting error

### DIFF
--- a/changelogs/master/fixed/20200412_fix_change_color_temperature.md
+++ b/changelogs/master/fixed/20200412_fix_change_color_temperature.md
@@ -1,0 +1,2 @@
+* Fixed `change_color_temperatures_()` crashing on batches
+  that did not contain exactly `1` or `3` images. #646 #650

--- a/changelogs/master/fixed/20200412_fix_change_colorspace.md
+++ b/changelogs/master/fixed/20200412_fix_change_colorspace.md
@@ -1,2 +1,2 @@
 * Fixed `change_colorspaces_()` crashing on batches that
-  did not contain exactly `1` or `3` images. #646 #649
+  did not contain exactly `1` or `3` images. #646 #650

--- a/changelogs/master/fixed/20200412_fix_change_colorspace.md
+++ b/changelogs/master/fixed/20200412_fix_change_colorspace.md
@@ -1,0 +1,2 @@
+* Fixed `change_colorspaces_()` crashing on batches that
+  did not contain exactly `1` or `3` images. #646 #649

--- a/changelogs/master/fixed/20200412_fix_change_colorspace.md
+++ b/changelogs/master/fixed/20200412_fix_change_colorspace.md
@@ -1,2 +1,0 @@
-* Fixed `change_colorspaces_()` crashing on batches that
-  did not contain exactly `1` or `3` images. #646 #650

--- a/imgaug/augmenters/color.py
+++ b/imgaug/augmenters/color.py
@@ -447,7 +447,7 @@ class _KelvinToRGBTable(object):
         multipliers_ceiled = self.table[tbl_indices_ceiled_int, :]
         multipliers = (
             multipliers_floored
-            + interpolation_factors
+            + interpolation_factors[:, np.newaxis]
             * (multipliers_ceiled - multipliers_floored)
         )
 

--- a/test/augmenters/test_color.py
+++ b/test/augmenters/test_color.py
@@ -256,9 +256,11 @@ class Test_change_color_temperatures_(unittest.TestCase):
                 expected = np.uint8(multiplier).reshape((1, 1, 3))
                 assert np.array_equal(image_temp, expected)
 
-    def test_several_images_as_list(self):
+    def test_three_images_as_list(self):
+        # separate tests for three and four images due to possible
+        # broadcasting errors, see issue #646
         image = np.full((1, 1, 3), 255, dtype=np.uint8)
-        
+
         images_temp = iaa.change_color_temperatures_(
             [np.copy(image), np.copy(image), np.copy(image)],
             [11100, 11200, 11300]
@@ -274,7 +276,30 @@ class Test_change_color_temperatures_(unittest.TestCase):
         assert np.array_equal(images_temp[1], expected[1])
         assert np.array_equal(images_temp[2], expected[2])
 
-    def test_several_images_as_array(self):
+    def test_four_images_as_list(self):
+        # separate tests for three and four images due to possible
+        # broadcasting errors, see issue #646
+        image = np.full((1, 1, 3), 255, dtype=np.uint8)
+        
+        images_temp = iaa.change_color_temperatures_(
+            [np.copy(image), np.copy(image), np.copy(image), np.copy(image)],
+            [11100, 11200, 11300, 11100]
+        )
+
+        expected = np.array([
+            [196, 214, 255],
+            [195, 214, 255],
+            [195, 214, 255],
+            [196, 214, 255]
+        ], dtype=np.uint8).reshape((4, 1, 1, 3))
+        assert isinstance(images_temp, list)
+        assert np.array_equal(images_temp[0], expected[0])
+        assert np.array_equal(images_temp[1], expected[1])
+        assert np.array_equal(images_temp[2], expected[2])
+
+    def test_three_images_as_array(self):
+        # separate tests for three and four images due to possible
+        # broadcasting errors, see issue #646
         image = np.full((1, 1, 3), 255, dtype=np.uint8)
 
         images_temp = iaa.change_color_temperatures_(
@@ -287,6 +312,26 @@ class Test_change_color_temperatures_(unittest.TestCase):
             [195, 214, 255],
             [195, 214, 255]
         ], dtype=np.uint8).reshape((3, 1, 1, 3))
+        assert ia.is_np_array(images_temp)
+        assert np.array_equal(images_temp, expected)
+
+    def test_four_images_as_array(self):
+        # separate tests for three and four images due to possible
+        # broadcasting errors, see issue #646
+        image = np.full((1, 1, 3), 255, dtype=np.uint8)
+
+        images_temp = iaa.change_color_temperatures_(
+            np.uint8([np.copy(image), np.copy(image), np.copy(image),
+                      np.copy(image)]),
+            np.float32([11100, 11200, 11300, 11100])
+        )
+
+        expected = np.array([
+            [196, 214, 255],
+            [195, 214, 255],
+            [195, 214, 255],
+            [196, 214, 255]
+        ], dtype=np.uint8).reshape((4, 1, 1, 3))
         assert ia.is_np_array(images_temp)
         assert np.array_equal(images_temp, expected)
 

--- a/test/augmenters/test_mixed_files.py
+++ b/test/augmenters/test_mixed_files.py
@@ -30,7 +30,7 @@ def test_determinism():
     images = [
         ia.quokka(size=(128, 128)),
         ia.quokka(size=(64, 64)),
-        ia.imresize_single_image(skimage.data.astronaut(), (128, 256))
+        ia.quokka((128, 256))
     ]
     images.extend([ia.quokka(size=(16, 16))] * 20)
 

--- a/test/test_multicore.py
+++ b/test/test_multicore.py
@@ -354,7 +354,7 @@ class TestPool(unittest.TestCase):
             result = [result] + list(gen)
             times = np.float64(times)
             times_diffs = times[1:] - times[0:-1]
-            assert np.all(times_diffs < timeout)
+            assert np.all(times_diffs < timeout * 1.01)
             assert contains_all_ids(result)
 
             # with output buffer limit, but set to the number of batches,
@@ -366,7 +366,7 @@ class TestPool(unittest.TestCase):
             result = [result] + list(gen)
             times = np.float64(times)
             times_diffs = times[1:] - times[0:-1]
-            assert np.all(times_diffs < timeout)
+            assert np.all(times_diffs < timeout * 1.01)
             assert contains_all_ids(result)
 
             # With output buffer limit of #batches/2 (=4), followed by a
@@ -385,9 +385,9 @@ class TestPool(unittest.TestCase):
             times_diffs = times[1:] - times[0:-1]
             # use -1 here because we have N-1 times for N batches as
             # diffs denote diffs between Nth and N+1th batch
-            assert np.all(times_diffs[0:4-1] < timeout)
-            assert np.all(times_diffs[4-1:4-1+1] >= timeout)
-            assert np.all(times_diffs[4-1+1:] < timeout)
+            assert np.all(times_diffs[0:4-1] < timeout * 1.01)
+            assert np.all(times_diffs[4-1:4-1+1] >= timeout * 0.99)
+            assert np.all(times_diffs[4-1+1:] < timeout * 1.01)
             assert contains_all_ids(result)
 
     def test_imap_batches(self):


### PR DESCRIPTION
This patch fixes `change_color_temperatures_()` crashing on
batches that do not contain exactly `1` or `3` images. #646