### PR TITLE
Improve performance of dtype checks

### DIFF
--- a/.github/workflows/test_master.yml
+++ b/.github/workflows/test_master.yml
@@ -130,9 +130,11 @@ jobs:
     # Code coverage reports
     # ----------------
     # Add 'coverage html -d out_foldername' to add html reports
+    # Dont deactivate -Walways here, otherwise some tests fail as warnings
+    # are no longer produced.
     - name: Generate code coverage report
       run: |
-        coverage run --source imgaug -m pytest --verbose
+        coverage run --source imgaug -m pytest --verbose -Walways
         coverage xml
         coverage report
 

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -136,9 +136,11 @@ jobs:
     # Code coverage reports
     # ----------------
     # Add 'coverage html -d out_foldername' to add html reports
+    # Dont deactivate -Walways here, otherwise some tests fail as warnings
+    # are no longer produced.
     - name: Generate code coverage report
       run: |
-        coverage run --source imgaug -m pytest --verbose
+        coverage run --source imgaug -m pytest --verbose -Walways
         coverage xml
         coverage report
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -170,6 +170,7 @@ disable=print-statement,
         len-as-condition,  # more annoying than useful warning, suggestion doesn't even work with np arrays
         unused-argument,  # without this pylint complains about almost every _augment_batch() implementation not using 'parents' and 'hooks'; due to inheritance we can't do anything about that
         no-self-use,  # without this pylint complains about every get_parameters() implementation that returns only []; due to inheritance we can't do anything about that
+        protected-access,  # we use plenty of calls of functions that are only marked private to discourage calls of them from outside of the library, but not from within the library
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/changelogs/master/improved/20200517_faster_dtype_checks.md
+++ b/changelogs/master/improved/20200517_faster_dtype_checks.md
@@ -1,4 +1,4 @@
-# Improved Performance of dtype checks #???
+# Improved Performance of dtype checks #663
 
 This patch improves the performance of dtype checks
 throughout the library. The new method verifies input

--- a/changelogs/master/improved/20200517_faster_dtype_checks.md
+++ b/changelogs/master/improved/20200517_faster_dtype_checks.md
@@ -1,0 +1,15 @@
+# Improved Performance of dtype checks #???
+
+This patch improves the performance of dtype checks
+throughout the library. The new method verifies input
+arrays around 10x to 100x faster than the previous one.
+
+Add functions:
+* `imgaug.dtypes.gate_dtypes_strs()`
+* `imgaug.dtypes.allow_only_uint8()`
+
+Add decorators:
+* `imgaug.testutils.ensure_deprecation_warning`
+
+Deprecate functions:
+* `imgaug.dtypes.gate_dtypes()`

--- a/imgaug/augmenters/artistic.py
+++ b/imgaug/augmenters/artistic.py
@@ -96,15 +96,7 @@ def stylize_cartoon(image, blur_ksize=3, segmentation_size=1.0,
         Image in cartoonish style.
 
     """
-    iadt.gate_dtypes(
-        image,
-        allowed=["uint8"],
-        disallowed=["bool",
-                    "uint16", "uint32", "uint64", "uint128", "uint256",
-                    "int8", "int16", "int32", "int64", "int128", "int256",
-                    "float16", "float32", "float64", "float96", "float128",
-                    "float256"],
-        augmenter=None)
+    iadt.allow_only_uint8({image.dtype})
 
     assert image.ndim == 3 and image.shape[2] == 3, (
         "Expected to get a (H,W,C) image, got shape %s." % (image.shape,))

--- a/imgaug/augmenters/blend.py
+++ b/imgaug/augmenters/blend.py
@@ -166,10 +166,10 @@ def blend_alpha_(image_fg, image_bg, alpha, eps=1e-2):
         "Expected foreground and background images to have the same dtype "
         "kind. Got %s and %s." % (image_fg.dtype.kind, image_bg.dtype.kind))
     # TODO switch to gate_dtypes()
-    assert image_fg.dtype.name not in ["float128"], (
+    assert image_fg.dtype != iadt._FLOAT128_DTYPE, (
         "Foreground image was float128, but blend_alpha_() cannot handle that "
         "dtype.")
-    assert image_bg.dtype.name not in ["float128"], (
+    assert image_bg.dtype != iadt._FLOAT128_DTYPE, (
         "Background image was float128, but blend_alpha_() cannot handle that "
         "dtype.")
 
@@ -228,8 +228,8 @@ def blend_alpha_(image_fg, image_bg, alpha, eps=1e-2):
             "Expected 'alpha' value(s) to be in the interval [0.0, 1.0]. "
             "Got min %.4f and max %.4f." % (np.min(alpha), np.max(alpha)))
 
-    both_uint8 = (image_fg.dtype.name == "uint8"
-                  and image_bg.dtype.name == "uint8")
+    uint8 = iadt._UINT8_DTYPE
+    both_uint8 = (image_fg.dtype, image_bg.dtype) == (uint8, uint8)
     if both_uint8:
         if alpha.size == 1:
             image_blend = _blend_alpha_uint8_single_alpha_(
@@ -352,11 +352,11 @@ def _blend_alpha_non_uint8(image_fg, image_bg, alpha):
     isize = max(isize, 4)
     dt_blend = np.dtype("f%d" % (isize,))
 
-    if alpha.dtype.name != dt_blend.name:
+    if alpha.dtype != dt_blend:
         alpha = alpha.astype(dt_blend)
-    if image_fg.dtype.name != dt_blend.name:
+    if image_fg.dtype != dt_blend:
         image_fg = image_fg.astype(dt_blend)
-    if image_bg.dtype.name != dt_blend.name:
+    if image_bg.dtype != dt_blend:
         image_bg = image_bg.astype(dt_blend)
 
     # the following is

--- a/imgaug/augmenters/contrast.py
+++ b/imgaug/augmenters/contrast.py
@@ -52,10 +52,12 @@ class _ContrastFuncWrapper(meta.Augmenter):
         images = batch.images
 
         if self.dtypes_allowed is not None:
-            iadt.gate_dtypes(images,
-                             allowed=self.dtypes_allowed,
-                             disallowed=self.dtypes_disallowed,
-                             augmenter=self)
+            iadt.gate_dtypes_strs(
+                images,
+                allowed=self.dtypes_allowed,
+                disallowed=self.dtypes_disallowed,
+                augmenter=self
+            )
 
         nb_images = len(images)
         rss = random_state.duplicate(1+nb_images)
@@ -152,7 +154,7 @@ def adjust_contrast_gamma(arr, gamma):
     # int8 is also possible according to docs
     # https://docs.opencv.org/3.0-beta/modules/core/doc/operations_on_arrays.html#cv2.LUT ,
     # but here it seemed like `d` was 0 for CV_8S, causing that to fail
-    if arr.dtype.name == "uint8":
+    if arr.dtype == iadt._UINT8_DTYPE:
         min_value, _center_value, max_value = \
             iadt.get_value_range_of_dtype(arr.dtype)
         dynamic_range = max_value - min_value
@@ -236,7 +238,7 @@ def adjust_contrast_sigmoid(arr, gain, cutoff):
     # int8 is also possible according to docs
     # https://docs.opencv.org/3.0-beta/modules/core/doc/operations_on_arrays.html#cv2.LUT ,
     # but here it seemed like `d` was 0 for CV_8S, causing that to fail
-    if arr.dtype.name == "uint8":
+    if arr.dtype == iadt._UINT8_DTYPE:
         min_value, _center_value, max_value = \
             iadt.get_value_range_of_dtype(arr.dtype)
         dynamic_range = max_value - min_value
@@ -321,7 +323,7 @@ def adjust_contrast_log(arr, gain):
     # int8 is also possible according to docs
     # https://docs.opencv.org/3.0-beta/modules/core/doc/operations_on_arrays.html#cv2.LUT ,
     # but here it seemed like `d` was 0 for CV_8S, causing that to fail
-    if arr.dtype.name == "uint8":
+    if arr.dtype == iadt._UINT8_DTYPE:
         min_value, _center_value, max_value = \
             iadt.get_value_range_of_dtype(arr.dtype)
         dynamic_range = max_value - min_value
@@ -391,7 +393,7 @@ def adjust_contrast_linear(arr, alpha):
     # int8 is also possible according to docs
     # https://docs.opencv.org/3.0-beta/modules/core/doc/operations_on_arrays.html#cv2.LUT ,
     # but here it seemed like `d` was 0 for CV_8S, causing that to fail
-    if arr.dtype.name == "uint8":
+    if arr.dtype == iadt._UINT8_DTYPE:
         min_value, center_value, max_value = \
             iadt.get_value_range_of_dtype(arr.dtype)
         # TODO get rid of this int(...)
@@ -492,10 +494,9 @@ class GammaContrast(_ContrastFuncWrapper):
         func = adjust_contrast_gamma
         super(GammaContrast, self).__init__(
             func, params1d, per_channel,
-            dtypes_allowed=["uint8", "uint16", "uint32", "uint64",
-                            "int8", "int16", "int32", "int64",
-                            "float16", "float32", "float64"],
-            dtypes_disallowed=["float96", "float128", "float256", "bool"],
+            dtypes_allowed="uint8 uint16 uint32 uint64 int8 int16 int32 int64 "
+                           "float16 float32 float64",
+            dtypes_disallowed="float128 bool",
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
@@ -598,10 +599,9 @@ class SigmoidContrast(_ContrastFuncWrapper):
 
         super(SigmoidContrast, self).__init__(
             func, params1d, per_channel,
-            dtypes_allowed=["uint8", "uint16", "uint32", "uint64",
-                            "int8", "int16", "int32", "int64",
-                            "float16", "float32", "float64"],
-            dtypes_disallowed=["float96", "float128", "float256", "bool"],
+            dtypes_allowed="uint8 uint16 uint32 uint64 int8 int16 int32 int64 "
+                           "float16 float32 float64",
+            dtypes_disallowed="float128 bool",
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
@@ -680,10 +680,9 @@ class LogContrast(_ContrastFuncWrapper):
 
         super(LogContrast, self).__init__(
             func, params1d, per_channel,
-            dtypes_allowed=["uint8", "uint16", "uint32", "uint64",
-                            "int8", "int16", "int32", "int64",
-                            "float16", "float32", "float64"],
-            dtypes_disallowed=["float96", "float128", "float256", "bool"],
+            dtypes_allowed="uint8 uint16 uint32 uint64 int8 int16 int32 int64 "
+                           "float16 float32 float64",
+            dtypes_disallowed="float128 bool",
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
@@ -760,11 +759,9 @@ class LinearContrast(_ContrastFuncWrapper):
 
         super(LinearContrast, self).__init__(
             func, params1d, per_channel,
-            dtypes_allowed=["uint8", "uint16", "uint32",
-                            "int8", "int16", "int32",
-                            "float16", "float32", "float64"],
-            dtypes_disallowed=["uint64", "int64", "float96", "float128",
-                               "float256", "bool"],
+            dtypes_allowed="uint8 uint16 uint32 int8 int16 int32 float16 "
+                           "float32 float64",
+            dtypes_disallowed="uint64 int64 float128 bool",
             seed=seed, name=name,
             random_state=random_state, deterministic=deterministic)
 
@@ -1019,15 +1016,13 @@ class AllChannelsCLAHE(meta.Augmenter):
 
         images = batch.images
 
-        iadt.gate_dtypes(
+        iadt.gate_dtypes_strs(
             images,
-            allowed=["uint8", "uint16"],
-            disallowed=["bool",
-                        "uint32", "uint64", "uint128", "uint256",
-                        "int8", "int16", "int32", "int64", "int128", "int256",
-                        "float16", "float32", "float64", "float96",
-                        "float128", "float256"],
-            augmenter=self)
+            allowed="uint8 uint16",
+            disallowed="bool uint32 uint64 int8 int16 int32 int64 "
+                       "float16 float32 float64 float128",
+            augmenter=self
+        )
 
         nb_images = len(images)
         nb_channels = meta.estimate_max_number_of_channels(images)
@@ -1282,15 +1277,7 @@ class CLAHE(meta.Augmenter):
 
         images = batch.images
 
-        iadt.gate_dtypes(
-            images,
-            allowed=["uint8"],
-            disallowed=["bool",
-                        "uint16", "uint32", "uint64", "uint128", "uint256",
-                        "int8", "int16", "int32", "int64", "int128", "int256",
-                        "float16", "float32", "float64", "float96", "float128",
-                        "float256"],
-            augmenter=self)
+        iadt.allow_only_uint8(images, augmenter=self)
 
         def _augment_all_channels_clahe(images_normalized,
                                         random_state_derived):
@@ -1396,15 +1383,7 @@ class AllChannelsHistogramEqualization(meta.Augmenter):
 
         images = batch.images
 
-        iadt.gate_dtypes(
-            images,
-            allowed=["uint8"],
-            disallowed=["bool",
-                        "uint16", "uint32", "uint64", "uint128", "uint256",
-                        "int8", "int16", "int32", "int64", "int128", "int256",
-                        "float16", "float32", "float64", "float96", "float128",
-                        "float256"],
-            augmenter=self)
+        iadt.allow_only_uint8(images, augmenter=self)
 
         for i, image in enumerate(images):
             if image.size == 0:
@@ -1556,15 +1535,7 @@ class HistogramEqualization(meta.Augmenter):
 
         images = batch.images
 
-        iadt.gate_dtypes(
-            images,
-            allowed=["uint8"],
-            disallowed=["bool",
-                        "uint16", "uint32", "uint64", "uint128", "uint256",
-                        "int8", "int16", "int32", "int64", "int128", "int256",
-                        "float16", "float32", "float64", "float96", "float128",
-                        "float256"],
-            augmenter=self)
+        iadt.allow_only_uint8(images, augmenter=self)
 
         def _augment_all_channels_histogram_equalization(images_normalized,
                                                          random_state_derived):

--- a/imgaug/augmenters/convolutional.py
+++ b/imgaug/augmenters/convolutional.py
@@ -103,16 +103,10 @@ def convolve_(image, kernel):
         Might have been modified in-place.
 
     """
-    iadt.gate_dtypes(
-        image,
-        allowed=["bool",
-                 "uint8", "uint16",
-                 "int8", "int16",
-                 "float16", "float32", "float64"],
-        disallowed=["uint32", "uint64", "uint128", "uint256",
-                    "int32", "int64", "int128", "int256",
-                    "float96", "float128", "float256"],
-        augmenter=None
+    iadt.gate_dtypes_strs(
+        {image.dtype},
+        allowed="bool uint8 uint16 int8 int16 float16 float32 float64",
+        disallowed="uint32 uint64 int32 int64 float128"
     )
 
     # currently we don't have to worry here about alignemnt with
@@ -125,9 +119,9 @@ def convolve_(image, kernel):
     nb_channels = 1 if len(input_shape) == 2 else input_shape[2]
 
     input_dtype = image.dtype
-    if image.dtype.name in ["bool", "float16"]:
+    if image.dtype in {iadt._BOOL_DTYPE, iadt._FLOAT16_DTYPE}:
         image = image.astype(np.float32, copy=False)
-    elif image.dtype.name == "int8":
+    elif image.dtype == iadt._INT8_DTYPE:
         image = image.astype(np.int16, copy=False)
 
     if ia.is_np_array(kernel):
@@ -173,9 +167,9 @@ def convolve_(image, kernel):
                     dst=arr_channel
                 )
 
-    if input_dtype.name == "bool":
+    if input_dtype.kind == "b":
         image = image > 0.5
-    elif input_dtype.name in ["int8", "float16"]:
+    elif input_dtype in {iadt._INT8_DTYPE, iadt._FLOAT16_DTYPE}:
         image = iadt.restore_dtypes_(image, input_dtype)
 
     if len(input_shape) == 3 and image.ndim == 2:

--- a/imgaug/augmenters/edges.py
+++ b/imgaug/augmenters/edges.py
@@ -126,7 +126,7 @@ class RandomColorsBinaryImageColorizer(IBinaryImageColorizer):
         assert image_original.shape[-1] in [1, 3, 4], (
             "Expected original image to have 1, 3 or 4 channels. "
             "Got %d channels." % (image_original.shape[-1],))
-        assert image_original.dtype.name == "uint8", (
+        assert image_original.dtype == iadt._UINT8_DTYPE, (
             "Expected original image to have dtype uint8, got dtype %s." % (
                 image_original.dtype.name))
 
@@ -421,17 +421,7 @@ class Canny(meta.Augmenter):
 
         images = batch.images
 
-        iadt.gate_dtypes(images,
-                         allowed=["uint8"],
-                         disallowed=[
-                             "bool",
-                             "uint16", "uint32", "uint64", "uint128",
-                             "uint256",
-                             "int8", "int16", "int32", "int64", "int128",
-                             "int256",
-                             "float32", "float64", "float96", "float128",
-                             "float256"],
-                         augmenter=self)
+        iadt.allow_only_uint8(images, augmenter=self)
 
         rss = random_state.duplicate(len(images))
         samples = self._draw_samples(images, rss[-1])

--- a/imgaug/augmenters/flip.py
+++ b/imgaug/augmenters/flip.py
@@ -16,6 +16,7 @@ import six.moves as sm
 from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from .. import parameters as iap
+from .. import dtypes as iadt
 
 
 # pylint:disable=pointless-string-statement
@@ -673,7 +674,9 @@ fort cv2_ get contig 1.95215ms
 """
 # pylint:enable=pointless-string-statement
 
-_FLIPLR_DTYPES_CV2 = {"uint8", "uint16", "int8", "int16"}
+_FLIPLR_DTYPES_CV2 = iadt._convert_dtype_strs_to_types(
+    "uint8 uint16 int8 int16"
+)
 
 
 def fliplr(arr):
@@ -719,7 +722,7 @@ def fliplr(arr):
     # kinda works with that, it is very rare to happen and would induce an
     # additional check (with significant relative impact on runtime considering
     # flipping is already ultra fast)
-    if arr.dtype.name in _FLIPLR_DTYPES_CV2:
+    if arr.dtype in _FLIPLR_DTYPES_CV2:
         return _fliplr_cv2(arr)
     return _fliplr_sliced(arr)
 

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -42,12 +42,12 @@ from .. import dtypes as iadt
 from .. import random as iarandom
 
 
-_VALID_DTYPES_CV2_ORDER_0 = {"uint8", "uint16", "int8", "int16", "int32",
-                             "float16", "float32", "float64",
-                             "bool"}
-_VALID_DTYPES_CV2_ORDER_NOT_0 = {"uint8", "uint16", "int8", "int16",
-                                 "float16", "float32", "float64",
-                                 "bool"}
+_WARP_AFF_VALID_DTYPES_CV2_ORDER_0 = iadt._convert_dtype_strs_to_types(
+    "uint8 uint16 int8 int16 int32 float16 float32 float64 bool"
+)
+_WARP_AFF_VALID_DTYPES_CV2_ORDER_NOT_0 = iadt._convert_dtype_strs_to_types(
+    "uint8 uint16 int8 int16 float16 float32 float64 bool"
+)
 
 # skimage | cv2
 # 0       | cv2.INTER_NEAREST
@@ -178,9 +178,11 @@ def _warp_affine_arr(arr, matrix, order=1, mode="constant", cval=0,
 
     cv2_bad_order = order not in [0, 1, 3]
     if order == 0:
-        cv2_bad_dtype = (arr.dtype.name not in _VALID_DTYPES_CV2_ORDER_0)
+        cv2_bad_dtype = (arr.dtype
+                         not in _WARP_AFF_VALID_DTYPES_CV2_ORDER_0)
     else:
-        cv2_bad_dtype = (arr.dtype.name not in _VALID_DTYPES_CV2_ORDER_NOT_0)
+        cv2_bad_dtype = (arr.dtype
+                         not in _WARP_AFF_VALID_DTYPES_CV2_ORDER_NOT_0)
     cv2_impossible = cv2_bad_order or cv2_bad_dtype
     use_skimage = (
         backend == "skimage"
@@ -219,16 +221,12 @@ def _warp_affine_arr(arr, matrix, order=1, mode="constant", cval=0,
 
 
 def _warp_affine_arr_skimage(arr, matrix, cval, mode, order, output_shape):
-    iadt.gate_dtypes(
-        arr,
-        allowed=["bool",
-                 "uint8", "uint16", "uint32",
-                 "int8", "int16", "int32",
-                 "float16", "float32", "float64"],
-        disallowed=["uint64", "uint128", "uint256",
-                    "int64", "int128", "int256",
-                    "float96", "float128", "float256"],
-        augmenter=None)
+    iadt.gate_dtypes_strs(
+        {arr.dtype},
+        allowed="bool uint8 uint16 uint32 int8 int16 int32 "
+                "float16 float32 float64",
+        disallowed="uint64 int64 float128"
+    )
 
     input_dtype = arr.dtype
 
@@ -252,27 +250,22 @@ def _warp_affine_arr_skimage(arr, matrix, cval, mode, order, output_shape):
 
 
 def _warp_affine_arr_cv2(arr, matrix, cval, mode, order, output_shape):
-    iadt.gate_dtypes(
-        arr,
-        allowed=["bool",
-                 "uint8", "uint16",
-                 "int8", "int16", "int32",
-                 "float16", "float32", "float64"],
-        disallowed=["uint32", "uint64", "uint128", "uint256",
-                    "int64", "int128", "int256",
-                    "float96", "float128", "float256"],
-        augmenter=None)
+    iadt.gate_dtypes_strs(
+        {arr.dtype},
+        allowed="bool uint8 uint16 int8 int16 int32 float16 float32 float64",
+        disallowed="uint32 uint64 int64 float128"
+    )
 
     if order != 0:
-        assert arr.dtype.name != "int32", (
+        assert arr.dtype != iadt._INT32_DTYPE, (
             "Affine only supports cv2-based transformations of int32 "
             "arrays when using order=0, but order was set to %d." % (
                 order,))
 
     input_dtype = arr.dtype
-    if input_dtype.name in ["bool", "float16"]:
+    if input_dtype in {iadt._BOOL_DTYPE, iadt._FLOAT16_DTYPE}:
         arr = arr.astype(np.float32)
-    elif input_dtype.name == "int8" and order != 0:
+    elif input_dtype == iadt._INT8_DTYPE and order != 0:
         arr = arr.astype(np.int16)
 
     dsize = (
@@ -319,9 +312,9 @@ def _warp_affine_arr_cv2(arr, matrix, cval, mode, order, output_shape):
         ]
         image_warped = np.stack(image_warped, axis=-1)
 
-    if input_dtype.name == "bool":
+    if input_dtype.kind == "b":
         image_warped = image_warped > 0.5
-    elif input_dtype.name in ["int8", "float16"]:
+    elif input_dtype in {iadt._INT8_DTYPE, iadt._FLOAT16_DTYPE}:
         image_warped = iadt.restore_dtypes_(image_warped, input_dtype)
 
     return image_warped
@@ -2920,9 +2913,11 @@ class AffineCv2(meta.Augmenter):
                 (nb_samples,), random_state=rngs[5])
             translate_samples = (translate_samples, translate_samples)
 
-        valid_dts = ["int32", "int64", "float32", "float64"]
+        valid_dts = iadt._convert_dtype_strs_to_types(
+            "int32 int64 float32 float64"
+        )
         for i in sm.xrange(2):
-            assert translate_samples[i].dtype.name in valid_dts, (
+            assert translate_samples[i].dtype in valid_dts, (
                 "Expected translate_samples to have any dtype of %s. "
                 "Got %s." % (str(valid_dts), translate_samples[i].dtype.name,))
 
@@ -3182,16 +3177,13 @@ class PiecewiseAffine(meta.Augmenter):
 
     # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
-        iadt.gate_dtypes(
+        iadt.gate_dtypes_strs(
             images,
-            allowed=["bool",
-                     "uint8", "uint16", "uint32",
-                     "int8", "int16", "int32",
-                     "float16", "float32", "float64"],
-            disallowed=["uint64", "uint128", "uint256",
-                        "int64", "int128", "int256",
-                        "float96", "float128", "float256"],
-            augmenter=self)
+            allowed="bool uint8 uint16 uint32 int8 int16 int32 "
+                    "float16 float32 float64",
+            disallowed="uint64 int64 float128",
+            augmenter=self
+        )
 
         result = images
 
@@ -3783,16 +3775,12 @@ class PerspectiveTransform(meta.Augmenter):
 
     # Added in 0.4.0.
     def _augment_images_by_samples(self, images, samples):
-        iadt.gate_dtypes(
+        iadt.gate_dtypes_strs(
             images,
-            allowed=["bool",
-                     "uint8", "uint16",
-                     "int8", "int16",
-                     "float16", "float32", "float64"],
-            disallowed=["uint32", "uint64", "uint128", "uint256",
-                        "int32", "int64", "int128", "int256",
-                        "float96", "float128", "float256"],
-            augmenter=self)
+            allowed="bool uint8 uint16 int8 int16 float16 float32 float64",
+            disallowed="uint32 uint64 int32 int64 float128",
+            augmenter=self
+        )
 
         result = images
         if not self.keep_size:
@@ -3803,9 +3791,10 @@ class PerspectiveTransform(meta.Augmenter):
 
         for i, (image, matrix, max_height, max_width, cval, mode) in gen:
             input_dtype = image.dtype
-            if input_dtype.name in ["int8"]:
+            if input_dtype == iadt._INT8_DTYPE:
                 image = image.astype(np.int16)
-            elif input_dtype.name in ["bool", "float16"]:
+            elif (input_dtype
+                  in {iadt._BOOL_DTYPE, iadt._FLOAT16_DTYPE}):
                 image = image.astype(np.float32)
 
             # cv2.warpPerspective only supports <=4 channels and errors
@@ -3844,9 +3833,9 @@ class PerspectiveTransform(meta.Augmenter):
                 h, w = image.shape[0:2]
                 warped = ia.imresize_single_image(warped, (h, w))
 
-            if input_dtype.name == "bool":
+            if input_dtype.kind == "b":
                 warped = warped > 0.5
-            elif warped.dtype.name != input_dtype.name:
+            elif warped.dtype != input_dtype:
                 warped = iadt.restore_dtypes_(warped, input_dtype)
 
             result[i] = warped
@@ -4407,16 +4396,13 @@ class ElasticTransformation(meta.Augmenter):
     def _augment_batch_(self, batch, random_state, parents, hooks):
         # pylint: disable=invalid-name
         if batch.images is not None:
-            iadt.gate_dtypes(
+            iadt.gate_dtypes_strs(
                 batch.images,
-                allowed=["bool",
-                         "uint8", "uint16", "uint32", "uint64",
-                         "int8", "int16", "int32", "int64",
-                         "float16", "float32", "float64"],
-                disallowed=["uint128", "uint256",
-                            "int128", "int256",
-                            "float96", "float128", "float256"],
-                augmenter=self)
+                allowed="bool uint8 uint16 uint32 uint64 int8 int16 int32 "
+                        "int64 float16 float32 float64",
+                disallowed="float128",
+                augmenter=self
+            )
 
         shapes = batch.get_rowwise_shapes()
         samples = self._draw_samples(len(shapes), random_state)
@@ -4461,7 +4447,7 @@ class ElasticTransformation(meta.Augmenter):
         cval = max(min(samples.cvals[row_idx], max_value), min_value)
 
         input_dtype = image.dtype
-        if image.dtype.name == "float16":
+        if image.dtype == iadt._FLOAT16_DTYPE:
             image = image.astype(np.float32)
 
         image_aug = self._map_coordinates(
@@ -4470,7 +4456,7 @@ class ElasticTransformation(meta.Augmenter):
             cval=cval,
             mode=samples.modes[row_idx])
 
-        if image.dtype.name != input_dtype.name:
+        if image.dtype != input_dtype:
             image_aug = iadt.restore_dtypes_(image_aug, input_dtype)
         return image_aug
 
@@ -4735,47 +4721,39 @@ class ElasticTransformation(meta.Augmenter):
         if image.size == 0:
             return np.copy(image)
 
-        if order == 0 and image.dtype.name in ["uint64", "int64"]:
+        if (order == 0
+                and image.dtype
+                in {iadt._UINT64_DTYPE, iadt._INT64_DTYPE}):
             raise Exception(
                 "dtypes uint64 and int64 are only supported in "
                 "ElasticTransformation for order=0, got order=%d with "
                 "dtype=%s." % (order, image.dtype.name))
 
         input_dtype = image.dtype
-        if image.dtype.name == "bool":
+        if image.dtype.kind == "b":
             image = image.astype(np.float32)
-        elif order == 1 and image.dtype.name in ["int8", "int16", "int32"]:
+        elif (order == 1
+              and image.dtype
+              in {iadt._INT8_DTYPE, iadt._INT16_DTYPE, iadt._INT32_DTYPE}):
             image = image.astype(np.float64)
-        elif order >= 2 and image.dtype.name == "int8":
+        elif order >= 2 and image.dtype == iadt._INT8_DTYPE:
             image = image.astype(np.int16)
-        elif order >= 2 and image.dtype.name == "int32":
+        elif order >= 2 and image.dtype == iadt._INT32_DTYPE:
             image = image.astype(np.float64)
 
         shrt_max = 32767  # maximum of datatype `short`
         backend = "cv2"
         if order == 0:
-            bad_dtype_cv2 = (
-                image.dtype.name in [
-                    "uint32", "uint64",
-                    "int64",
-                    "float128",
-                    "bool"]
+            bad_dtype_cv2 = image.dtype in iadt._convert_dtype_strs_to_types(
+                "uint32 uint64 int64 float128 bool"
             )
         elif order == 1:
-            bad_dtype_cv2 = (
-                image.dtype.name in [
-                    "uint32", "uint64",
-                    "int8", "int16", "int32", "int64",
-                    "float128",
-                    "bool"]
+            bad_dtype_cv2 = image.dtype in iadt._convert_dtype_strs_to_types(
+                "uint32 uint64 int8 int16 int32 int64 float128 bool"
             )
         else:
-            bad_dtype_cv2 = (
-                image.dtype.name in [
-                    "uint32", "uint64",
-                    "int8", "int32", "int64",
-                    "float128",
-                    "bool"]
+            bad_dtype_cv2 = image.dtype in iadt._convert_dtype_strs_to_types(
+                "uint32 uint64 int8 int32 int64 float128 bool"
             )
 
         bad_dx_shape_cv2 = (dx.shape[0] >= shrt_max or dx.shape[1] >= shrt_max)
@@ -4854,7 +4832,7 @@ class ElasticTransformation(meta.Augmenter):
                     current_chan_idx += 4
                 result = np.concatenate(result, axis=2)
 
-        if result.dtype.name != input_dtype.name:
+        if result.dtype != input_dtype:
             result = iadt.restore_dtypes_(result, input_dtype)
 
         return result
@@ -5364,16 +5342,13 @@ class WithPolarWarping(meta.Augmenter):
     # Added in 0.4.0.
     def _augment_batch_(self, batch, random_state, parents, hooks):
         if batch.images is not None:
-            iadt.gate_dtypes(
+            iadt.gate_dtypes_strs(
                 batch.images,
-                allowed=["bool",
-                         "uint8", "uint16",
-                         "int8", "int16", "int32",
-                         "float16", "float32", "float64"],
-                disallowed=["uint32", "uint64", "uint128", "uint256",
-                            "int64", "int128", "int256",
-                            "float96", "float128", "float256"],
-                augmenter=self)
+                allowed="bool uint8 uint16 int8 int16 int32 float16 float32 "
+                        "float64",
+                disallowed="uint32 uint64 int64 float128",
+                augmenter=self
+            )
 
         with batch.propagation_hooks_ctx(self, hooks, parents):
             batch, inv_data_bbs = self._convert_bbs_to_polygons_(batch)
@@ -5566,10 +5541,10 @@ class WithPolarWarping(meta.Augmenter):
                 shapes_orig.append(arr.shape)
                 continue
 
-            input_dtype = arr.dtype.name
-            if input_dtype == "bool":
+            input_dtype = arr.dtype
+            if input_dtype.kind == "b":
                 arr = arr.astype(np.uint8) * 255
-            elif input_dtype == "float16":
+            elif input_dtype == iadt._FLOAT16_DTYPE:
                 arr = arr.astype(np.float32)
 
             height, width = arr.shape[0:2]
@@ -5597,9 +5572,9 @@ class WithPolarWarping(meta.Augmenter):
                 if arr_warped.ndim == 2 and arr.ndim == 3:
                     arr_warped = arr_warped[:, :, np.newaxis]
 
-            if input_dtype == "bool":
+            if input_dtype.kind == "b":
                 arr_warped = (arr_warped > 128)
-            elif input_dtype == "float16":
+            elif input_dtype == iadt._FLOAT16_DTYPE:
                 arr_warped = arr_warped.astype(np.float16)
 
             arrays_warped.append(arr_warped)
@@ -5627,10 +5602,10 @@ class WithPolarWarping(meta.Augmenter):
                 arrays_inv.append(arr_warped)
                 continue
 
-            input_dtype = arr_warped.dtype.name
-            if input_dtype == "bool":
+            input_dtype = arr_warped.dtype
+            if input_dtype.kind == "b":
                 arr_warped = arr_warped.astype(np.uint8) * 255
-            elif input_dtype == "float16":
+            elif input_dtype == iadt._FLOAT16_DTYPE:
                 arr_warped = arr_warped.astype(np.float32)
 
             height, width = shape_orig[0:2]
@@ -5661,9 +5636,9 @@ class WithPolarWarping(meta.Augmenter):
                 if arr_inv.ndim == 2 and arr_warped.ndim == 3:
                     arr_inv = arr_inv[:, :, np.newaxis]
 
-            if input_dtype == "bool":
+            if input_dtype.kind == "b":
                 arr_inv = (arr_inv > 128)
-            elif input_dtype == "float16":
+            elif input_dtype == iadt._FLOAT16_DTYPE:
                 arr_inv = arr_inv.astype(np.float16)
 
             arrays_inv.append(arr_inv)

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -44,10 +44,10 @@ from .. import random as iarandom
 
 _WARP_AFF_VALID_DTYPES_CV2_ORDER_0 = iadt._convert_dtype_strs_to_types(
     "uint8 uint16 int8 int16 int32 float16 float32 float64 bool"
-)
+)  # Added in 0.5.0.
 _WARP_AFF_VALID_DTYPES_CV2_ORDER_NOT_0 = iadt._convert_dtype_strs_to_types(
     "uint8 uint16 int8 int16 float16 float32 float64 bool"
-)
+)  # Added in 0.5.0.
 
 # skimage | cv2
 # 0       | cv2.INTER_NEAREST

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -159,15 +159,7 @@ def _call_imgcorrupt_func(fname, seed, convert_to_pil, *args, **kwargs):
 
     image = args[0]
 
-    iadt.gate_dtypes(
-        image,
-        allowed=["uint8"],
-        disallowed=["bool",
-                    "uint16", "uint32", "uint64", "uint128", "uint256",
-                    "int8", "int16", "int32", "int64", "int128", "int256",
-                    "float16", "float32", "float64", "float96", "float128",
-                    "float256"],
-        augmenter=None)
+    iadt.allow_only_uint8({image.dtype})
 
     input_shape = image.shape
 

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -3858,12 +3858,13 @@ class WithChannels(Augmenter):
     @classmethod
     def _assert_dtypes_not_changed(cls, images_aug, images):
         if ia.is_np_array(images_aug) and ia.is_np_array(images):
-            dtypes_same = (images_aug.dtype.name == images.dtype.name)
+            dtypes_same = (images_aug.dtype == images.dtype)
         else:
-            dtypes_same = all(
-                [image_aug.dtype.name == image.dtype.name
-                 for image_aug, image
-                 in zip(images_aug, images)])
+            dtypes_same = all([
+                image_aug.dtype == image.dtype
+                for image_aug, image
+                in zip(images_aug, images)
+            ])
 
         assert dtypes_same, (
             "dtypes of images changed in WithChannels from "

--- a/imgaug/augmenters/pillike.py
+++ b/imgaug/augmenters/pillike.py
@@ -66,6 +66,7 @@ from . import contrast as contrastlib
 from . import geometric
 from . import size as sizelib
 from .. import parameters as iap
+from .. import dtypes as iadt
 
 
 # TODO some of the augmenters in this module broke on numpy arrays as
@@ -297,12 +298,12 @@ def equalize_(image, mask=None):
                   for c in np.arange(nb_channels)]
         return np.stack(result, axis=-1)
 
-    assert image.dtype.name == "uint8", (
-        "Expected image of dtype uint8, got dtype %s." % (image.dtype.name,))
+    iadt.allow_only_uint8({image.dtype})
+
     if mask is not None:
         assert mask.ndim == 2, (
             "Expected 2-dimensional mask, got shape %s." % (mask.shape,))
-        assert mask.dtype.name == "uint8", (
+        assert mask.dtype == iadt._UINT8_DTYPE, (
             "Expected mask of dtype uint8, got dtype %s." % (mask.dtype.name,))
 
     size = image.size
@@ -412,9 +413,7 @@ def autocontrast(image, cutoff=0, ignore=None):
         Contrast-enhanced image.
 
     """
-    assert image.dtype.name == "uint8", (
-        "Can apply autocontrast only to uint8 images, got dtype %s." % (
-            image.dtype.name,))
+    iadt.allow_only_uint8({image.dtype})
 
     if 0 in image.shape:
         return np.copy(image)
@@ -533,9 +532,7 @@ def _autocontrast_no_pil(image, cutoff, ignore):  # noqa: C901
 
 # Added in 0.4.0.
 def _apply_enhance_func(image, cls, factor):
-    assert image.dtype.name == "uint8", (
-        "Can apply PIL image enhancement only to uint8 images, "
-        "got dtype %s." % (image.dtype.name,))
+    iadt.allow_only_uint8({image.dtype})
 
     if 0 in image.shape:
         return np.copy(image)
@@ -729,9 +726,7 @@ def enhance_sharpness(image, factor):
 
 # Added in 0.4.0.
 def _filter_by_kernel(image, kernel):
-    assert image.dtype.name == "uint8", (
-        "Can apply PIL filters only to uint8 images, "
-        "got dtype %s." % (image.dtype.name,))
+    iadt.allow_only_uint8({image.dtype})
 
     if 0 in image.shape:
         return np.copy(image)
@@ -1238,9 +1233,7 @@ def warp_affine(image,
         Image after affine transformation.
 
     """
-    assert image.dtype.name == "uint8", (
-        "Can apply PIL affine transformation only to uint8 images, "
-        "got dtype %s." % (image.dtype.name,))
+    iadt.allow_only_uint8({image.dtype})
 
     if 0 in image.shape:
         return np.copy(image)
@@ -1502,14 +1495,13 @@ class Autocontrast(contrastlib._ContrastFuncWrapper):
 
         super(Autocontrast, self).__init__(
             func, params1d, per_channel,
-            dtypes_allowed=["uint8"],
-            dtypes_disallowed=["uint16", "uint32", "uint64",
-                               "int8", "int16", "int32", "int64",
-                               "float16", "float32", "float64",
-                               "float16", "float32", "float64", "float96",
-                               "float128", "float256", "bool"],
+            dtypes_allowed="uint8",
+            dtypes_disallowed="uint16 uint32 uint64 int8 int16 int32 int64 "
+                              "float16 float32 float64 float128 "
+                              "bool",
             seed=seed, name=name,
-            random_state=random_state, deterministic=deterministic)
+            random_state=random_state, deterministic=deterministic
+        )
 
 
 # Added in 0.4.0.

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -233,15 +233,12 @@ class Superpixels(meta.Augmenter):
 
         images = batch.images
 
-        iadt.gate_dtypes(images,
-                         allowed=["bool",
-                                  "uint8", "uint16", "uint32", "uint64",
-                                  "int8", "int16", "int32", "int64"],
-                         disallowed=["uint128", "uint256",
-                                     "int128", "int256",
-                                     "float16", "float32", "float64",
-                                     "float96", "float128", "float256"],
-                         augmenter=self)
+        iadt.gate_dtypes_strs(
+            images,
+            allowed="bool uint8 uint16 uint32 uint64 int8 int16 int32 int64",
+            disallowed="float16 float32 float64 float128",
+            augmenter=self
+        )
 
         nb_images = len(images)
         rss = random_state.duplicate(1+nb_images)
@@ -362,7 +359,9 @@ def replace_segments_(image, segments, replace_flags):
 
     nb_segments = None
     func = _replace_segments_scipy_
-    bad_dtype = image.dtype.name not in ["uint8", "int8"]
+    bad_dtype = (
+        image.dtype not in {iadt._UINT8_DTYPE, iadt._INT8_DTYPE}
+    )
     area = image.shape[0] * image.shape[1]
     if bad_dtype or area < _REPLACE_SEGMENTS_NP_BELOW_AREA:
         func = _replace_segments_np_
@@ -685,16 +684,7 @@ class Voronoi(meta.Augmenter):
 
         images = batch.images
 
-        iadt.gate_dtypes(images,
-                         allowed=["uint8"],
-                         disallowed=["bool",
-                                     "uint16", "uint32", "uint64", "uint128",
-                                     "uint256",
-                                     "int8", "int16", "int32", "int64",
-                                     "int128", "int256",
-                                     "float16", "float32", "float64",
-                                     "float96", "float128", "float256"],
-                         augmenter=self)
+        iadt.allow_only_uint8(images, augmenter=self)
 
         rss = random_state.duplicate(len(images))
         for i, (image, rs) in enumerate(zip(images, rss)):

--- a/imgaug/augmenters/size.py
+++ b/imgaug/augmenters/size.py
@@ -42,6 +42,7 @@ import imgaug as ia
 from imgaug.imgaug import _normalize_cv2_input_arr_
 from . import meta
 from .. import parameters as iap
+from .. import dtypes as iadt
 
 
 def _crop_trbl_to_xyxy(shape, top, right, bottom, left, prevent_zero_size=True):
@@ -429,7 +430,6 @@ def pad(arr, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
         ``W'=W+left+right``.
 
     """
-    import imgaug.dtypes as iadt
 
     _assert_two_or_three_dims(arr)
     assert all([v >= 0 for v in [top, right, bottom, left]]), (
@@ -444,7 +444,7 @@ def pad(arr, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
         # without the if here there are crashes for float128, e.g. if
         # cval is an int (just using float(cval) seems to not be accurate
         # enough)
-        if arr.dtype.name == "float128":
+        if arr.dtype == iadt._FLOAT128_DTYPE:
             cval = np.float128(cval)  # pylint: disable=no-member
 
         if is_multi_cval:
@@ -480,8 +480,9 @@ def pad(arr, top=0, right=0, bottom=0, left=0, mode="constant", cval=0):
         # these datatypes all simply generate a "TypeError: src data type = X
         # is not supported" error
         bad_datatype_cv2 = (
-            arr.dtype.name
-            in ["uint32", "uint64", "int64", "float16", "float128", "bool"]
+            arr.dtype in iadt._convert_dtype_strs_to_types(
+                "uint32 uint64 int64 float16 float128 bool"
+            )
         )
 
         # OpenCV turns the channel axis for arrays with 0 channels to 512

--- a/imgaug/augmenters/weather.py
+++ b/imgaug/augmenters/weather.py
@@ -391,15 +391,12 @@ class CloudLayer(meta.Augmenter):
                 self.intensity_coarse_scale]
 
     def draw_on_image(self, image, random_state):
-        iadt.gate_dtypes(image,
-                         allowed=["uint8",
-                                  "float16", "float32", "float64",
-                                  "float96", "float128", "float256"],
-                         disallowed=["bool",
-                                     "uint16", "uint32", "uint64", "uint128",
-                                     "uint256",
-                                     "int8", "int16", "int32", "int64",
-                                     "int128", "int256"])
+        iadt.gate_dtypes_strs(
+            image,
+            allowed="uint8 float16 float32 float64 float128",
+            disallowed="bool uint16 uint32 uint64 int8 int16 int32 int64",
+            augmenter=self
+        )
 
         alpha, intensity = self.generate_maps(image, random_state)
         alpha = alpha[..., np.newaxis]

--- a/imgaug/dtypes.py
+++ b/imgaug/dtypes.py
@@ -27,7 +27,7 @@ _INT64_DTYPE = np.dtype("int64")  # Added in 0.5.0.
 _FLOAT16_DTYPE = np.dtype("float16")  # Added in 0.5.0.
 _FLOAT32_DTYPE = np.dtype("float32")  # Added in 0.5.0.
 _FLOAT64_DTYPE = np.dtype("float64")  # Added in 0.5.0.
-_BOOL_DTYPE = np.dtype("bool")
+_BOOL_DTYPE = np.dtype("bool")  # Added in 0.5.0.
 
 # Added in 0.5.0.
 try:

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -1503,27 +1503,20 @@ def imresize_many_images(images, sizes=None, interpolation=None):
     # TODO find more beautiful way to avoid circular imports
     from . import dtypes as iadt
     if inter == cv2.INTER_NEAREST:
-        iadt.gate_dtypes(
+        iadt.gate_dtypes_strs(
             images,
-            allowed=["bool",
-                     "uint8", "uint16",
-                     "int8", "int16", "int32",
-                     "float16", "float32", "float64"],
-            disallowed=["uint32", "uint64", "uint128", "uint256",
-                        "int64", "int128", "int256",
-                        "float96", "float128", "float256"],
-            augmenter=None)
+            allowed="bool uint8 uint16 int8 int16 int32 "
+                    "float16 float32 float64",
+            disallowed="uint32 uint64 int64 float128",
+            augmenter=None
+        )
     else:
-        iadt.gate_dtypes(
+        iadt.gate_dtypes_strs(
             images,
-            allowed=["bool",
-                     "uint8", "uint16",
-                     "int8", "int16",
-                     "float16", "float32", "float64"],
-            disallowed=["uint32", "uint64", "uint128", "uint256",
-                        "int32", "int64", "int128", "int256",
-                        "float96", "float128", "float256"],
-            augmenter=None)
+            allowed="bool uint8 uint16 int8 int16 float16 float32 float64",
+            disallowed="uint32 uint64 int32 int64 float128",
+            augmenter=None
+        )
 
     result_shape = (nb_images, height_target, width_target)
     if nb_channels is not None:
@@ -1698,15 +1691,12 @@ def pool(arr, block_size, func, pad_mode="constant", pad_cval=0,
     if arr.size == 0:
         return np.copy(arr)
 
-    iadt.gate_dtypes(arr,
-                     allowed=["bool",
-                              "uint8", "uint16", "uint32",
-                              "int8", "int16", "int32",
-                              "float16", "float32", "float64", "float128"],
-                     disallowed=["uint64", "uint128", "uint256",
-                                 "int64", "int128", "int256",
-                                 "float256"],
-                     augmenter=None)
+    iadt.gate_dtypes_strs(
+        {arr.dtype},
+        allowed="bool uint8 uint16 uint32 int8 int16 int32 "
+                "float16 float32 float64 float128",
+        disallowed="uint64 int64"
+    )
 
     if cval is not None:
         warn_deprecated("`cval` is a deprecated argument in pool(). "


### PR DESCRIPTION
This patch improves the performance of dtype checks
throughout the library. The new method verifies input
arrays around 10x to 100x faster than the previous one.

Add functions:
* `imgaug.dtypes.gate_dtypes_strs()`
* `imgaug.dtypes.allow_only_uint8()`

Add decorators:
* `imgaug.testutils.ensure_deprecation_warning`

Deprecate functions:
* `imgaug.dtypes.gate_dtypes()`
