### PR TITLE
Fix prefetchers wrapping prefetchers

### DIFF
--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -1116,7 +1116,7 @@ class Choice(StochasticParameter):
     @property
     def prefetchable(self):
         """See :func:`StochasticParameter.prefetchable`."""
-        return True
+        return self.replace
 
     def _draw_samples(self, size, random_state):
         if any([isinstance(a_i, StochasticParameter) for a_i in self.a]):

--- a/imgaug/parameters.py
+++ b/imgaug/parameters.py
@@ -75,6 +75,15 @@ def _wrap_leafs_of_param_in_prefetchers(param, nb_prefetch):
 
 # Added in 0.5.0.
 def _wrap_leafs_of_param_in_prefetchers_recursive(param, nb_prefetch):
+    # Do not descent into AutoPrefetcher, otherwise we risk turning an
+    # AutoPrefetcher(X) into AutoPrefetcher(AutoPrefetcher(X)) if X is
+    # prefetchable
+    if isinstance(param, AutoPrefetcher):
+        # report did_wrap_any_child=True here, so that parent parameters
+        # are not wrapped in prefetchers, which could lead to ugly scenarios
+        # like AutoPrefetcher(Normal(AutoPrefetcher(Uniform(-1.0, 1.0))),
+        return param, True
+
     if isinstance(param, (list, tuple)):
         result = []
         did_wrap_any_child = False

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -6111,7 +6111,7 @@ class TestPerspectiveTransform(unittest.TestCase):
         bbsoi = ia.BoundingBoxesOnImage(bbs, shape=img.shape)
         aug = iaa.PerspectiveTransform(scale=(0.05, 0.2), keep_size=True)
 
-        for _ in sm.xrange(10):
+        for _ in sm.xrange(30):
             imgs_aug, bbsois_aug = aug(
                 images=[img, img, img, img],
                 bounding_boxes=[bbsoi, bbsoi, bbsoi, bbsoi])
@@ -6136,7 +6136,7 @@ class TestPerspectiveTransform(unittest.TestCase):
                         assert np.max(rgt_row) > 10
                     else:
                         nb_skipped += 1
-            assert nb_skipped <= 2
+            assert nb_skipped <= 3
 
     def test_bounding_boxes_cover_extreme_points(self):
         # Test that for BBs, the augmented BB x coord is really the minimum


### PR DESCRIPTION
This patch fixes AutoPrefetcher wrapping other instances of
AutoPrefetcher, leading sometimes to endlessly growing
cascades of prefetchers.