### PR TITLE
Fix multicore aug error on Mac + python 3.7

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -22,13 +22,13 @@ jobs:
         # https://raw.githubusercontent.com/actions/python-versions/master/versions-manifest.json
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         # test only 2.7 and the latest 3.x on mac
-        exclude:
-          - os: macos-latest
-            python-version: 3.5
-          - os: macos-latest
-            python-version: 3.6
-          - os: macos-latest
-            python-version: 3.7
+        #exclude:
+          #- os: macos-latest
+          #  python-version: 3.5
+          #- os: macos-latest
+          #  python-version: 3.6
+          #- os: macos-latest
+          #  python-version: 3.7
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -22,13 +22,13 @@ jobs:
         # https://raw.githubusercontent.com/actions/python-versions/master/versions-manifest.json
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         # test only 2.7 and the latest 3.x on mac
-        #exclude:
-          #- os: macos-latest
-          #  python-version: 3.5
-          #- os: macos-latest
-          #  python-version: 3.6
-          #- os: macos-latest
-          #  python-version: 3.7
+        exclude:
+          - os: macos-latest
+            python-version: 3.5
+          - os: macos-latest
+            python-version: 3.6
+          - os: macos-latest
+            python-version: 3.7
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/changelogs/master/fixed/20200522_fix_mac_multiprocessing.md
+++ b/changelogs/master/fixed/20200522_fix_mac_multiprocessing.md
@@ -1,0 +1,6 @@
+- Fixed an error on MacOS in python 3.7 that could appear
+  when using multicore augmentation. The library will now
+  use `spawn` mode in that situation. The error can thus
+  still appear when using a custom multiprocessing
+  implementation. It is recommended to use python 3.8 on
+  Mac.

--- a/changelogs/master/fixed/20200522_fix_mac_multiprocessing.md
+++ b/changelogs/master/fixed/20200522_fix_mac_multiprocessing.md
@@ -3,4 +3,4 @@
   use `spawn` mode in that situation. The error can thus
   still appear when using a custom multiprocessing
   implementation. It is recommended to use python 3.8 on
-  Mac.
+  Mac. #673

--- a/imgaug/multicore.py
+++ b/imgaug/multicore.py
@@ -56,6 +56,19 @@ def _get_context_method():
                     "hanging programs when also making use of multicore "
                     "augmentation (aka background augmentation). Use "
                     "python 3.5 or later to prevent this.")
+    elif platform.system() == "Darwin" and vinfo[0:2] == (3, 7):
+        # On Mac with python 3.7 there seems to be a problem with matplotlib,
+        # resulting in the error "libc++abi.dylib: terminating with uncaught
+        # exception of type std::runtime_error: Couldn't close file".
+        # The error seems to be due to opened files that get closed in
+        # child processes and can be prevented by switching to spawn mode.
+        # See https://github.com/matplotlib/matplotlib/issues/15410
+        # and https://bugs.python.org/issue33725.
+        # It is possible that this problem also affects other python versions,
+        # but here it only appeared (consistently) in the 3.7 tests and the
+        # reports also seem to be focused around 3.7, suggesting explicitly
+        # to update to 3.8.2.
+        method = "spawn"
 
     if get_context_unsupported:
         return False


### PR DESCRIPTION
Fixed an error on MacOS in python 3.7 that could appear
when using multicore augmentation. The library will now
use `spawn` mode in that situation. The error can thus
still appear when using a custom multiprocessing
implementation. It is recommended to use python 3.8 on
Mac.