### PR TITLE
Add timeouts to ci/cd jobs

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build:
 
+    # There were errors on Mac that would lead to non-stop printing of
+    # error messages forever instead of the job crashing. To prevent this,
+    # a timeout is placed here (default value is otherwise 360min).
+    timeout-minutes: 30
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test_master.yml
+++ b/.github/workflows/test_master.yml
@@ -11,6 +11,12 @@ on:
 jobs:
   build:
 
+    # There were errors on Mac that would lead to non-stop printing of
+    # error messages forever instead of the job crashing. To prevent this,
+    # a timeout is placed here (default value is otherwise 360min).
+    # Usually, jobs currently run through in around 10min.
+    timeout-minutes: 60
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   build:
 
+    # There were errors on Mac that would lead to non-stop printing of
+    # error messages forever instead of the job crashing. To prevent this,
+    # a timeout is placed here (default value is otherwise 360min).
+    # Usually, jobs currently run through in around 10min.
+    timeout-minutes: 45
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
This patch adds timeouts to all github action jobs.
This prevents them from running essentially forever (up
until the default maximum of 6 hours) upon endless loops.