### PR TITLE
Remove f128 requirement from tests

### DIFF
--- a/changelogs/master/improved/20200522_tests_f128.md
+++ b/changelogs/master/improved/20200522_tests_f128.md
@@ -1,0 +1,5 @@
+# Removed Requirement of float128 Support from Tests #677
+
+This patch modifies all tests so that they can be run on
+systems that do not support the dtype `float128`, such
+as Windows.

--- a/test/augmenters/test_blend.py
+++ b/test/augmenters/test_blend.py
@@ -202,6 +202,11 @@ class Test_blend_alpha(unittest.TestCase):
 
     # TODO split this up into multiple tests
     def test_other_dtypes_uint_int(self):
+        try:
+            high_res_dt = np.float128
+        except AttributeError:
+            high_res_dt = np.float64
+
         #dtypes = ["uint8", "uint16", "uint32", "uint64",
         #          "int8", "int16", "int32", "int64"]
         dtypes = ["uint8"]
@@ -266,8 +271,8 @@ class Test_blend_alpha(unittest.TestCase):
                             v_blend = min(
                                 max(
                                     int(
-                                        0.75*np.float128(v1)
-                                        + 0.25*np.float128(v2)
+                                        0.75*high_res_dt(v1)
+                                        + 0.25*high_res_dt(v2)
                                     ),
                                     min_value
                                 ),
@@ -286,8 +291,8 @@ class Test_blend_alpha(unittest.TestCase):
                     v_blend = min(
                         max(
                             int(
-                                0.75 * np.float128(v1)
-                                + 0.25 * np.float128(v2)
+                                0.75 * high_res_dt(v1)
+                                + 0.25 * high_res_dt(v2)
                             ),
                             min_value
                         ),
@@ -347,6 +352,11 @@ class Test_blend_alpha(unittest.TestCase):
 
     # TODO split this up into multiple tests
     def test_other_dtypes_float(self):
+        try:
+            high_res_dt = np.float128
+        except AttributeError:
+            high_res_dt = np.float64
+
         dtypes = ["float16", "float32", "float64"]
         for dtype in dtypes:
             with self.subTest(dtype=dtype):
@@ -377,7 +387,7 @@ class Test_blend_alpha(unittest.TestCase):
                 ]
                 values = values + [(v2, v1) for v1, v2 in values]
 
-                max_float_dt = np.float128
+                max_float_dt = high_res_dt
 
                 for v1, v2 in values:
                     v1_scalar = np.full((), v1, dtype=dtype)

--- a/test/augmenters/test_contrast.py
+++ b/test/augmenters/test_contrast.py
@@ -147,8 +147,16 @@ class TestGammaContrast(unittest.TestCase):
                 assert image_aug.shape == shape
 
     def test_other_dtypes_uint_int(self):
-        dts = [np.uint8, np.uint16, np.uint32, np.uint64,
-               np.int8, np.int16, np.int32, np.int64]
+        try:
+            high_res_dt = np.float128
+            dts = [np.uint8, np.uint16, np.uint32, np.uint64,
+                   np.int8, np.int16, np.int32, np.int64]
+        except AttributeError:
+            # cannot reliably check uint64 and int64 on systems that dont
+            # support float128
+            high_res_dt = np.float64
+            dts = [np.uint8, np.uint16, np.uint32,
+                   np.int8, np.int16, np.int32]
 
         for dtype in dts:
             dtype = np.dtype(dtype)
@@ -170,7 +178,7 @@ class TestGammaContrast(unittest.TestCase):
                         image = np.full((3, 3), value, dtype=dtype)
                         expected = (
                             (
-                                (image.astype(np.float128) / max_value)
+                                (image.astype(high_res_dt) / max_value)
                                 ** exp
                             ) * max_value
                         ).astype(dtype)
@@ -193,7 +201,7 @@ class TestGammaContrast(unittest.TestCase):
                                 image[..., c] += c
                             expected = (
                                 (
-                                    (image.astype(np.float128) / max_value)
+                                    (image.astype(high_res_dt) / max_value)
                                     ** exp
                                 ) * max_value
                             ).astype(dtype)
@@ -231,7 +239,7 @@ class TestGammaContrast(unittest.TestCase):
                                       nb_channels=None):
                         image = np.full((3, 3), value, dtype=dtype)
                         expected = (
-                            image.astype(np.float128)
+                            image.astype(np.float64)
                             ** exp
                         ).astype(dtype)
                         image_aug = aug.augment_image(image)
@@ -248,7 +256,7 @@ class TestGammaContrast(unittest.TestCase):
                             for c in sm.xrange(nb_channels):
                                 image[..., c] += float(c)
                             expected = (
-                                image.astype(np.float128)
+                                image.astype(np.float64)
                                 ** exp
                             ).astype(dtype)
                             image_aug = aug.augment_image(image)
@@ -402,8 +410,16 @@ class TestSigmoidContrast(unittest.TestCase):
                 assert image_aug.shape == shape
 
     def test_other_dtypes_uint_int(self):
-        dtypes = [np.uint8, np.uint16, np.uint32, np.uint64,
-                  np.int8, np.int16, np.int32, np.int64]
+        try:
+            high_res_dt = np.float128
+            dtypes = [np.uint8, np.uint16, np.uint32, np.uint64,
+                      np.int8, np.int16, np.int32, np.int64]
+        except AttributeError:
+            # cannot reliably check uint64 and int64 on systems that dont
+            # support float128
+            high_res_dt = np.float64
+            dtypes = [np.uint8, np.uint16, np.uint32,
+                      np.int8, np.int16, np.int32]
 
         for dtype in dtypes:
             dtype = np.dtype(dtype)
@@ -435,7 +451,7 @@ class TestSigmoidContrast(unittest.TestCase):
                                     gain
                                     * (
                                         cutoff
-                                        - image.astype(np.float128)/max_value
+                                        - image.astype(high_res_dt)/max_value
                                     )
                                 )
                             )
@@ -444,7 +460,7 @@ class TestSigmoidContrast(unittest.TestCase):
                         # expected = (
                         #   1/(1 + np.exp(gain * (
                         #       cutoff - (
-                        #           image.astype(np.float128)-min_value
+                        #           image.astype(high_res_dt)-min_value
                         #       )/dynamic_range
                         #   ))))
                         # expected = (
@@ -484,7 +500,7 @@ class TestSigmoidContrast(unittest.TestCase):
                                     gain
                                     * (
                                         cutoff
-                                        - image.astype(np.float128)
+                                        - image.astype(np.float64)
                                     )
                                 )
                             )
@@ -642,7 +658,7 @@ class TestLogContrast(unittest.TestCase):
                         expected = (
                             gain
                             * np.log2(
-                                1 + (image.astype(np.float128)/max_value)
+                                1 + (image.astype(np.float64)/max_value)
                             )
                         )
                         expected = (expected*max_value).astype(dtype)
@@ -678,7 +694,7 @@ class TestLogContrast(unittest.TestCase):
                         expected = (
                             gain
                             * np.log2(
-                                1 + image.astype(np.float128)
+                                1 + image.astype(np.float64)
                             )
                         )
                         expected = expected.astype(dtype)

--- a/test/augmenters/test_convolutional.py
+++ b/test/augmenters/test_convolutional.py
@@ -645,7 +645,8 @@ class TestConvolve(unittest.TestCase):
             expected[2, 1] = 100 * 0.5 + 100 * 0.5
 
             diff = np.abs(
-                image_aug.astype(np.float128) - expected.astype(np.float128))
+                image_aug.astype(np.float64) - expected.astype(np.float64)
+            )
             assert image_aug.dtype.type == dtype
             assert np.max(diff) < 1.0
 
@@ -700,7 +701,7 @@ class TestConvolve(unittest.TestCase):
             expected[2, 1] = value * 0.5 + value * 0.5
 
             diff = np.abs(
-                image_aug.astype(np.float128) - expected.astype(np.float128))
+                image_aug.astype(np.float64) - expected.astype(np.float64))
             assert image_aug.dtype.type == dtype
             assert np.max(diff) < 1.0
 

--- a/test/augmenters/test_flip.py
+++ b/test/augmenters/test_flip.py
@@ -470,7 +470,11 @@ class _TestFliplrAndFlipudBase(object):
 
     def test_other_dtypes_float(self):
         aug = self.create_aug(1.0)
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128").name]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000**2, 1000**3, 1000**4]
         for dtype, value in zip(dtypes, values):
             with self.subTest(dtype=dtype):
@@ -734,8 +738,19 @@ class Test_fliplr(unittest.TestCase):
     @mock.patch("imgaug.augmenters.flip._fliplr_sliced")
     @mock.patch("imgaug.augmenters.flip._fliplr_cv2")
     def test__fliplr_sliced_called_mocked(self, mock_cv2, mock_sliced):
-        for dtype in ["bool", "uint32", "uint64", "int32", "int64",
-                      "float16", "float32", "float64", "float128"]:
+        try:
+            f128 = [np.dtype("float128").name]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = [
+            "bool",
+            "uint32", "uint64",
+            "int32", "int64",
+            "float16", "float32", "float64"
+        ] + f128
+
+        for dtype in dtypes:
             mock_cv2.reset_mock()
             mock_sliced.reset_mock()
             arr = np.zeros((1, 1), dtype=dtype)
@@ -901,8 +916,14 @@ class Test_fliplr(unittest.TestCase):
                 assert np.array_equal(arr_flipped, expected)
 
     def test_float_faithful_to_min_max(self):
-        dts = ["float16", "float32", "float64", "float128"]
-        for dt in dts:
+        try:
+            f128 = [np.dtype("float128").name]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
+
+        for dt in dtypes:
             with self.subTest(dtype=dt):
                 dt = np.dtype(dt)
                 minv, center, maxv = iadt.get_value_range_of_dtype(dt)
@@ -918,7 +939,12 @@ class Test_fliplr(unittest.TestCase):
                 assert np.allclose(arr_flipped, expected, rtol=0, atol=atol)
 
     def test_float_faithful_to_large_values(self):
-        dts = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128").name]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dts = ["float16", "float32", "float64"] + f128
         values = [
             [0.01, 0.1, 1.0, 10.0**1, 10.0**2],  # float16
             [0.01, 0.1, 1.0, 10.0**1, 10.0**2, 10.0**4, 10.0**6],  # float32
@@ -1028,7 +1054,11 @@ class Test_flipud(unittest.TestCase):
                 assert np.array_equal(arr_flipped, expected)
 
     def test_float_faithful_to_min_max(self):
-        dts = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+        dts = ["float16", "float32", "float64"] + f128
         for dt in dts:
             with self.subTest(dtype=dt):
                 dt = np.dtype(dt)
@@ -1045,7 +1075,11 @@ class Test_flipud(unittest.TestCase):
                 assert np.allclose(arr_flipped, expected, rtol=0, atol=atol)
 
     def test_float_faithful_to_large_values(self):
-        dts = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+        dts = ["float16", "float32", "float64"] + f128
         values = [
             [0.01, 0.1, 1.0, 10.0**1, 10.0**2],  # float16
             [0.01, 0.1, 1.0, 10.0**1, 10.0**2, 10.0**4, 10.0**6],  # float32

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -2697,8 +2697,14 @@ class TestAffine_other_dtypes(unittest.TestCase):
                 return np.isclose(a, b, atol=atol, rtol=0)
 
             isize = np.dtype(dtype).itemsize
-            values = [0.01, 1.0, 10.0, 100.0, 500 ** (isize - 1),
-                      1000 ** (isize - 1)]
+            values = [
+                0.01,
+                1.0,
+                10.0,
+                100.0,
+                500 ** (isize - 1),
+                float(np.float64(1000 ** (isize - 1)))
+            ]
             values = values + [(-1) * value for value in values]
             values = values + [min_value, max_value]
             for value in values:
@@ -2711,7 +2717,7 @@ class TestAffine_other_dtypes(unittest.TestCase):
                     assert image_aug.dtype.name == dtype
                     assert np.all(_isclose(image_aug[~self.translate_mask], 0))
                     assert np.all(_isclose(image_aug[self.translate_mask],
-                                           np.float128(value)))
+                                           value))
 
     def test_rotate_skimage_order_not_0_bool(self):
         # skimage, order!=0 and rotate=180
@@ -2879,8 +2885,14 @@ class TestAffine_other_dtypes(unittest.TestCase):
                 return np.isclose(a, b, atol=atol, rtol=0)
 
             isize = np.dtype(dtype).itemsize
-            values = [0.01, 1.0, 10.0, 100.0, 500 ** (isize - 1),
-                      1000 ** (isize - 1)]
+            values = [
+                0.01,
+                1.0,
+                10.0,
+                100.0,
+                500 ** (isize - 1),
+                float(np.float64(1000 ** (isize - 1)))
+            ]
             values = values + [(-1) * value for value in values]
             values = values + [min_value, max_value]
             for value in values:
@@ -2893,7 +2905,7 @@ class TestAffine_other_dtypes(unittest.TestCase):
                     assert image_aug.dtype.name == dtype
                     assert np.all(_isclose(image_aug[~self.translate_mask], 0))
                     assert np.all(_isclose(image_aug[self.translate_mask],
-                                           np.float128(value)))
+                                           value))
 
     def test_rotate_cv2_order_1_and_3_bool(self):
         # cv2, order=1 and rotate=180
@@ -5395,8 +5407,14 @@ class TestPiecewiseAffine(unittest.TestCase):
                 return np.isclose(a, b, atol=atol, rtol=0)
 
             isize = np.dtype(dtype).itemsize
-            values = [0.01, 1.0, 10.0, 100.0, 500 ** (isize - 1),
-                      1000 ** (isize - 1)]
+            values = [
+                0.01,
+                1.0,
+                10.0,
+                100.0,
+                500 ** (isize - 1),
+                float(np.float64(1000 ** (isize - 1)))
+            ]
             values = values + [(-1) * value for value in values]
             values = values + [min_value, max_value]
             for value in values:
@@ -5407,12 +5425,9 @@ class TestPiecewiseAffine(unittest.TestCase):
                     image_aug = aug.augment_image(image)
 
                     assert image_aug.dtype.name == dtype
-                    # TODO switch all other tests from float(...) to
-                    #      np.float128(...) pattern, seems to be more accurate
-                    #      for 128bit floats
-                    assert not np.all(_isclose(image_aug, np.float128(value)))
+                    assert not np.all(_isclose(image_aug, value))
                     assert np.any(_isclose(image_aug[~self.other_dtypes_mask],
-                                           np.float128(value)))
+                                           value))
 
     def test_pickleable(self):
         aug = iaa.PiecewiseAffine(scale=0.2, nb_rows=4, nb_cols=4, seed=1)
@@ -7714,8 +7729,14 @@ class TestElasticTransformation(unittest.TestCase):
                 return np.isclose(a, b, atol=atol, rtol=0)
 
             isize = np.dtype(dtype).itemsize
-            values = [0.01, 1.0, 10.0, 100.0, 500 ** (isize - 1),
-                      1000 ** (isize - 1)]
+            values = [
+                0.01,
+                1.0,
+                10.0,
+                100.0,
+                500 ** (isize - 1),
+                float(np.float64(1000 ** (isize - 1)))
+            ]
             values = values + [(-1) * value for value in values]
             for value in values:
                 with self.subTest(dtype=dtype, value=value):
@@ -7725,9 +7746,8 @@ class TestElasticTransformation(unittest.TestCase):
                     image_aug = aug.augment_image(image)
 
                     assert image_aug.dtype.name == dtype
-                    assert not np.all(_isclose(image_aug, np.float128(value)))
-                    assert np.any(_isclose(image_aug[~mask],
-                                           np.float128(value)))
+                    assert not np.all(_isclose(image_aug, value))
+                    assert np.any(_isclose(image_aug[~mask], value))
 
     def test_other_dtypes_bool_all_orders(self):
         mask = np.zeros((50, 50), dtype=bool)
@@ -7812,10 +7832,10 @@ class TestElasticTransformation(unittest.TestCase):
                     if order == 0:
                         assert image_aug.dtype.name == dtype
                         assert not np.all(
-                            _isclose(image_aug, np.float128(value))
+                            _isclose(image_aug, value)
                         )
                         assert np.any(
-                            _isclose(image_aug[~mask], np.float128(value))
+                            _isclose(image_aug[~mask], value)
                         )
                     else:
                         atol = (
@@ -7825,13 +7845,13 @@ class TestElasticTransformation(unittest.TestCase):
                         assert not np.all(
                             np.isclose(
                                 image_aug,
-                                np.float128(value),
+                                value,
                                 rtol=0, atol=atol
                             ))
                         assert np.any(
                             np.isclose(
                                 image_aug[~mask],
-                                np.float128(value),
+                                value,
                                 rtol=0, atol=atol
                             ))
 
@@ -8856,14 +8876,27 @@ class TestRot90(unittest.TestCase):
     def test_other_dtypes_float(self):
         aug = iaa.Rot90(2)
 
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            high_res_dt = np.float128
+            dtypes = ["float16", "float32", "float64", "float128"]
+        except AttributeError:
+            high_res_dt = np.float64
+            dtypes = ["float16", "float32", "float64"]
+
         for dtype in dtypes:
             def _allclose(a, b):
                 atol = 1e-4 if dtype == "float16" else 1e-8
                 return np.allclose(a, b, atol=atol, rtol=0)
 
             isize = np.dtype(dtype).itemsize
-            values = [0, 1.0, 10.0, 100.0, 500 ** (isize-1), 1000 ** (isize-1)]
+            values = [
+                0,
+                1.0,
+                10.0,
+                100.0,
+                high_res_dt(500 ** (isize-1)),
+                high_res_dt(1000 ** (isize-1))
+            ]
             values = values + [(-1) * value for value in values]
             for value in values:
                 with self.subTest(dtype=dtype, value=value):
@@ -8874,7 +8907,7 @@ class TestRot90(unittest.TestCase):
 
                     assert image_aug.dtype.name == dtype
                     assert _allclose(image_aug[0, 0], 0)
-                    assert _allclose(image_aug[2, 2], np.float128(value))
+                    assert _allclose(image_aug[2, 2], high_res_dt(value))
 
     def test_pickleable(self):
         aug = iaa.Rot90([0, 1, 2, 3], seed=1)
@@ -9502,10 +9535,17 @@ class TestWithPolarWarping(unittest.TestCase):
 
 class Test_apply_jigsaw(unittest.TestCase):
     def test_no_movement(self):
-        dtypes = ["bool",
-                  "uint8", "uint16", "uint32", "uint64",
-                  "int8", "int16", "int32", "int64",
-                  "float16", "float32", "float64", "float128"]
+        dtypes = [
+            "bool",
+            "uint8", "uint16", "uint32", "uint64",
+            "int8", "int16", "int32", "int64",
+            "float16", "float32", "float64"
+        ]
+
+        try:
+            dtypes.append(np.dtype("float128"))
+        except TypeError:
+            pass  # float128 not known on system
 
         for dtype in dtypes:
             with self.subTest(dtype=dtype):
@@ -9550,10 +9590,17 @@ class Test_apply_jigsaw(unittest.TestCase):
                 assert np.array_equal(observed, arr)
 
     def _test_two_cells_moved__n_channels(self, nb_channels):
-        dtypes = ["bool",
-                  "uint8", "uint16", "uint32", "uint64",
-                  "int8", "int16", "int32", "int64",
-                  "float16", "float32", "float64", "float128"]
+        dtypes = [
+            "bool",
+            "uint8", "uint16", "uint32", "uint64",
+            "int8", "int16", "int32", "int64",
+            "float16", "float32", "float64"
+        ]
+
+        try:
+            dtypes.append(np.dtype("float128").name)
+        except TypeError:
+            pass  # float128 not known by user system
 
         for dtype in dtypes:
             with self.subTest(dtype=dtype):

--- a/test/augmenters/test_meta.py
+++ b/test/augmenters/test_meta.py
@@ -307,7 +307,12 @@ class TestIdentity(unittest.TestCase):
     def test_other_dtypes_float(self):
         aug = iaa.Identity()
 
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128").name]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
 
         for dtype, value in zip(dtypes, values):
@@ -805,7 +810,12 @@ class TestLambda(unittest.TestCase):
 
         aug = iaa.Lambda(func_images=func_images)
 
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128").name]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
 
         for dtype, value in zip(dtypes, values):
@@ -835,7 +845,12 @@ def _lambda_pickleable_callback_images(images, random_state, parents, hooks):
 class TestAssertLambda(unittest.TestCase):
     DTYPES_UINT = ["uint8", "uint16", "uint32", "uint64"]
     DTYPES_INT = ["int8", "int32", "int64"]
-    DTYPES_FLOAT = ["float16", "float32", "float64", "float128"]
+    DTYPES_FLOAT = (
+        ["float16", "float32", "float64"]
+        + (
+            ["float128"] if hasattr(np, "float128") else []
+        )
+    )
 
     def setUp(self):
         reseed()
@@ -1210,7 +1225,12 @@ def _assertlambda_pickleable_callback_images(images, random_state,
 class TestAssertShape(unittest.TestCase):
     DTYPES_UINT = ["uint8", "uint16", "uint32", "uint64"]
     DTYPES_INT = ["int8", "int32", "int64"]
-    DTYPES_FLOAT = ["float16", "float32", "float64", "float128"]
+    DTYPES_FLOAT = (
+        ["float16", "float32", "float64"]
+        + (
+            ["float128"] if hasattr(np, "float128") else []
+        )
+    )
 
     def setUp(self):
         reseed()
@@ -6133,7 +6153,12 @@ class TestSequential(unittest.TestCase):
                 assert np.array_equal(image_aug, image)
 
     def test_other_dtypes_noop__float(self):
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
 
         for random_order in [False, True]:
@@ -6192,7 +6217,12 @@ class TestSequential(unittest.TestCase):
                 assert np.array_equal(image_aug, expected)
 
     def test_other_dtypes_flips__float(self):
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
 
         for random_order in [False, True]:
@@ -6718,7 +6748,12 @@ class TestSomeOf(unittest.TestCase):
                 assert np.array_equal(image_aug, image)
 
     def test_other_dtypes_via_noop__float(self):
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
         random_orders = [False, True]
 
@@ -6792,7 +6827,12 @@ class TestSomeOf(unittest.TestCase):
                                 for expected_i in expected])
 
     def test_other_dtypes_via_flip__float(self):
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
         random_orders = [False, True]
 
@@ -7851,7 +7891,13 @@ class TestSometimes(unittest.TestCase):
 
     def test_other_dtypes_via_noop__float(self):
         aug = iaa.Sometimes(1.0, iaa.Identity())
-        dtypes = ["float16", "float32", "float64", "float128"]
+
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
         for dtype, value in zip(dtypes, values):
             with self.subTest(dtype=dtype):
@@ -7916,7 +7962,14 @@ class TestSometimes(unittest.TestCase):
 
     def test_other_dtypes_via_flip__float(self):
         aug = iaa.Sometimes(0.5, iaa.Fliplr(1.0), iaa.Flipud(1.0))
-        dtypes = ["float16", "float32", "float64", "float128"]
+
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
+
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
         for dtype, value in zip(dtypes, values):
             with self.subTest(dtype=dtype):
@@ -8388,7 +8441,14 @@ class TestWithChannels(unittest.TestCase):
 
     def test_other_dtypes_via_noop__float(self):
         aug = iaa.WithChannels([0], iaa.Identity())
-        dtypes = ["float16", "float32", "float64", "float128"]
+
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
+
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
         for dtype, value in zip(dtypes, values):
             with self.subTest(dtype=dtype):
@@ -8436,7 +8496,14 @@ class TestWithChannels(unittest.TestCase):
 
     def test_other_dtypes_via_flips__float(self):
         aug = iaa.WithChannels([0], iaa.Fliplr(1.0))
-        dtypes = ["float16", "float32", "float64", "float128"]
+
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
+
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
         for dtype, value in zip(dtypes, values):
             with self.subTest(dtype=dtype):
@@ -8671,7 +8738,14 @@ class TestChannelShuffle(unittest.TestCase):
 
     def test_other_dtypes_float(self):
         aug = iaa.ChannelShuffle(p=0.5)
-        dtypes = ["float16", "float32", "float64", "float128"]
+
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = ["float16", "float32", "float64"] + f128
+
         values = [5000, 1000 ** 2, 1000 ** 3, 1000 ** 4]
         for dtype, value in zip(dtypes, values):
             with self.subTest(dtype=dtype):
@@ -8712,10 +8786,19 @@ class TestRemoveCBAsByOutOfImageFraction(unittest.TestCase):
 
     def test_no_cbas_in_batch(self):
         aug = iaa.RemoveCBAsByOutOfImageFraction(0.51)
-        dtypes = ["uint8", "uint16", "uint32", "uint64",
-                  "int8", "int16", "int32", "int64",
-                  "float16", "float32", "float64", "float128",
-                  "bool"]
+
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = [
+            "uint8", "uint16", "uint32", "uint64",
+            "int8", "int16", "int32", "int64",
+            "float16", "float32", "float64",
+            "bool"
+        ] + f128
+
         for dt in dtypes:
             arr = np.ones((5, 10, 3), dtype=dt)
 
@@ -8808,10 +8891,19 @@ class TestClipCBAsToImagePlanes(unittest.TestCase):
 
     def test_no_cbas_in_batch(self):
         aug = iaa.RemoveCBAsByOutOfImageFraction(0.51)
-        dtypes = ["uint8", "uint16", "uint32", "uint64",
-                  "int8", "int16", "int32", "int64",
-                  "float16", "float32", "float64", "float128",
-                  "bool"]
+
+        try:
+            f128 = [np.dtype("float128")]
+        except TypeError:
+            f128 = []  # float128 not known by user system
+
+        dtypes = [
+            "uint8", "uint16", "uint32", "uint64",
+            "int8", "int16", "int32", "int64",
+            "float16", "float32", "float64",
+            "bool"
+        ] + f128
+
         for dt in dtypes:
             arr = np.ones((5, 10, 3), dtype=dt)
 

--- a/test/augmenters/test_size.py
+++ b/test/augmenters/test_size.py
@@ -451,7 +451,15 @@ def test_pad():
     # -------
     # float
     # -------
-    for dtype in [np.float16, np.float32, np.float64, np.float128]:
+    dtypes = [np.float16, np.float32, np.float64]
+
+    try:
+        # without .type here the dtype(<list>) statements below fail
+        dtypes.append(np.dtype("float128").type)
+    except TypeError:
+        pass  # float128 not known by user system
+
+    for dtype in dtypes:
         arr = np.zeros((3, 3), dtype=dtype) + 1.0
 
         def _allclose(a, b):
@@ -3003,7 +3011,12 @@ class TestPad(unittest.TestCase):
         mask = np.zeros((4, 3), dtype=bool)
         mask[2, 1] = True
 
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            high_res_dt = np.float128
+            dtypes = ["float16", "float32", "float64", "float128"]
+        except AttributeError:
+            high_res_dt = np.float64
+            dtypes = ["float16", "float32", "float64"]
 
         for dtype in dtypes:
             with self.subTest(dtype=dtype):
@@ -3027,7 +3040,7 @@ class TestPad(unittest.TestCase):
                     assert image_aug.shape == (4, 3)
                     assert np.all(_isclose(image_aug[~mask], 0))
                     assert np.all(_isclose(image_aug[mask],
-                                           np.float128(value)))
+                                           high_res_dt(value)))
 
     def test_pickleable(self):
         aug = iaa.Pad((0, 10), seed=1)
@@ -4116,7 +4129,12 @@ class TestCrop(unittest.TestCase):
         mask = np.zeros((2, 3), dtype=bool)
         mask[0, 1] = True
 
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            high_res_dt = np.float128
+            dtypes = ["float16", "float32", "float64", "float128"]
+        except AttributeError:
+            high_res_dt = np.float64
+            dtypes = ["float16", "float32", "float64"]
 
         for dtype in dtypes:
             with self.subTest(dtype=dtype):
@@ -4140,7 +4158,7 @@ class TestCrop(unittest.TestCase):
                     assert image_aug.shape == (2, 3)
                     assert np.all(_isclose(image_aug[~mask], 0))
                     assert np.all(_isclose(image_aug[mask],
-                                           np.float128(value)))
+                                           high_res_dt(value)))
 
     def test_pickleable(self):
         aug = iaa.Crop((0, 10), seed=1)
@@ -4791,7 +4809,13 @@ class TestPadToFixedSize(unittest.TestCase):
 
     def test_other_dtypes_float(self):
         aug = iaa.PadToFixedSize(height=4, width=3, position="center-top")
-        dtypes = ["float16", "float32", "float64", "float128"]
+
+        try:
+            high_res_dt = np.float128
+            dtypes = ["float16", "float32", "float64", "float128"]
+        except AttributeError:
+            high_res_dt = np.float64
+            dtypes = ["float16", "float32", "float64"]
 
         mask = np.zeros((4, 3), dtype=bool)
         mask[2, 1] = True
@@ -4819,7 +4843,7 @@ class TestPadToFixedSize(unittest.TestCase):
                     assert image_aug.shape == (4, 3)
                     assert np.all(_isclose(image_aug[~mask], 0))
                     assert np.all(_isclose(image_aug[mask],
-                                           np.float128(value)))
+                                           high_res_dt(value)))
 
     def test_pickleable(self):
         aug = iaa.PadToFixedSize(20, 20, position="uniform", seed=1)
@@ -5433,7 +5457,12 @@ class TestCropToFixedSize(unittest.TestCase):
         mask = np.zeros((2, 3), dtype=bool)
         mask[0, 1] = True
 
-        dtypes = ["float16", "float32", "float64", "float128"]
+        try:
+            high_res_dt = np.float128
+            dtypes = ["float16", "float32", "float64", "float128"]
+        except AttributeError:
+            high_res_dt = np.float64
+            dtypes = ["float16", "float32", "float64"]
 
         for dtype in dtypes:
             min_value, center_value, max_value = \
@@ -5459,7 +5488,7 @@ class TestCropToFixedSize(unittest.TestCase):
                     assert image_aug.shape == (2, 3)
                     assert np.all(_isclose(image_aug[~mask], 0))
                     assert np.all(_isclose(image_aug[mask],
-                                           np.float128(value)))
+                                           high_res_dt(value)))
 
     def test_pickleable(self):
         aug = iaa.CropToFixedSize(10, 10, position="uniform", seed=1)


### PR DESCRIPTION
This patch modifies all tests so that they can be run on
systems that do not support the dtype `float128`, such
as Windows.