### PR TITLE
Fix Affine always casting cvals to int

### DIFF
--- a/changelogs/master/fixed/20200525_fix_affine_cval_float.md
+++ b/changelogs/master/fixed/20200525_fix_affine_cval_float.md
@@ -1,0 +1,4 @@
+- Fixed `Affine` casting float cvals to int, even when
+  the image had a float dtype, making it impossible to
+  properly use cvals for images with value
+  range `[0.0, 1.0]`. #669 #679

--- a/changelogs/master/fixed/20200525_fix_affine_cval_float.md
+++ b/changelogs/master/fixed/20200525_fix_affine_cval_float.md
@@ -1,4 +1,4 @@
 - Fixed `Affine` casting float cvals to int, even when
   the image had a float dtype, making it impossible to
   properly use cvals for images with value
-  range `[0.0, 1.0]`. #669 #679
+  range `[0.0, 1.0]`. #669 #680

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -166,12 +166,12 @@ def _handle_mode_arg(mode):
 
 def _warp_affine_arr(arr, matrix, order=1, mode="constant", cval=0,
                      output_shape=None, backend="auto"):
-    if ia.is_single_integer(cval):
-        cval = [cval] * len(arr.shape[2])
-
     # no changes to zero-sized arrays
     if arr.size == 0:
         return arr
+
+    if ia.is_single_integer(cval) or ia.is_single_float(cval):
+        cval = [cval] * len(arr.shape[2])
 
     min_value, _center_value, max_value = \
         iadt.get_value_range_of_dtype(arr.dtype)
@@ -209,10 +209,11 @@ def _warp_affine_arr(arr, matrix, order=1, mode="constant", cval=0,
             "cannot handle. Try using a different dtype or set "
             "order=0." % (
                 arr.dtype,))
+        cval_type = float if arr.dtype.kind == "f" else int
         image_warped = _warp_affine_arr_cv2(
             arr,
             matrix,
-            cval=tuple([int(v) for v in cval]),
+            cval=tuple([cval_type(v) for v in cval]),
             mode=mode,
             order=order,
             output_shape=output_shape

--- a/test/augmenters/test_geometric.py
+++ b/test/augmenters/test_geometric.py
@@ -1984,6 +1984,20 @@ class TestAffine_cval(unittest.TestCase):
 
         assert nb_changed_aug_det == 0
 
+    def test_float_cval_on_float_image(self):
+        aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
+                         cval=0.25)
+        image = np.full((10, 10, 3), 0.75, dtype=np.float32)
+        image_aug = aug(image=image)
+        assert np.allclose(image_aug, 0.25)
+
+    def test_float_cval_on_int_image(self):
+        aug = iaa.Affine(scale=1.0, translate_px=100, rotate=0, shear=0,
+                         cval=2.75)
+        image = np.full((10, 10, 3), 10, dtype=np.uint8)
+        image_aug = aug(image=image)
+        assert np.allclose(image_aug, 2)  # cval is casted to int, no rounding
+
 
 class TestAffine_fit_output(unittest.TestCase):
     @property


### PR DESCRIPTION
This patch fixes `Affine` casting float cvals to
int, even when the image has a float dtype,
making it impossible to properly use cvals for
images with value range `[0.0, 1.0]`.

Fixes #669 