### PR TITLE
Improve performance of glass blur

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -409,6 +409,9 @@ good-names=i,
            xx,   # x-coordinates
            yy,   # y-coordinates
            zz,   # z-coordinates
+           dx,   # some difference/shift in x
+           dy,
+           dz,
            x1,   # bounding box top left x-coordinate
            x2,   # bounding box bottom right x-coordinate
            x3,

--- a/changelogs/master/improved/20200530_glass_blur_perf.md
+++ b/changelogs/master/improved/20200530_glass_blur_perf.md
@@ -2,9 +2,9 @@
 
 This patch improves the performance of
 `imgaug.augmenters.imgcorruptplike.apply_glass_blur()`
-and the corresponding augmenter. The improvement is
-around 14x to 45x, depending on the image size
-(larger images have more speedup).
+and the corresponding augmenter in python 3.6+.
+The improvement is around 14x to 45x, depending on
+the image size (larger images have more speedup).
 
 Added dependencies:
-* `numba`
+* `numba` (requires python 3.6+)

--- a/changelogs/master/improved/20200530_glass_blur_perf.md
+++ b/changelogs/master/improved/20200530_glass_blur_perf.md
@@ -1,0 +1,10 @@
+# Improved Performance of Glass Blur #683
+
+This patch improves the performance of
+`imgaug.augmenters.imgcorruptplike.apply_glass_blur()`
+and the corresponding augmenter. The improvement is
+around 14x to 45x, depending on the image size
+(larger images have more speedup).
+
+Added dependencies:
+* `numba`

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -72,6 +72,9 @@ from __future__ import print_function, division, absolute_import
 import warnings
 
 import numpy as np
+import numba
+import skimage.filters
+import six.moves as sm
 
 import imgaug as ia
 from .. import dtypes as iadt
@@ -459,8 +462,6 @@ def _apply_glass_blur_imgaug(x, severity=1):
     # original function implementation from
     # https://github.com/bethgelab/imagecorruptions/blob/master/imagecorruptions/corruptions.py
     # this is an improved (i.e. faster) version
-    from skimage.filters import gaussian
-
     # sigma, max_delta, iterations
     c = [
         (0.7, 1, 2),
@@ -472,42 +473,54 @@ def _apply_glass_blur_imgaug(x, severity=1):
 
     sigma, max_delta, iterations = c
 
-    x = np.uint8(
-        gaussian(np.array(x) / 255., sigma=sigma, multichannel=True) * 255)
-    x_shape = np.array(x).shape
+    x = (
+        skimage.filters.gaussian(
+            np.array(x) / 255., sigma=sigma, multichannel=True
+        ) * 255
+    ).astype(np.uint)
+    x_shape = x.shape
 
-    # locally shuffle pixels
+    dxxdyy = np.random.randint(
+        -max_delta,
+        max_delta,
+        size=(
+            iterations,
+            x_shape[0] - 2*max_delta,
+            x_shape[1] - 2*max_delta,
+            2
+        )
+    )
+
+    x = _apply_glass_blur_imgaug_loop(x, iterations, max_delta, dxxdyy)
+
+    return np.clip(
+        skimage.filters.gaussian(x / 255., sigma=sigma, multichannel=True),
+        0, 1
+    ) * 255
+
+
+# Added in 0.5.0.
+# fastmath seems to slow this down
+@numba.jit(nopython=True, nogil=True)
+def _apply_glass_blur_imgaug_loop(
+        x, iterations, max_delta, dxxdyy
+):
+    x_shape = x.shape
     nb_height = x_shape[0] - 2 * max_delta
     nb_width = x_shape[1] - 2 * max_delta
 
-    for _ in range(iterations):
-        dxxdyy = np.random.randint(-max_delta, max_delta,
-                                   size=(nb_height, nb_width, 2,))
-        dxxdyy = dxxdyy.astype(np.int16)
-        # Rotate here, because imagecorruptions starts the replacement at the
-        # bottom right, so the first generated sample should be placed in that
-        # corner and not the top left corner.
-        # We could avoid this with some fancy (but unreadable) indexing.
-        dxxdyy = np.rot90(dxxdyy, 2, axes=(1, 0))
-
-        # Pad the array to make things easier for us.
-        # We could avoid this with a bit better indexing.
-        dxxdyy = np.pad(
-            dxxdyy,
-            ((max_delta+1, max_delta-1), (max_delta+1, max_delta-1), (0, 0)),
-            mode="constant")
-
-        for h in range(x_shape[0] - max_delta, max_delta, -1):
-            for w in range(x_shape[1] - max_delta, max_delta, -1):
-                dx, dy = dxxdyy[h, w, :]
+    # locally shuffle pixels
+    for i in sm.xrange(iterations):
+        for j in sm.xrange(nb_height):
+            for k in sm.xrange(nb_width):
+                h = x_shape[0] - max_delta - j
+                w = x_shape[1] - max_delta - k
+                dx, dy = dxxdyy[i, j, k]
                 h_prime, w_prime = h + dy, w + dx
                 # swap
                 x[h, w], x[h_prime, w_prime] = x[h_prime, w_prime], x[h, w]
 
-    return np.clip(
-        gaussian(x / 255., sigma=sigma, multichannel=True),
-        0, 1
-    ) * 255
+    return x
 
 
 def apply_defocus_blur(x, severity=1, seed=None):

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -71,8 +71,8 @@ from __future__ import print_function, division, absolute_import
 
 import warnings
 
-import numpy as np
 import six.moves as sm
+import numpy as np
 import skimage.filters
 # numba cannot be installed in python <=3.5
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ opencv-python-headless
 imageio<=2.6.1; python_version<'3.5'
 imageio; python_version>='3.5'
 Shapely
-numba
+# numba is not available in <=3.5
+numba; python_version>='3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ opencv-python-headless
 imageio<=2.6.1; python_version<'3.5'
 imageio; python_version>='3.5'
 Shapely
+numba


### PR DESCRIPTION
This patch improves the performance of
`imgaug.augmenters.imgcorruptplike.apply_glass_blur()`
and the corresponding augmenter. The improvement is
around 14x to 45x, depending on the image size
(larger images have more speedup).

Added dependencies:
* `numba`