### PR TITLE
Incorporate numba into segment replacement

### DIFF
--- a/changelogs/master/improved/20200315_segment_replacement.md
+++ b/changelogs/master/improved/20200315_segment_replacement.md
@@ -1,22 +1,16 @@
-# Improved Performance of Segment Replacement #640
+# Improved Performance of Segment Replacement #640 #684
 
 This patch improves the performance of segment
 replacement (by average colors within the segments),
 used in `Superpixels` and `segment_voronoi()`.
-The new method is up to around 7x faster, more for
-smaller images and more segments. It can be slightly
-slower in some cases for large images (512x512 and
-larger).
+The new method is in some cases (especially small
+images) up to 100x faster now. For 224x224 images
+the speed improvement is around 1.4x to 10x,
+depending on how many segments have to be replaced.
 
-This change seems to improve the overall performance
-of `Superpixels` by a factor of around 1.1x to 1.4x
-(more for smaller images).
-It improves the overall performance of
-`segment_voronoi()` by about 1.1x to 2.0x and can
-reach much higher improvements in the case of very few
-segments that have to be replaced.
-
-Note that `segment_voronoi()` is used in `Voronoi`.
+This change is expected to have a moderate positive
+impact on `Superpixels` and `segment_voronoi()` (i.e.
+`Voronoi`).
 
 Added functions:
 * `imgaug.augmenters.segmentation.replace_segments_`

--- a/changelogs/master/improved/20200530_glass_blur_perf.md
+++ b/changelogs/master/improved/20200530_glass_blur_perf.md
@@ -1,4 +1,4 @@
-# Improved Performance of Glass Blur #683
+# Improved Performance of Glass Blur #683 #684
 
 This patch improves the performance of
 `imgaug.augmenters.imgcorruptplike.apply_glass_blur()`

--- a/imgaug/augmenters/imgcorruptlike.py
+++ b/imgaug/augmenters/imgcorruptlike.py
@@ -74,13 +74,9 @@ import warnings
 import six.moves as sm
 import numpy as np
 import skimage.filters
-# numba cannot be installed in python <=3.5
-try:
-    import numba
-except ImportError:
-    numba = None
 
 import imgaug as ia
+from ..imgaug import _numbajit
 from .. import dtypes as iadt
 from .. import random as iarandom
 from .. import parameters as iap
@@ -495,7 +491,7 @@ def _apply_glass_blur_imgaug(x, severity=1):
         )
     )
 
-    x = _apply_glass_blur_imgaug_loop_dispatcher(
+    x = _apply_glass_blur_imgaug_loop(
         x, iterations, max_delta, dxxdyy
     )
 
@@ -506,16 +502,7 @@ def _apply_glass_blur_imgaug(x, severity=1):
 
 
 # Added in 0.5.0.
-def _apply_glass_blur_imgaug_loop_dispatcher(x, iterations, max_delta, dxxdyy):
-    func = _apply_glass_blur_imgaug_loop
-    # numba is None if it could not be imported
-    if numba is not None:
-        # fastmath seems to slow this down
-        func = numba.jit(func, nopython=True, nogil=True)
-    return func(x, iterations, max_delta, dxxdyy)
-
-
-# Added in 0.5.0.
+@_numbajit(nopython=True, nogil=True, cache=True)
 def _apply_glass_blur_imgaug_loop(
         x, iterations, max_delta, dxxdyy
 ):

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -433,7 +433,7 @@ def _replace_segments_numba_dispatcher_(
 def _replace_segments_numba_collect_avg_colors(
         image_f64, segments, replace_flags, nb_segments, output_dtype
 ):
-    h, w, nb_channels = image_f64.shape[0:3]
+    height, width, nb_channels = image_f64.shape
     nb_flags = len(replace_flags)
 
     average_colors = np.zeros((nb_segments, nb_channels), dtype=np.float64)
@@ -443,8 +443,8 @@ def _replace_segments_numba_collect_avg_colors(
         if not replace_flags[seg_id % nb_flags]:
             counters[seg_id] = -1
 
-    for y in sm.xrange(h):
-        for x in sm.xrange(w):
+    for y in sm.xrange(height):
+        for x in sm.xrange(width):
             seg_id = segments[y, x]
             count = counters[seg_id]
 
@@ -466,11 +466,11 @@ def _replace_segments_numba_collect_avg_colors(
 def _replace_segments_numba_apply_avg_cols_(
         image, segments, replace_flags, average_colors
 ):
-    h, w = image.shape[0:2]
+    height, width = image.shape[0:2]
     nb_flags = len(replace_flags)
 
-    for y in sm.xrange(h):
-        for x in sm.xrange(w):
+    for y in sm.xrange(height):
+        for x in sm.xrange(width):
             seg_id = segments[y, x]
             if replace_flags[seg_id % nb_flags]:
                 image[y, x, :] = average_colors[seg_id]

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -379,7 +379,7 @@ def replace_segments_(image, segments, replace_flags):
     bad_dtype = (
         image.dtype not in {iadt._UINT8_DTYPE, iadt._INT8_DTYPE}
     )
-    if bad_dtype or _NUMBA_INSTALLED is None:
+    if bad_dtype or not _NUMBA_INSTALLED:
         func = _replace_segments_np_
     else:
         max_id = np.max(segments)

--- a/imgaug/augmenters/segmentation.py
+++ b/imgaug/augmenters/segmentation.py
@@ -416,7 +416,7 @@ def _replace_segments_numba_dispatcher_(
         return image
 
     average_colors = _replace_segments_numba_collect_avg_colors(
-        image.astype(np.float64),
+        image,
         segments,
         replace_flags,
         nb_segments,
@@ -431,9 +431,9 @@ def _replace_segments_numba_dispatcher_(
 # Added in 0.5.0.
 @_numbajit(nopython=True, nogil=True, cache=True)
 def _replace_segments_numba_collect_avg_colors(
-        image_f64, segments, replace_flags, nb_segments, output_dtype
+        image, segments, replace_flags, nb_segments, output_dtype
 ):
-    height, width, nb_channels = image_f64.shape
+    height, width, nb_channels = image.shape
     nb_flags = len(replace_flags)
 
     average_colors = np.zeros((nb_segments, nb_channels), dtype=np.float64)
@@ -449,7 +449,7 @@ def _replace_segments_numba_collect_avg_colors(
             count = counters[seg_id]
 
             if count != -1:
-                col = image_f64[y, x, :]
+                col = image[y, x, :]
                 average_colors[seg_id] += col
                 counters[seg_id] += 1
 

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -63,6 +63,9 @@ _POOLING_KERNELS_CACHE = {}
 # Added in 0.5.0.
 _NUMBA_INSTALLED = numba is not None
 
+# Added in 0.5.0.
+_UINT8_DTYPE = np.dtype("uint8")
+
 
 ###############################################################################
 # Helpers for deprecation
@@ -2555,10 +2558,8 @@ def apply_lut_(image, table):
 
         return np.concatenate(subluts, axis=2)
 
-    assert image.dtype.name == "uint8", (
+    assert image.dtype == _UINT8_DTYPE, (
         "Expected uint8 image, got dtype %s." % (image.dtype.name,))
-    assert table.dtype.name == "uint8", (
-        "Expected uint8 table, got dtype %s." % (table.dtype.name,))
 
     image = cv2.LUT(image, table, dst=image)
     return image

--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -21,6 +21,10 @@ import six
 import six.moves as sm
 import skimage.draw
 import skimage.measure
+try:
+    import numba
+except ImportError:
+    numba = None
 
 
 ALL = "ALL"
@@ -55,6 +59,9 @@ IMRESIZE_VALID_INTERPOLATIONS = [
 # Cache dict to save kernels used for pooling.
 # Added in 0.5.0.
 _POOLING_KERNELS_CACHE = {}
+
+# Added in 0.5.0.
+_NUMBA_INSTALLED = numba is not None
 
 
 ###############################################################################
@@ -2555,6 +2562,23 @@ def apply_lut_(image, table):
 
     image = cv2.LUT(image, table, dst=image)
     return image
+
+
+# Added in 0.5.0.
+def _identity_decorator(*_dec_args, **_dec_kwargs):
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return _wrapper
+    return _decorator
+
+
+# Added in 0.5.0.
+if numba is not None:
+    _numbajit = numba.jit
+else:
+    _numbajit = _identity_decorator
 
 
 class HooksImages(object):


### PR DESCRIPTION
This patch makes use of numba in segment
replacement used in Superpixels and Voronoi.
This leads to a decent performance improvement,
especially for smaller images.