### PR TITLE
Fix Affine deprecation warning

### DIFF
--- a/changelogs/master/fixed/20200601_fix_affine_skimage_order_0.md
+++ b/changelogs/master/fixed/20200601_fix_affine_skimage_order_0.md
@@ -1,0 +1,3 @@
+- Fixed a deprecation warning in `Affine` that would
+  be caused when providing boolean images and
+  `order != 0`. #685

--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -231,6 +231,12 @@ def _warp_affine_arr_skimage(arr, matrix, cval, mode, order, output_shape):
 
     input_dtype = arr.dtype
 
+    # tf.warp() produces a deprecation warning for bool images with
+    # order!=0. We either need to convert them to float or use NN
+    # interpolation.
+    if input_dtype == iadt._BOOL_DTYPE and order != 0:
+        arr = arr.astype(np.float32)
+
     image_warped = tf.warp(
         arr,
         np.linalg.inv(matrix),


### PR DESCRIPTION
This patch fixes a deprecation warning in
`Affine` that would be caused when providing
boolean images and `order != 0`.