### PR TITLE
Fix bounding_box assignment on BoundingBoxesOnImage 

### DIFF
--- a/imgaug/augmentables/bbs.py
+++ b/imgaug/augmentables/bbs.py
@@ -1383,7 +1383,17 @@ class BoundingBoxesOnImage(IAugmentable):
 
     """
     def __init__(self, bounding_boxes, shape):
-        self.bounding_boxes = bounding_boxes
+        if isinstance(bounding_boxes, list):
+            self.bounding_boxes = bounding_boxes
+        elif isinstance(bboxes.items, ia.augmentables.bbs.BoundingBox):
+            self.bounding_boxes = [bounding_boxes]
+        elif isinstance(bboxes.items, ia.augmentables.bbs.BoundingBoxesOnImage):
+            self.bounding_boxes = bounding_boxes.items
+        else:
+            raise Exception(
+                f"Cannot assign {type(bounding_boxes)}"
+                f"bounding_boxes should be a list of ia.augmentables.bbs.BoundingBox"
+                )
         self.shape = _handle_on_image_shape(shape, self)
 
     @property


### PR DESCRIPTION
While performing augmentations on bounding boxes one might have to use the classes ia.augmentables.bbs.BoundingBox and/or ia.augmentables.bbs.BoundingBoxesOnImage. However, the assignment of the latter does not check if the variable bounding_boxes is of the correct type (a list containing ia.augmentables.bbs.BoundingBox). This change standardizes the object BoundingBoxesOnImage.bounding_boxes to be always a list of BoundingBox objects