### PR TITLE
Adding 0.5 to Affine Transformation for Images causes misalignment

### DIFF
--- a/imgaug/augmenters/geometric.py
+++ b/imgaug/augmenters/geometric.py
@@ -774,7 +774,7 @@ class _AffineSamplingResult(object):
         return matrix, arr_shape
 
     # Added in 0.4.0.
-    def to_matrix_cba(self, idx, arr_shape, fit_output, shift_add=(0.0, 0.0)):
+    def to_matrix_cba(self, idx, arr_shape, fit_output, shift_add=(0.5, 0.5)):
         return self.to_matrix(idx, arr_shape, arr_shape, fit_output, shift_add)
 
     # Added in 0.4.0.


### PR DESCRIPTION
The shift (0.5, 0.5) mentioned on line 740 being applied to the image but not the rest of the components causes alignment issues. Adding this shift to the rest of the components corrects these issues.

Without fix:
![image](https://user-images.githubusercontent.com/3977802/114802404-7e7e0800-9d52-11eb-8d6d-73231987b7a9.png)
With fix:
![image](https://user-images.githubusercontent.com/3977802/114802447-935a9b80-9d52-11eb-8e47-9d2c71badda0.png)
