### PR TITLE
feat: consider multiple images

### DIFF
--- a/imgaug/augmentables/normalization.py
+++ b/imgaug/augmentables/normalization.py
@@ -1,6 +1,7 @@
 """Functions dealing with normalization of user input data to imgaug classes."""
 from __future__ import print_function, division, absolute_import
 import functools
+import itertools
 
 import numpy as np
 
@@ -565,7 +566,7 @@ def invert_normalize_images(images, images_old):
         return images
     if ia.is_iterable(images_old):
         result = []
-        for image, image_old in zip(images, images_old):
+        for image, image_old in itertools.product(images, images_old):
             if image_old.ndim == 2:
                 assert image.shape[2] == 1, (
                     "Expected each image of shape (H,W,C) to have C=1 due to "


### PR DESCRIPTION
This change encourages to return images wherein one wishes to return multiple images for augmentation.

### Example

```python
import deeply.img.augmenters as dia # https://github.com/achillesrasquinha/deeply
import imgaug.augmenters as iaa

image = ia.quokka()

augmenter = dia.Combination([
    iaa.Fliplr(1.0),
    iaa.Flipud(1.0)
])

images = augmenter(images = [image])
print(len(images)) # => 4
```