### PR TITLE
Fix numpy >= 1.20 np.bool deprecation

### DIFF
--- a/imgaug/augmentables/polys.py
+++ b/imgaug/augmentables/polys.py
@@ -950,7 +950,7 @@ class Polygon(object):
         rr_face, cc_face = skimage.draw.polygon(
             yy_mask, xx_mask, shape=(height_mask, width_mask))
 
-        mask = np.zeros((height_mask, width_mask), dtype=np.bool)
+        mask = np.zeros((height_mask, width_mask), dtype=bool)
         mask[rr_face, cc_face] = True
 
         if image.ndim == 3:

--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -3384,7 +3384,7 @@ class SomeOf(Augmenter, list):
         # pylint: disable=invalid-name
         nn = self._get_n(nb_rows, random_state)
         nn = [min(n, len(self)) for n in nn]
-        augmenter_active = np.zeros((nb_rows, len(self)), dtype=np.bool)
+        augmenter_active = np.zeros((nb_rows, len(self)), dtype=bool)
         for row_idx, n_true in enumerate(nn):
             if n_true > 0:
                 augmenter_active[row_idx, 0:n_true] = 1

--- a/test/augmentables/test_bbs.py
+++ b/test/augmentables/test_bbs.py
@@ -749,7 +749,7 @@ class TestBoundingBox(unittest.TestCase):
     def _get_standard_draw_box_on_image_vars(cls):
         image = np.zeros((10, 10, 3), dtype=np.uint8)
         bb = ia.BoundingBox(y1=1, x1=1, y2=3, x2=3)
-        bb_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        bb_mask = np.zeros(image.shape[0:2], dtype=bool)
         bb_mask[1:3+1, 1] = True
         bb_mask[1:3+1, 3] = True
         bb_mask[1, 1:3+1] = True
@@ -823,7 +823,7 @@ class TestBoundingBox(unittest.TestCase):
     def test_draw_box_on_image_bb_outside_of_image(self):
         image = np.zeros((10, 10, 3), dtype=np.uint8)
         bb = ia.BoundingBox(y1=-1, x1=-1, y2=2, x2=2)
-        bb_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        bb_mask = np.zeros(image.shape[0:2], dtype=bool)
         bb_mask[2, 0:3] = True
         bb_mask[0:3, 2] = True
 
@@ -837,7 +837,7 @@ class TestBoundingBox(unittest.TestCase):
     def test_draw_box_on_image_bb_outside_of_image_and_very_small(self):
         image, bb, bb_mask = self._get_standard_draw_box_on_image_vars()
         bb = ia.BoundingBox(y1=-1, x1=-1, y2=1, x2=1)
-        bb_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        bb_mask = np.zeros(image.shape[0:2], dtype=bool)
         bb_mask[0:1+1, 1] = True
         bb_mask[1, 0:1+1] = True
 
@@ -850,7 +850,7 @@ class TestBoundingBox(unittest.TestCase):
 
     def test_draw_box_on_image_size_2(self):
         image, bb, _ = self._get_standard_draw_box_on_image_vars()
-        bb_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        bb_mask = np.zeros(image.shape[0:2], dtype=bool)
         bb_mask[0:5, 0:5] = True
         bb_mask[2, 2] = False
 

--- a/test/augmentables/test_kps.py
+++ b/test/augmentables/test_kps.py
@@ -624,7 +624,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -640,7 +640,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -659,7 +659,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -678,7 +678,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -694,7 +694,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -710,7 +710,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         kpi = ia.KeypointsOnImage(keypoints=kps, shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -733,7 +733,7 @@ class TestKeypointsOnImage(unittest.TestCase):
         )
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -766,7 +766,7 @@ class TestKeypointsOnImage(unittest.TestCase):
             shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -784,7 +784,7 @@ class TestKeypointsOnImage(unittest.TestCase):
             shape=(5, 5, 3))
         image = np.zeros((5, 5, 3), dtype=np.uint8) + 10
 
-        kps_mask = np.zeros(image.shape[0:2], dtype=np.bool)
+        kps_mask = np.zeros(image.shape[0:2], dtype=bool)
         kps_mask[2, 1] = 1
         kps_mask[4, 3] = 1
 
@@ -908,7 +908,7 @@ class TestKeypointsOnImage(unittest.TestCase):
 
         image = kpi.to_keypoint_image(size=1)
 
-        kps_mask = np.zeros((5, 5, 2), dtype=np.bool)
+        kps_mask = np.zeros((5, 5, 2), dtype=bool)
         kps_mask[2, 1, 0] = 1
         kps_mask[4, 3, 1] = 1
         assert np.all(image[kps_mask] == 255)
@@ -920,7 +920,7 @@ class TestKeypointsOnImage(unittest.TestCase):
 
         image = kpi.to_keypoint_image(size=3)
 
-        kps_mask = np.zeros((5, 5, 2), dtype=np.bool)
+        kps_mask = np.zeros((5, 5, 2), dtype=bool)
         kps_mask[2-1:2+1+1, 1-1:1+1+1, 0] = 1
         kps_mask[4-1:4+1+1, 3-1:3+1+1, 1] = 1
         assert np.all(image[kps_mask] >= 128)

--- a/test/augmentables/test_segmaps.py
+++ b/test/augmentables/test_segmaps.py
@@ -107,7 +107,7 @@ class TestSegmentationMapsOnImage___init__(unittest.TestCase):
     def test_boolean_masks(self):
         # Test for #189 (boolean mask inputs into SegmentationMapsOnImage not
         # working)
-        for dt in [bool, np.bool]:
+        for dt in [bool, bool]:
             arr = np.array([
                 [0, 0, 0],
                 [0, 1, 0],

--- a/test/test_imgaug.py
+++ b/test/test_imgaug.py
@@ -225,7 +225,7 @@ def test_is_integer_array():
         np.zeros((1, 2), dtype=np.float16),
         np.zeros((100,), dtype=np.float32),
         np.zeros((1, 2), dtype=np.float64),
-        np.zeros((1, 2), dtype=np.bool)
+        np.zeros((1, 2), dtype=bool)
     ]
     for value in values_true:
         assert ia.is_integer_array(value) is True
@@ -250,7 +250,7 @@ def test_is_float_array():
         np.zeros((1, 2), dtype=np.uint16),
         np.zeros((1, 2), dtype=np.int32),
         np.zeros((1, 2), dtype=np.int64),
-        np.zeros((1, 2), dtype=np.bool)
+        np.zeros((1, 2), dtype=bool)
     ]
     for value in values_true:
         assert ia.is_float_array(value) is True


### PR DESCRIPTION
Changed np.bool to bool as suggested by deprecation message for numpy>=1.20

Closes #829 