### PR TITLE
Fix alias error due to numpy update（meta.py）

### DIFF
--- a/imgaug/augmenters/meta.py
+++ b/imgaug/augmenters/meta.py
@@ -3384,7 +3384,7 @@ class SomeOf(Augmenter, list):
         # pylint: disable=invalid-name
         nn = self._get_n(nb_rows, random_state)
         nn = [min(n, len(self)) for n in nn]
-        augmenter_active = np.zeros((nb_rows, len(self)), dtype=np.bool)
+        augmenter_active = np.zeros((nb_rows, len(self)), dtype=np.bool_)
         for row_idx, n_true in enumerate(nn):
             if n_true > 0:
                 augmenter_active[row_idx, 0:n_true] = 1


### PR DESCRIPTION
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

It says:
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use bool by itself. Doing this will not modify any behavior and is safe. If specifically wanted the numpy scalar type, use `np.bool_` here.


AttributeError: module 'numpy' has no attribute 'bool'. `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations