### PR TITLE
Resolve bug of imgaug.py

### DIFF
--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -36,9 +36,15 @@ DEFAULT_FONT_FP = os.path.join(
 # to check if a dtype instance is among these dtypes, use e.g.
 # `dtype.type in  NP_FLOAT_TYPES` do not just use `dtype in NP_FLOAT_TYPES` as
 # that would fail
-NP_FLOAT_TYPES = set(np.sctypes["float"])
-NP_INT_TYPES = set(np.sctypes["int"])
-NP_UINT_TYPES = set(np.sctypes["uint"])
+
+# AttributeError: np.sctypes was removed in NumPy 2.0 release
+# NP_FLOAT_TYPES = set(np.sctypes["float"])
+# NP_INT_TYPES = set(np.sctypes["int"])
+# NP_UINT_TYPES = set(np.sctypes["uint"])
+
+NP_FLOAT_TYPES = {np.float16, np.float32, np.float64}
+NP_INT_TYPES = {np.int8, np.int16, np.int32, np.int64}
+NP_UINT_TYPES = {np.uint8, np.uint16, np.uint32, np.uint64}
 
 IMSHOW_BACKEND_DEFAULT = "matplotlib"
 


### PR DESCRIPTION
The current version cause "AttributeError: np.sctypes was removed in NumPy 2.0 release"

I suggest you modify the part that uses 'np.sctypes' to fit the current numpy version