### PR TITLE
Refactor dtype sets in imgaug.py to match migration guide from numpy

### DIFF
--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -36,9 +36,9 @@ DEFAULT_FONT_FP = os.path.join(
 # to check if a dtype instance is among these dtypes, use e.g.
 # `dtype.type in  NP_FLOAT_TYPES` do not just use `dtype in NP_FLOAT_TYPES` as
 # that would fail
-NP_FLOAT_TYPES = set(np.sctypes["float"])
-NP_INT_TYPES = set(np.sctypes["int"])
-NP_UINT_TYPES = set(np.sctypes["uint"])
+NP_FLOAT_TYPES = set([np.float16, np.float32, np.float64, np.float128],)
+NP_INT_TYPES = set([np.int8, np.int16, np.int32, np.int64])
+NP_UINT_TYPES = set([np.uint8, np.uint16, np.uint32, np.uint64],)
 
 IMSHOW_BACKEND_DEFAULT = "matplotlib"
 


### PR DESCRIPTION
citing [migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html) for numpy2.0 instead of `np.sctypes` you should _Access dtypes explicitly instead._. To maintain the functionality I did the following:
```python
In [1]: import numpy as np
np
In [2]: np.__version__
Out[2]: '1.22.0'

In [3]: np.sctypes
Out[3]:
{'int': [numpy.int8, numpy.int16, numpy.int32, numpy.int64],
 'uint': [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64],
 'float': [numpy.float16, numpy.float32, numpy.float64, numpy.float128],
 'complex': [numpy.complex64, numpy.complex128, numpy.complex256],
 'others': [bool, object, bytes, str, numpy.void]}
```

I replaced deprecated code in the `imgaug.py` as shown in changes below.

Additionally I checked with `Ruff` (which was advised [here](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin)) whether there were other issues.

```bash
$ ruff check --select NPY201
All checks passed!
``` 