### PR TITLE
Fixed NumPy 2.0 compatibility issue (replaced np.sctypes)

### DIFF
--- a/imgaug/imgaug.py
+++ b/imgaug/imgaug.py
@@ -36,9 +36,14 @@ DEFAULT_FONT_FP = os.path.join(
 # to check if a dtype instance is among these dtypes, use e.g.
 # `dtype.type in  NP_FLOAT_TYPES` do not just use `dtype in NP_FLOAT_TYPES` as
 # that would fail
-NP_FLOAT_TYPES = set(np.sctypes["float"])
-NP_INT_TYPES = set(np.sctypes["int"])
-NP_UINT_TYPES = set(np.sctypes["uint"])
+try:
+    NP_FLOAT_TYPES = set(np.sctypes["float"])
+    NP_INT_TYPES = set(np.sctypes["int"])
+    NP_UINT_TYPES = set(np.sctypes["uint"])
+except AttributeError:
+    NP_FLOAT_TYPES = set([np.float16, np.float32, np.float64])
+    NP_INT_TYPES = set([np.int8, np.int16, np.int32, np.int64])
+    NP_UINT_TYPES = set([np.uint8, np.uint16, np.uint32, np.uint64])
 
 IMSHOW_BACKEND_DEFAULT = "matplotlib"
 


### PR DESCRIPTION
NumPy 2.0 removed np.sctypes. This PR replaces its usage with explicit float types (and keeps backward compatibility for NumPy < 2.0).

