### PR TITLE
Fix sdist build under setuptools >= 82 (pkg_resources removed)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-module-docstring
 import re
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version as get_distribution, PackageNotFoundError as DistributionNotFound
 from setuptools import setup, find_packages
 
 long_description = """A library for image augmentation in machine learning experiments, particularly convolutional


### PR DESCRIPTION
setuptools 82.0.0 (2026-02-08) removed `pkg_resources`. Because pip's default isolated build installs the latest setuptools, installing imgaug from sdist now fails:

```
$ docker run --rm python:3.12 pip install --no-binary :all: imgaug
...
ModuleNotFoundError: No module named 'pkg_resources'
```

This swaps the pkg_resources installed-package probe for stdlib importlib.metadata (available since Python 3.8); behavior is otherwise unchanged.

Verified: with this patch the sdist builds a wheel against setuptools 82 in a clean python:3.12 container; without it, it does not.

Found while scanning the top-5000 PyPI packages for breakage from the setuptools 82 removals — happy to adjust the patch however you prefer.